### PR TITLE
Fix maintenance settings page missing tasks

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -425,6 +425,16 @@ function renderSettings(){
 
 
 
+  // --- Normalize relationships so legacy data can't hide tasks ---
+  // Tasks synced from Firestore/localStorage may still carry the
+  // legacy `cat` values ("interval"/"asreq") or point at folders that
+  // no longer exist. That caused the new explorer view to render an
+  // empty list even though the calendar still had tasks. Running the
+  // shared repair step resets any stale pointers before we render.
+  if (typeof repairMaintenanceGraph === "function") {
+    repairMaintenanceGraph();
+  }
+
   // --- Small, compact scoped styles (once) ---
   if (!document.getElementById("settingsExplorerCSS")){
     const st = document.createElement("style");


### PR DESCRIPTION
## Summary
- normalize maintenance data before rendering the explorer so tasks with legacy category pointers appear in the settings list
- ensure stale category references no longer hide tasks that are still visible on the calendar

## Testing
- npm test *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cdba7caf208325ac0a8c43a730618f