### PR TITLE
feat: support nested maintenance tasks in settings

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -82,10 +82,43 @@ function repairMaintenanceGraph(){
     if (!Array.isArray(window.tasksInterval))   window.tasksInterval   = [];
     if (!Array.isArray(window.tasksAsReq))      window.tasksAsReq      = [];
 
+    // Flatten any legacy nested `.sub` arrays so every task lives in the
+    // top-level list with a parentTask pointer (Explorer-style tree).
+    const seenIds = new Set();
+    function flattenTasks(list, type){
+      const flat = [];
+      function visit(task, parentId){
+        if (!task || task.id == null) return;
+        const tid = String(task.id);
+        if (seenIds.has(tid)) return; // guard against circular references
+        seenIds.add(tid);
+
+        if (!task.mode) task.mode = type;
+        else task.mode = type; // enforce consistency with owning list
+        task.parentTask = parentId != null ? parentId : null;
+        if (!isFinite(task.order)) task.order = 0;
+
+        flat.push(task);
+
+        if (Array.isArray(task.sub)){
+          const children = task.sub.slice();
+          delete task.sub;
+          for (const child of children){
+            visit(child, tid);
+          }
+        }
+      }
+      for (const task of list){ visit(task, null); }
+      list.splice(0, list.length, ...flat);
+    }
+
+    flattenTasks(window.tasksInterval, "interval");
+    flattenTasks(window.tasksAsReq, "asreq");
+
     // Build task map across both lists
     const allTasks = [];
-    for (const t of window.tasksInterval){ if (t && t.id!=null){ t.__type="interval"; allTasks.push(t); } }
-    for (const t of window.tasksAsReq){    if (t && t.id!=null){ t.__type="asreq";    allTasks.push(t); } }
+    for (const t of window.tasksInterval){ if (t && t.id!=null){ t.mode = "interval"; allTasks.push(t); } }
+    for (const t of window.tasksAsReq){    if (t && t.id!=null){ t.mode = "asreq";    allTasks.push(t); } }
     const tMap = Object.create(null);
     for (const t of allTasks) tMap[String(t.id)] = t;
 
@@ -137,6 +170,12 @@ function repairMaintenanceGraph(){
           p = tMap[String(p.parentTask)] || null;
         }
         if (!safe) t.parentTask = null;
+        if (t.parentTask != null){
+          const parent = tMap[String(t.parentTask)];
+          if (parent){
+            t.cat = parent.cat ?? null;
+          }
+        }
       }
 
       // numeric 'order' normalization (optional but stabilizes rendering)
@@ -169,49 +208,40 @@ function moveNodeSafely(kind, nodeId, target){
   if (typeof window._maintOrderCounter === "undefined") window._maintOrderCounter = 0;
 
   // ---------- Helpers: tasks ----------
-  const topListByType = (type) => (type === "interval" ? tasksInterval : tasksAsReq);
-
-  // DFS find a task anywhere (top-level or nested .sub)
-  function findTaskRef(id){
-    function dfs(list, ownerType, parentTask=null, path=[]){
-      for (let i=0;i<list.length;i++){
-        const t = list[i];
-        if (String(t.id) === String(id)) return { task:t, index:i, list, ownerType, parentTask, path };
-        if (Array.isArray(t.sub) && t.sub.length){
-          const hit = dfs(t.sub, ownerType, t, path.concat(t.id));
-          if (hit) return hit;
-        }
-      }
-      return null;
-    }
-    return dfs(tasksInterval, "interval") || dfs(tasksAsReq, "asreq");
-  }
-
-  // Find a task only at the top level of a list (for beforeTask insert)
-  function findTopRef(id){
-    let idx = tasksInterval.findIndex(t => String(t.id)===String(id));
-    if (idx>=0) return { list:tasksInterval, ownerType:"interval", index:idx, task:tasksInterval[idx], parentTask:null };
-    idx = tasksAsReq.findIndex(t => String(t.id)===String(id));
-    if (idx>=0) return { list:tasksAsReq, ownerType:"asreq", index:idx, task:tasksAsReq[idx], parentTask:null };
+  function findTaskMeta(id){
+    const tid = String(id);
+    let idx = window.tasksInterval.findIndex(t => String(t.id) === tid);
+    if (idx >= 0) return { task: window.tasksInterval[idx], list: window.tasksInterval, mode: "interval", index: idx };
+    idx = window.tasksAsReq.findIndex(t => String(t.id) === tid);
+    if (idx >= 0) return { task: window.tasksAsReq[idx], list: window.tasksAsReq, mode: "asreq", index: idx };
     return null;
   }
 
-  function isDescendant(ancestorTask, maybeChildId){
-    if (!ancestorTask || !Array.isArray(ancestorTask.sub)) return false;
-    for (const c of ancestorTask.sub){
-      if (String(c.id) === String(maybeChildId)) return true;
-      if (isDescendant(c, maybeChildId)) return true;
-    }
-    return false;
+  function normalizeTaskOrder(mode, catId, parentId){
+    const list = mode === "interval" ? window.tasksInterval : window.tasksAsReq;
+    const keyCat = String(catId ?? "");
+    const keyParent = String(parentId ?? "");
+    const siblings = list
+      .filter(t => String(t.parentTask ?? "") === keyParent && String(t.cat ?? "") === keyCat)
+      .sort((a,b)=> (Number(b.order||0) - Number(a.order||0)) || String(a.name||"").localeCompare(String(b.name||"")));
+    let n = siblings.length;
+    for (const t of siblings){ t.order = n--; }
   }
 
-  function detachTask(ref){
-    if (!ref) return;
-    if (ref.parentTask){
-      ref.parentTask.sub.splice(ref.index, 1);
-    }else{
-      ref.list.splice(ref.index, 1);
+  function ensureFolder(catId){
+    if (catId == null) return true;
+    return window.settingsFolders.some(f => String(f.id) === String(catId));
+  }
+
+  function isDescendant(candidateId, possibleAncestorId){
+    if (candidateId == null || possibleAncestorId == null) return false;
+    let guard = 0;
+    let cur = findTaskMeta(candidateId);
+    while (cur && cur.task.parentTask != null && guard++ < 1000){
+      if (String(cur.task.parentTask) === String(possibleAncestorId)) return true;
+      cur = findTaskMeta(cur.task.parentTask);
     }
+    return false;
   }
 
   // ---------- Helpers: categories ----------
@@ -227,8 +257,10 @@ function moveNodeSafely(kind, nodeId, target){
 
   // ---------- TASK MOVES ----------
   if (kind === "task"){
-    const src = findTaskRef(nodeId);
+    const src = findTaskMeta(nodeId);
     if (!src) return false;
+
+    const originalGroup = { cat: src.task.cat ?? null, parent: src.task.parentTask ?? null };
 
     // intoTask can be string or {id}
     const intoTaskId = (target && Object.prototype.hasOwnProperty.call(target,"intoTask"))
@@ -236,54 +268,47 @@ function moveNodeSafely(kind, nodeId, target){
       : null;
 
     if (intoTaskId != null){
-      // no self / no cycle
       if (String(intoTaskId) === String(nodeId)) return false;
-      const parentRef = findTaskRef(intoTaskId);
+      const parentRef = findTaskMeta(intoTaskId);
       if (!parentRef) return false;
-      if (isDescendant(src.task, intoTaskId)) return false;
+      if (isDescendant(parentRef.task.id, src.task.id)) return false;
 
-      // move: detach then push into parent's sub[]
-      detachTask(src);
-      if (!Array.isArray(parentRef.task.sub)) parentRef.task.sub = [];
-      parentRef.task.sub.push(src.task);
+      src.task.parentTask = parentRef.task.id;
+      src.task.cat = parentRef.task.cat ?? null;
+      src.task.order = ++window._maintOrderCounter;
 
-      if (typeof saveTasks === "function") saveTasks();
-      if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
+      normalizeTaskOrder(src.mode, src.task.cat ?? null, src.task.parentTask ?? null);
+      normalizeTaskOrder(src.mode, originalGroup.cat, originalGroup.parent);
       return true;
     }
 
     if (target && target.beforeTask && target.beforeTask.id){
-      // Reorder at top level: place BEFORE the target card
-      const destTop = findTopRef(target.beforeTask.id);
-      const destType = target.beforeTask.type || destTop?.ownerType; // fallback if type missing
-      if (!destTop || !destType) return false;
+      const dest = findTaskMeta(target.beforeTask.id);
+      if (!dest) return false;
+      if (dest.mode !== src.mode) return false;
 
-      // detach source from wherever it was
-      detachTask(src);
+      src.task.cat = dest.task.cat ?? null;
+      src.task.parentTask = dest.task.parentTask ?? null;
+      src.task.order = (Number(dest.task.order) || 0) + 0.5;
 
-      // insert into the destination list at the correct index
-      const destList = topListByType(destType);
-      const j = destList.findIndex(t => String(t.id)===String(destTop.task.id));
-      const insertAt = (j>=0) ? j : destList.length;
-      destList.splice(insertAt, 0, src.task);
-
-      if (typeof saveTasks === "function") saveTasks();
-      if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
+      normalizeTaskOrder(src.mode, dest.task.cat ?? null, dest.task.parentTask ?? null);
+      normalizeTaskOrder(src.mode, originalGroup.cat, originalGroup.parent);
       return true;
     }
 
     if (Object.prototype.hasOwnProperty.call(target || {}, "intoCat")){
-      // File the task into a folder (no positional change required)
       const catId = target.intoCat;
-      if (catId != null && !findCat(catId)) return false;
-      // ensure we keep the task where it is; just set a folder tag
-      src.task.cat = (catId || null);
-      if (typeof saveTasks === "function") saveTasks();
-      if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
+      if (!ensureFolder(catId)) return false;
+
+      src.task.cat = catId ?? null;
+      src.task.parentTask = null;
+      src.task.order = ++window._maintOrderCounter;
+
+      normalizeTaskOrder(src.mode, src.task.cat ?? null, null);
+      normalizeTaskOrder(src.mode, originalGroup.cat, originalGroup.parent);
       return true;
     }
 
-    // nothing matched
     return false;
   }
 
@@ -446,37 +471,51 @@ function renderSettings(){
       #explorer .tree{border:1px solid #e5e5e5;background:#fff;border-radius:10px;padding:6px}
       #explorer details{margin:4px 0;border:1px solid #eee;border-radius:8px;background:#fafafa}
       #explorer details>summary{display:flex;align-items:center;gap:8px;padding:6px 8px;cursor:grab;user-select:none}
-      #explorer details.task>summary{cursor:grab; font-weight:600; background:#fff}
-      #explorer details.cat>summary{font-weight:800}
-      #explorer .children{padding:4px 8px 8px 18px}
-      #explorer .dz{height:8px;margin:4px 0;border-radius:6px}
-      #explorer .dz.dragover{height:18px;background:rgba(0,0,0,.05);outline:2px dashed #888}
-      #explorer .drop-hint{outline:2px solid #6aa84f;border-radius:6px}
-      #explorer .body{padding:6px 8px;border-top:1px dashed #e5e5e5;background:#fff}
-      #explorer .grid{display:grid;grid-template-columns:1fr 1fr;gap:.5rem}
-      #explorer label{font-size:.85rem;display:block}
-      #explorer input{width:100%;padding:.35rem .45rem}
-      #explorer .chip{font-size:.72rem;border:1px solid #bbb;border-radius:999px;padding:.05rem .45rem}
-      #explorer .row-actions{display:flex;gap:.4rem;justify-content:flex-end;margin-top:.4rem;flex-wrap:wrap}
+      #explorer details.task>summary{background:#fff;font-weight:600;border-bottom:1px solid #ececec}
+      #explorer details.cat>summary{font-weight:700;background:#f4f6fb}
+      #explorer .task-name{flex:1;min-width:0}
+      #explorer summary .chip{font-size:.72rem;border:1px solid #bbb;border-radius:999px;padding:.05rem .45rem;background:#fff}
+      #explorer .body{padding:8px 10px;background:#fff;border-top:1px dashed #e5e5e5}
+      #explorer .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:.5rem}
+      #explorer label{font-size:.85rem;display:flex;flex-direction:column;gap:4px}
+      #explorer input,#explorer select{width:100%;padding:.35rem .45rem;border:1px solid #ccd4e0;border-radius:6px;font-size:.9rem}
+      #explorer .row-actions{display:flex;gap:.4rem;justify-content:flex-end;margin-top:.6rem;flex-wrap:wrap}
+      #explorer .row-actions button{padding:.35rem .65rem;border-radius:6px;border:0;cursor:pointer;background:#eef3fb;color:#0a63c2}
+      #explorer .row-actions .danger{background:#e14b4b;color:#fff}
+      #explorer .row-actions .btn-complete{background:#0a63c2;color:#fff}
+      #explorer .children{padding:6px 8px 10px 18px}
+      #explorer .task-children{padding:6px 8px 12px 22px;background:#fbfbfb;border-top:1px solid #f0f0f0}
+      #explorer .task-children>.dz{margin:4px 0 6px;border:1px dashed #bbb;border-radius:8px;padding:6px;font-size:.78rem;color:#666;background:#fff;cursor:grab}
+      #explorer .dz{min-height:8px;margin:4px 0;border-radius:6px}
+      #explorer .dz.dragover{min-height:18px;background:rgba(10,99,194,.08);outline:2px dashed #0a63c2}
+      #explorer summary.drop-hint{outline:2px solid #6aa84f;border-radius:6px}
+      #explorer .sub-empty{font-size:.78rem;color:#777;margin-left:4px}
       #explorer .empty{padding:.5rem;color:#666}
+      #explorer .chip.due-ok{border-color:#ccebd6;background:#e5f6eb;color:#2e7d32}
+      #explorer .chip.due-warn{border-color:#f2e4a3;background:#fff7d1;color:#8a6d00}
+      #explorer .chip.due-soon{border-color:#ffd0b5;background:#ffe6d6;color:#a14d00}
+      #explorer .chip.due-late{border-color:#ffc9c9;background:#ffe1e1;color:#c62828}
+      .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.35);display:flex;align-items:center;justify-content:center;z-index:9999;padding:12px}
+      .modal-backdrop[hidden]{display:none}
+      .modal-card{background:#fff;border-radius:12px;padding:18px 20px;box-shadow:0 18px 36px rgba(0,0,0,.25);min-width:min(480px,90vw);max-height:90vh;overflow:auto;position:relative}
+      .modal-card h4{margin:0 0 12px;font-size:1.1rem}
+      .modal-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px}
+      .modal-grid label{display:flex;flex-direction:column;font-size:.9rem;gap:4px}
+      .modal-grid input,.modal-grid select{padding:.45rem .55rem;border:1px solid #cdd4e1;border-radius:6px;font-size:.95rem}
+      .modal-actions{display:flex;justify-content:flex-end;gap:8px;margin-top:16px}
+      .modal-actions button{padding:.45rem .85rem;border-radius:6px;border:0;cursor:pointer;font-weight:600}
+      .modal-actions .secondary{background:#eef3fb;color:#0a63c2}
+      .modal-actions .primary{background:#0a63c2;color:#fff}
+      .modal-close{position:absolute;top:10px;right:10px;background:none;border:0;font-size:1.4rem;cursor:pointer;color:#666;line-height:1}
     `;
     document.head.appendChild(st);
   }
 
-  // --- Helpers ---
-  const fmtPrice = v => (v==null || v==="") ? "" : String(v);
+  // --- Helpers & derived collections ---
   const byIdFolder = (id)=> window.settingsFolders.find(f => String(f.id)===String(id)) || null;
   const childrenFolders = (parent)=> window.settingsFolders
       .filter(f => String(f.parent||"") === String(parent||""))
       .sort((a,b)=> (Number(b.order||0)-Number(a.order||0)) || String(a.name).localeCompare(String(b.name)));
-  const topTasksInCat = (catId)=> {
-    const bucket = []
-      .concat(window.tasksInterval.map(x=>({t:x,type:"interval"})))
-      .concat(window.tasksAsReq.map(x=>({t:x,type:"asreq"})));
-    return bucket
-      .filter(x => (x.t.parentTask == null) && String(x.t.cat||"") === String(catId||""))
-      .sort((a,b)=> (Number(b.t.order||0) - Number(a.t.order||0)) || String(a.t.name||"").localeCompare(String(b.t.name||"")));
-  };
 
   function ensureIdsOrder(obj){
     if (!obj.id){
@@ -485,54 +524,135 @@ function renderSettings(){
     if (obj.order == null) obj.order = ++window._maintOrderCounter;
   }
 
-  // --- Row renderers ---
-  function taskRow({t,type}){
-    const badge = (type==="interval" ? (t.interval!=null?`<span class="chip">Interval: ${t.interval}h</span>`:`<span class="chip">Interval</span>`)
-                                     : `<span class="chip">As Required</span>`);
+  const escapeHtml = (str)=> String(str||"").replace(/[&<>"']/g, c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+
+  function ensureTaskDefaults(task, type){
+    ensureIdsOrder(task);
+    task.mode = type;
+    if (task.parentTask == null) task.parentTask = null;
+    if (task.cat == null) task.cat = task.cat ?? null;
+  }
+
+  const taskEntries = [];
+  window.tasksInterval.forEach(t=>{ if (t){ ensureTaskDefaults(t,"interval"); taskEntries.push({ task:t, type:"interval" }); } });
+  window.tasksAsReq.forEach(t=>{ if (t){ ensureTaskDefaults(t,"asreq"); taskEntries.push({ task:t, type:"asreq" }); } });
+
+  const tasksById = new Map();
+  const childrenByParent = new Map();
+  const topByCat = new Map();
+
+  const sortEntries = (arr)=> arr.sort((a,b)=> (Number(b.task.order||0) - Number(a.task.order||0)) || String(a.task.name||"").localeCompare(String(b.task.name||"")));
+
+  for (const entry of taskEntries){
+    const t = entry.task;
+    const id = String(t.id);
+    tasksById.set(id, entry);
+    if (t.parentTask != null){
+      const key = String(t.parentTask);
+      if (!childrenByParent.has(key)) childrenByParent.set(key, []);
+      childrenByParent.get(key).push(entry);
+    }else{
+      const catKey = String(t.cat ?? "");
+      if (!topByCat.has(catKey)) topByCat.set(catKey, []);
+      topByCat.get(catKey).push(entry);
+    }
+  }
+
+  childrenByParent.forEach(sortEntries);
+  topByCat.forEach(sortEntries);
+
+  function dueChip(task){
+    if (task.mode !== "interval" || typeof nextDue !== "function") return "";
+    try{
+      const nd = nextDue(task);
+      if (!nd){
+        return `<span class="chip due-warn" data-due-chip="${task.id}">Awaiting usage data</span>`;
+      }
+      let cls = "due-ok";
+      if (nd.days <= 1) cls = "due-late";
+      else if (nd.days <= 3) cls = "due-soon";
+      else if (nd.days <= 7) cls = "due-warn";
+      return `<span class="chip ${cls}" data-due-chip="${task.id}">${nd.days}d → ${escapeHtml(nd.due.toDateString())}</span>`;
+    }catch{
+      return `<span class="chip due-warn" data-due-chip="${task.id}">Awaiting usage data</span>`;
+    }
+  }
+
+  function renderTask(entry){
+    const t = entry.task;
+    const type = entry.type;
+    const name = escapeHtml(t.name || "(unnamed task)");
+    const condition = escapeHtml(t.condition || "As required");
+    const freq = t.interval ? `${t.interval} hrs` : "Set frequency";
+    const children = childrenByParent.get(String(t.id)) || [];
+    const childHtml = children.map(renderTask).join("");
+    const dropLabel = escapeHtml(t.name || "this task");
     return `
-      <details class="task" data-task-id="${t.id}" data-owner="${type}">
-        <summary draggable="true">${t.name||"(unnamed)"} ${badge}</summary>
+      <details class="task task--${type}" data-task-id="${t.id}" data-owner="${type}">
+        <summary draggable="true">
+          <span class="task-name">${name}</span>
+          <span class="chip">${type === "interval" ? "By Interval" : "As Required"}</span>
+          ${type === "interval" ? `<span class=\"chip\" data-chip-frequency="${t.id}">${escapeHtml(freq)}</span>` : `<span class=\"chip\" data-chip-condition="${t.id}">${condition}</span>`}
+          ${type === "interval" ? dueChip(t) : ""}
+        </summary>
         <div class="body">
           <div class="grid">
-            <label>Name<input data-k="name" data-id="${t.id}" data-list="${type}" value="${t.name||""}"></label>
-            ${
-              type==="interval" 
-                ? `<label>Interval (hrs)<input type="number" min="1" step="1" data-k="interval" data-id="${t.id}" data-list="interval" value="${t.interval||""}"></label>`
-                : `<label>Condition/Notes<input data-k="condition" data-id="${t.id}" data-list="asreq" value="${t.condition||""}" placeholder="optional"></label>`
-            }
-            <label>Part #<input data-k="pn" data-id="${t.id}" data-list="${type}" value="${t.pn||""}"></label>
-            <label>Price<input type="number" step="0.01" min="0" data-k="price" data-id="${t.id}" data-list="${type}" value="${fmtPrice(t.price)}" placeholder="optional"></label>
-            <label>Store / Manual (URL)<input type="url" data-k="link" data-id="${t.id}" data-list="${type}" value="${t.link||t.storeLink||t.manualLink||""}" placeholder="https://…"></label>
+            <label>Task name<input data-k="name" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.name||"")}" placeholder="Name"></label>
+            <label>Type<select data-k="mode" data-id="${t.id}" data-list="${type}">
+              <option value="interval" ${type==="interval"?"selected":""}>By interval</option>
+              <option value="asreq" ${type==="asreq"?"selected":""}>As required</option>
+            </select></label>
+            ${type === "interval" ? `<label>Frequency (hrs)<input type=\"number\" min=\"1\" step=\"1\" data-k=\"interval\" data-id=\"${t.id}\" data-list=\"interval\" value=\"${t.interval!=null?t.interval:""}\" placeholder=\"Hours between service\"></label>` : `<label>Condition / trigger<input data-k=\"condition\" data-id=\"${t.id}\" data-list=\"asreq\" value=\"${escapeHtml(t.condition||"")}\" placeholder=\"When to perform\"></label>`}
+            ${type === "interval" ? `<label>Last serviced at (machine hrs)<input type=\"number\" min=\"0\" step=\"0.01\" data-k=\"anchorTotal\" data-id=\"${t.id}\" data-list=\"interval\" value=\"${t.anchorTotal!=null?t.anchorTotal:""}\" placeholder=\"optional\"></label>` : ""}
+            <label>Manual link<input type="url" data-k="manualLink" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.manualLink||"")}" placeholder="https://..."></label>
+            <label>Store link<input type="url" data-k="storeLink" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.storeLink||"")}" placeholder="https://..."></label>
+            <label>Part #<input data-k="pn" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.pn||"")}" placeholder="Part number"></label>
+            <label>Price ($)<input type="number" step="0.01" min="0" data-k="price" data-id="${t.id}" data-list="${type}" value="${t.price!=null?t.price:""}" placeholder="optional"></label>
           </div>
           <div class="row-actions">
-            ${type==="interval" ? `<button class="btn-complete" data-complete="${t.id}">Mark Completed</button>` : ``}
+            ${type === "interval" ? `<button class="btn-complete" data-complete="${t.id}">Mark completed now</button>` : ""}
             <button class="danger" data-remove="${t.id}" data-from="${type}">Remove</button>
           </div>
         </div>
-      </details>
-    `;
-  }
-
-  function folderHTML(f){
-    ensureIdsOrder(f);
-    const kids = childrenFolders(f.id).map(folderHTML).join("");
-    const tasks = topTasksInCat(f.id).map(taskRow).join("");
-    return `
-      <details class="cat" data-cat-id="${f.id}" open>
-        <summary draggable="true">📁 ${f.name}</summary>
-        <div class="dz" data-drop-into-cat="${f.id}"></div>
-        <div class="children">
-          ${kids}
-          ${tasks || ""}
+        <div class="task-children" data-task-children="${t.id}">
+          <div class="dz" data-drop-into-task="${t.id}">Drop here to make a sub-task of ${dropLabel}</div>
+          ${childHtml || `<div class="sub-empty" data-empty-sub="${t.id}">No sub-tasks yet. Drag any task here to nest it.</div>`}
         </div>
       </details>
     `;
   }
 
-  const roots = childrenFolders(null);
-  const rootTasks = topTasksInCat(null).map(taskRow).join("");
+  function renderFolder(folder){
+    ensureIdsOrder(folder);
+    const kids = childrenFolders(folder.id).map(renderFolder).join("");
+    const taskList = (topByCat.get(String(folder.id)) || []).map(renderTask).join("");
+    return `
+      <details class="cat" data-cat-id="${folder.id}" open>
+        <summary draggable="true"><span class="task-name">${escapeHtml(folder.name)}</span></summary>
+        <div class="dz" data-drop-into-cat="${folder.id}">Drop tasks here to file under ${escapeHtml(folder.name)}</div>
+        <div class="children">
+          ${kids}
+          ${taskList || `<div class="empty">No tasks in this category yet.</div>`}
+        </div>
+      </details>
+    `;
+  }
 
-  // --- Page ---
+  const rootTasks = (topByCat.get("") || []).map(renderTask).join("");
+  const folderHtml = childrenFolders(null).map(renderFolder).join("");
+
+  const flattenedFolders = [];
+  (function walk(parent, prefix){
+    for (const f of childrenFolders(parent)){
+      flattenedFolders.push({ id: f.id, label: `${prefix}${f.name}` });
+      walk(f.id, `${prefix}${f.name} / `);
+    }
+  })(null, "");
+
+  const categoryOptions = ["<option value=\"\">(No Category)</option>"]
+    .concat(flattenedFolders.map(f => `<option value=\"${f.id}\">${escapeHtml(f.label)}</option>`))
+    .join("");
+
   root.innerHTML = `
     <div id="explorer" class="container">
       <div class="block" style="grid-column:1 / -1">
@@ -540,214 +660,346 @@ function renderSettings(){
         <div class="toolbar">
           <button id="btnAddCategory">+ Add Category</button>
           <button id="btnAddTask">+ Add Task</button>
-          <span class="hint">Drag folders & tasks to organize. New items appear at the top.</span>
+          <span class="hint">Drag folders & tasks to organize. Tasks can hold sub-tasks like folders.</span>
         </div>
         <div class="tree" id="tree">
-          <div class="dz" data-drop-root="1"></div>
-          ${roots.length ? roots.map(folderHTML).join("") : ""}
-          ${rootTasks || (roots.length ? "" : `<div class="empty">No tasks yet.</div>`)}
+          <div class="dz" data-drop-root="1">Drop here to move to the root</div>
+          ${rootTasks || ``}
+          ${folderHtml || (rootTasks ? `` : `<div class="empty">No tasks yet. Add one to get started.</div>`)}
         </div>
+      </div>
+    </div>
+    <div class="modal-backdrop" id="taskModal" hidden>
+      <div class="modal-card">
+        <button type="button" class="modal-close" id="closeTaskModal">×</button>
+        <h4>Create maintenance task</h4>
+        <form id="taskForm" class="modal-form">
+          <div class="modal-grid">
+            <label>Task name<input name="taskName" required placeholder="Task"></label>
+            <label>Type<select name="taskType" id="taskTypeSelect">
+              <option value="interval">By interval</option>
+              <option value="asreq">As required</option>
+            </select></label>
+            <label data-form-frequency>Frequency (hrs)<input type="number" min="1" step="1" name="taskInterval" placeholder="e.g. 40"></label>
+            <label data-form-last>Last serviced at (machine hrs)<input type="number" min="0" step="0.01" name="taskLastServiced" placeholder="optional"></label>
+            <label data-form-condition hidden>Condition / trigger<input name="taskCondition" placeholder="e.g. When clogged"></label>
+            <label>Manual link<input type="url" name="taskManual" placeholder="https://..."></label>
+            <label>Store link<input type="url" name="taskStore" placeholder="https://..."></label>
+            <label>Part #<input name="taskPN" placeholder="Part number"></label>
+            <label>Price ($)<input type="number" min="0" step="0.01" name="taskPrice" placeholder="optional"></label>
+            <label>Category<select name="taskCategory">${categoryOptions}</select></label>
+          </div>
+          <div class="modal-actions">
+            <button type="button" class="secondary" id="cancelTaskModal">Cancel</button>
+            <button type="submit" class="primary">Create Task</button>
+          </div>
+        </form>
       </div>
     </div>
   `;
 
-  // --- Wiring: add buttons ---
+  const tree = document.getElementById("tree");
+  const modal = document.getElementById("taskModal");
+  const form = document.getElementById("taskForm");
+  const typeField = document.getElementById("taskTypeSelect");
+  const freqRow = form?.querySelector('[data-form-frequency]');
+  const lastRow = form?.querySelector('[data-form-last]');
+  const conditionRow = form?.querySelector('[data-form-condition]');
+
+  const persist = ()=>{
+    if (typeof saveTasks === "function") { try{ saveTasks(); }catch(_){} }
+    if (typeof saveCloudDebounced === "function") { try{ saveCloudDebounced(); }catch(_){} }
+  };
+
+  function syncFormMode(mode){
+    if (!freqRow || !lastRow || !conditionRow) return;
+    if (mode === "interval"){
+      freqRow.hidden = false;
+      lastRow.hidden = false;
+      conditionRow.hidden = true;
+    }else{
+      freqRow.hidden = true;
+      lastRow.hidden = true;
+      conditionRow.hidden = false;
+    }
+  }
+
+  function showModal(){
+    if (!modal || !form || !typeField) return;
+    form.reset();
+    modal.hidden = false;
+    syncFormMode(typeField.value);
+  }
+  function hideModal(){ if (modal) modal.hidden = true; }
+
   document.getElementById("btnAddCategory")?.addEventListener("click", ()=>{
     const name = prompt("Category name?");
     if (!name) return;
     const cat = { id: name.toLowerCase().replace(/[^a-z0-9]+/g,"_")+"_"+Math.random().toString(36).slice(2,7), name, parent:null, order: ++window._maintOrderCounter };
     window.settingsFolders.push(cat);
-    if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
+    persist();
     renderSettings();
   });
 
-  document.getElementById("btnAddTask")?.addEventListener("click", ()=>{
-    const name = prompt("Task name?");
-    if (!name) return;
-    const occ = (prompt('Occurrence: type "interval" for Hourly Interval, or "asreq" for As Required').trim().toLowerCase());
-    const id  = (name.toLowerCase().replace(/[^a-z0-9]+/g,"_") + "_" + Date.now());
-    if (occ === "interval"){
-      const interval = Number(prompt("Interval (hours):") || "");
-      const t = { id, name, interval: isFinite(interval)&&interval>0 ? interval : 8, sinceBase:null, anchorTotal:null, link:"", pn:"", price:null, cat:null, order: ++window._maintOrderCounter };
-      window.tasksInterval.unshift(t);
+  document.getElementById("btnAddTask")?.addEventListener("click", showModal);
+  document.getElementById("cancelTaskModal")?.addEventListener("click", hideModal);
+  document.getElementById("closeTaskModal")?.addEventListener("click", hideModal);
+  modal?.addEventListener("click", (e)=>{ if (e.target === modal) hideModal(); });
+  typeField?.addEventListener("change", ()=> syncFormMode(typeField.value));
+  syncFormMode(typeField?.value || "interval");
+
+  form?.addEventListener("submit", (e)=>{
+    e.preventDefault();
+    if (!form) return;
+    const data = new FormData(form);
+    const name = (data.get("taskName")||"").toString().trim();
+    const mode = (data.get("taskType")||"interval").toString();
+    if (!name){ alert("Task name is required."); return; }
+    const catId = (data.get("taskCategory")||"").toString().trim() || null;
+    const manual = (data.get("taskManual")||"").toString().trim();
+    const store = (data.get("taskStore")||"").toString().trim();
+    const pn = (data.get("taskPN")||"").toString().trim();
+    const priceVal = data.get("taskPrice");
+    const price = priceVal === null || priceVal === "" ? null : Number(priceVal);
+    const id = genId(name);
+    const base = { id, name, manualLink: manual, storeLink: store, pn, price: isFinite(price)?price:null, cat: catId, parentTask:null, order: ++window._maintOrderCounter };
+
+    if (mode === "interval"){
+      const intervalVal = data.get("taskInterval");
+      const lastVal = data.get("taskLastServiced");
+      const interval = intervalVal === null || intervalVal === "" ? 8 : Number(intervalVal);
+      const task = Object.assign(base, { mode:"interval", interval: isFinite(interval) && interval>0 ? interval : 8, sinceBase:null, anchorTotal:null });
+      if (lastVal !== null && lastVal !== ""){ const v = Number(lastVal); if (isFinite(v)){ task.anchorTotal = v; task.sinceBase = 0; } }
+      window.tasksInterval.unshift(task);
     }else{
-      const t = { id, name, condition:"As required", link:"", pn:"", price:null, cat:null, order: ++window._maintOrderCounter };
-      window.tasksAsReq.unshift(t);
+      const condition = (data.get("taskCondition")||"").toString().trim() || "As required";
+      const task = Object.assign(base, { mode:"asreq", condition });
+      window.tasksAsReq.unshift(task);
     }
-    if (typeof saveTasks === "function") try{ saveTasks(); }catch(_){}
-    if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
+
+    persist();
+    hideModal();
     renderSettings();
   });
 
-  // --- Inline edits ---
-  root.querySelectorAll("[data-id]").forEach(inp=>{
-    inp.addEventListener("input", ()=>{
-      const id = inp.getAttribute("data-id");
-      const k  = inp.getAttribute("data-k");
-      const list = inp.getAttribute("data-list");
-      const arr = list === "interval" ? window.tasksInterval : window.tasksAsReq;
-      const t = arr.find(x => String(x.id)===String(id));
-      if (!t) return;
-      let v = inp.value;
-      if (["interval","price"].includes(k)){
-        v = (v === "" ? null : Number(v));
-      }
-      t[k] = v;
-      if (typeof saveTasks === "function") try{ saveTasks(); }catch(_){}
-      if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
-    });
+  function findTaskMeta(id){
+    const tid = String(id);
+    let idx = window.tasksInterval.findIndex(t => String(t.id)===tid);
+    if (idx >= 0) return { task: window.tasksInterval[idx], mode:"interval", list: window.tasksInterval, index: idx };
+    idx = window.tasksAsReq.findIndex(t => String(t.id)===tid);
+    if (idx >= 0) return { task: window.tasksAsReq[idx], mode:"asreq", list: window.tasksAsReq, index: idx };
+    return null;
+  }
+
+  function updateDueChip(holder, task){
+    const chip = holder.querySelector('[data-due-chip]');
+    if (!chip) return;
+    chip.textContent = "";
+    chip.classList.remove("due-ok","due-warn","due-soon","due-late");
+    if (typeof nextDue !== "function"){ chip.textContent = "—"; return; }
+    const nd = nextDue(task);
+    if (!nd){ chip.textContent = "Awaiting usage data"; chip.classList.add("due-warn"); return; }
+    chip.textContent = `${nd.days}d → ${nd.due.toDateString()}`;
+    if (nd.days <= 1) chip.classList.add("due-late");
+    else if (nd.days <= 3) chip.classList.add("due-soon");
+    else if (nd.days <= 7) chip.classList.add("due-warn");
+    else chip.classList.add("due-ok");
+  }
+
+  tree?.addEventListener("input", (e)=>{
+    const target = e.target;
+    if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement)) return;
+    const holder = target.closest("[data-task-id]");
+    if (!holder) return;
+    const id = holder.getAttribute("data-task-id");
+    const meta = findTaskMeta(id);
+    if (!meta) return;
+    const key = target.getAttribute("data-k");
+    if (!key || key === "mode") return;
+    let value = target.value;
+    if (key === "price" || key === "interval" || key === "anchorTotal"){
+      value = value === "" ? null : Number(value);
+      if (value !== null && !isFinite(value)) return;
+    }
+    if (key === "interval"){
+      meta.task.interval = value == null ? null : Number(value);
+      const chip = holder.querySelector('[data-chip-frequency]');
+      if (chip) chip.textContent = meta.task.interval ? `${meta.task.interval} hrs` : "Set frequency";
+      updateDueChip(holder, meta.task);
+    }else if (key === "anchorTotal"){
+      if (value == null){ meta.task.anchorTotal = null; meta.task.sinceBase = null; }
+      else { meta.task.anchorTotal = Number(value); meta.task.sinceBase = 0; }
+      updateDueChip(holder, meta.task);
+    }else if (key === "price"){
+      meta.task.price = value == null ? null : Number(value);
+    }else if (key === "manualLink" || key === "storeLink" || key === "pn" || key === "name" || key === "condition"){
+      meta.task[key] = target.value;
+      if (key === "name"){ const label = holder.querySelector('.task-name'); if (label) label.textContent = target.value || "(unnamed task)"; }
+      if (key === "condition"){ const chip = holder.querySelector('[data-chip-condition]'); if (chip) chip.textContent = target.value || "As required"; }
+    }
+    persist();
   });
 
-  // Remove + Complete
-  root.querySelectorAll("[data-remove]").forEach(btn=>{
-    btn.addEventListener("click", ()=>{
-      const id = btn.getAttribute("data-remove");
-      const from = btn.getAttribute("data-from");
-      if (from==="interval"){
-        window.tasksInterval = window.tasksInterval.filter(t=>String(t.id)!==String(id));
+  tree?.addEventListener("change", (e)=>{
+    const target = e.target;
+    if (!(target instanceof HTMLSelectElement)) return;
+    const holder = target.closest("[data-task-id]");
+    if (!holder) return;
+    const id = holder.getAttribute("data-task-id");
+    const meta = findTaskMeta(id);
+    if (!meta) return;
+    if (target.getAttribute("data-k") === "mode"){
+      const nextMode = target.value;
+      if (nextMode === meta.mode) return;
+      meta.list.splice(meta.index,1);
+      if (nextMode === "interval"){
+        meta.task.mode = "interval";
+        meta.task.interval = meta.task.interval && meta.task.interval>0 ? Number(meta.task.interval) : 8;
+        meta.task.sinceBase = meta.task.sinceBase ?? null;
+        meta.task.anchorTotal = meta.task.anchorTotal ?? null;
+        delete meta.task.condition;
+        window.tasksInterval.unshift(meta.task);
       }else{
-        window.tasksAsReq = window.tasksAsReq.filter(t=>String(t.id)!==String(id));
+        meta.task.mode = "asreq";
+        meta.task.condition = meta.task.condition || "As required";
+        delete meta.task.interval;
+        delete meta.task.sinceBase;
+        delete meta.task.anchorTotal;
+        window.tasksAsReq.unshift(meta.task);
       }
-      if (typeof saveTasks === "function") try{ saveTasks(); }catch(_){}
-      if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
+      persist();
       renderSettings();
-    });
-  });
-  root.querySelectorAll(".btn-complete").forEach(btn=>{
-    btn.addEventListener("click", ()=>{
-      const id = btn.getAttribute("data-complete");
-      const t = window.tasksInterval.find(x=>String(x.id)===String(id));
-      if (!t) return;
-      const cur = (typeof currentTotal === "function") ? currentTotal() : null;
-      t.anchorTotal = cur!=null ? cur : 0;
-      t.sinceBase = 0;
-      if (typeof saveTasks === "function") try{ saveTasks(); }catch(_){}
-      if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
-      renderSettings();
-    });
-  });
-
-  // --- Drag & Drop (tasks + folders) ---
-  const tree = document.getElementById("tree");
-  const DRAG = { kind:null, id:null, type:null }; // type = interval|asreq for tasks
-
-  tree.addEventListener("dragstart",(e)=>{
-    const sum = e.target.closest("summary");
-    if (!sum) return;
-    const cardTask = sum.closest("details.task");
-    const cardCat  = sum.closest("details.cat");
-    if (cardTask){
-      DRAG.kind = "task";
-      DRAG.id   = cardTask.getAttribute("data-task-id");
-      DRAG.type = cardTask.getAttribute("data-owner");
-      e.dataTransfer.setData("text/plain", `task:${DRAG.id}:${DRAG.type}`);
-      e.dataTransfer.effectAllowed = "move";
-      sum.classList.add("drop-hint");
-    }else if (cardCat){
-      DRAG.kind = "category";
-      DRAG.id   = cardCat.getAttribute("data-cat-id");
-      e.dataTransfer.setData("text/plain", `category:${DRAG.id}`);
-      e.dataTransfer.effectAllowed = "move";
-      sum.classList.add("drop-hint");
     }
   });
-  tree.addEventListener("dragend", ()=>{
-    tree.querySelectorAll(".drop-hint").forEach(x=>x.classList.remove("drop-hint"));
-    tree.querySelectorAll(".dz.dragover").forEach(x=>x.classList.remove("dragover"));
+
+  tree?.addEventListener("click", (e)=>{
+    const removeBtn = e.target.closest('[data-remove]');
+    if (removeBtn){
+      const id = removeBtn.getAttribute('data-remove');
+      const from = removeBtn.getAttribute('data-from');
+      window.tasksInterval.forEach(t => { if (String(t.parentTask) === String(id)) t.parentTask = null; });
+      window.tasksAsReq.forEach(t => { if (String(t.parentTask) === String(id)) t.parentTask = null; });
+      if (from === 'interval') window.tasksInterval = window.tasksInterval.filter(t => String(t.id)!==String(id));
+      else window.tasksAsReq = window.tasksAsReq.filter(t => String(t.id)!==String(id));
+      persist();
+      renderSettings();
+      return;
+    }
+    const completeBtn = e.target.closest('.btn-complete');
+    if (completeBtn){
+      const id = completeBtn.getAttribute('data-complete');
+      const meta = findTaskMeta(id);
+      if (!meta || meta.mode !== 'interval') return;
+      const cur = (typeof currentTotal === 'function') ? currentTotal() : null;
+      meta.task.anchorTotal = cur!=null ? cur : 0;
+      meta.task.sinceBase = 0;
+      persist();
+      renderSettings();
+    }
+  });
+
+  const DRAG = { kind:null, id:null, type:null };
+  tree?.addEventListener('dragstart',(e)=>{
+    const sum = e.target.closest('summary');
+    if (!sum) return;
+    const taskCard = sum.closest('details.task');
+    const catCard  = sum.closest('details.cat');
+    if (taskCard){
+      DRAG.kind = 'task';
+      DRAG.id   = taskCard.getAttribute('data-task-id');
+      DRAG.type = taskCard.getAttribute('data-owner');
+      e.dataTransfer.setData('text/plain', `task:${DRAG.id}:${DRAG.type}`);
+      e.dataTransfer.effectAllowed = 'move';
+      sum.classList.add('drop-hint');
+    }else if (catCard){
+      DRAG.kind = 'category';
+      DRAG.id   = catCard.getAttribute('data-cat-id');
+      e.dataTransfer.setData('text/plain', `category:${DRAG.id}`);
+      e.dataTransfer.effectAllowed = 'move';
+      sum.classList.add('drop-hint');
+    }
+  });
+  tree?.addEventListener('dragend',()=>{
+    tree.querySelectorAll('.drop-hint').forEach(el=>el.classList.remove('drop-hint'));
+    tree.querySelectorAll('.dz.dragover').forEach(el=>el.classList.remove('dragover'));
     DRAG.kind = DRAG.id = DRAG.type = null;
   });
-
-  function allow(e){ e.preventDefault(); e.dataTransfer.dropEffect = "move"; }
-  tree.addEventListener("dragover",(e)=>{
-    const dz  = e.target.closest(".dz");
-    const sum = e.target.closest("summary");
-    if (dz){ allow(e); dz.classList.add("dragover"); }
-    if (sum){ allow(e); sum.classList.add("drop-hint"); }
+  function allow(e){ e.preventDefault(); e.dataTransfer.dropEffect = 'move'; }
+  tree?.addEventListener('dragover',(e)=>{
+    const dz = e.target.closest('.dz');
+    const sum = e.target.closest('summary');
+    if (dz){ allow(e); dz.classList.add('dragover'); }
+    if (sum){ allow(e); sum.classList.add('drop-hint'); }
   });
-  tree.addEventListener("dragleave",(e)=>{
-    const dz  = e.target.closest(".dz"); dz?.classList.remove("dragover");
-    const sum = e.target.closest("summary"); sum?.classList.remove("drop-hint");
+  tree?.addEventListener('dragleave',(e)=>{
+    e.target.closest('.dz')?.classList.remove('dragover');
+    e.target.closest('summary')?.classList.remove('drop-hint');
   });
-
-  tree.addEventListener("drop",(e)=>{
-    const raw = e.dataTransfer.getData("text/plain") || "";
-    const parts = raw.split(":");
-    const kind  = parts[0];
-    const id    = parts[1] || null;
-    const type  = parts[2] || null;
-
-    const dzRoot = e.target.closest("[data-drop-root]");
-    const dzInto = e.target.closest("[data-drop-into-cat]");
-    const onSum  = e.target.closest("summary");
-
+  tree?.addEventListener('drop',(e)=>{
+    const raw = e.dataTransfer.getData('text/plain') || '';
+    const parts = raw.split(':');
+    const kind = parts[0];
+    const id = parts[1] || null;
     e.preventDefault();
+    const dzRoot = e.target.closest('[data-drop-root]');
+    const dzCat  = e.target.closest('[data-drop-into-cat]');
+    const dzTask = e.target.closest('[data-drop-into-task]');
+    const onSum  = e.target.closest('summary');
 
-    // TASK moves
-    if (kind==="task" && id){
+    if (kind === 'task' && id){
       if (dzRoot){
-        if (typeof moveNodeSafely === "function" ? moveNodeSafely("task", id, { intoCat: null }) : (()=>{
-          // Fallback simple move: remove from both lists, push to top with cat=null
-          let ref = (type==="interval" ? window.tasksInterval : window.tasksAsReq).find(x=>String(x.id)===String(id));
-          if (!ref) return false;
-          // Remove from possible .sub locations is handled by moveNodeSafely only.
-          ref.cat = null; ref.parentTask = null; ref.order = ++window._maintOrderCounter;
-          return true;
-        })()){
-          if (typeof saveTasks === "function") try{ saveTasks(); }catch(_){}
-          if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
+        if (typeof moveNodeSafely === 'function' && moveNodeSafely('task', id, { intoCat: null })){
+          persist();
           renderSettings();
         }
         return;
       }
-      if (dzInto){
-        const catId = dzInto.getAttribute("data-drop-into-cat");
-        if (typeof moveNodeSafely === "function" ? moveNodeSafely("task", id, { intoCat: catId }) : (()=>{
-          let ref = (type==="interval" ? window.tasksInterval : window.tasksAsReq).find(x=>String(x.id)===String(id));
-          if (!ref) return false;
-          ref.cat = catId; ref.parentTask = null; ref.order = ++window._maintOrderCounter;
-          return true;
-        })()){
-          if (typeof saveTasks === "function") try{ saveTasks(); }catch(_){}
-          if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
+      if (dzCat){
+        const catId = dzCat.getAttribute('data-drop-into-cat');
+        if (typeof moveNodeSafely === 'function' && moveNodeSafely('task', id, { intoCat: catId })){
+          persist();
+          renderSettings();
+        }
+        return;
+      }
+      if (dzTask){
+        const parentId = dzTask.getAttribute('data-drop-into-task');
+        if (typeof moveNodeSafely === 'function' && moveNodeSafely('task', id, { intoTask: parentId })){
+          persist();
           renderSettings();
         }
         return;
       }
       if (onSum){
-        // Reorder before another task in the same container
-        const t2 = onSum.closest("details.task");
-        const beforeId = t2?.getAttribute("data-task-id");
-        if (beforeId && typeof moveNodeSafely === "function" && moveNodeSafely("task", id, { beforeTask: { id: beforeId } })){
-          if (typeof saveTasks === "function") try{ saveTasks(); }catch(_){}
-          if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
+        const beforeId = onSum.closest('details.task')?.getAttribute('data-task-id');
+        if (beforeId && typeof moveNodeSafely === 'function' && moveNodeSafely('task', id, { beforeTask: { id: beforeId } })){
+          persist();
           renderSettings();
         }
         return;
       }
     }
 
-    // CATEGORY moves
-    if (kind==="category" && id){
+    if (kind === 'category' && id){
       if (dzRoot){
-        if (typeof moveNodeSafely === "function" && moveNodeSafely("category", id, { intoCat: null })){
-          if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
+        if (typeof moveNodeSafely === 'function' && moveNodeSafely('category', id, { intoCat: null })){
+          persist();
           renderSettings();
         }
         return;
       }
-      if (dzInto){
-        const parent = dzInto.getAttribute("data-drop-into-cat");
-        if (typeof moveNodeSafely === "function" && moveNodeSafely("category", id, { intoCat: parent })){
-          if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
+      if (dzCat){
+        const parent = dzCat.getAttribute('data-drop-into-cat');
+        if (typeof moveNodeSafely === 'function' && moveNodeSafely('category', id, { intoCat: parent })){
+          persist();
           renderSettings();
         }
         return;
       }
       if (onSum){
-        const holder = onSum.closest("details.cat");
-        const beforeId = holder?.getAttribute("data-cat-id");
-        if (beforeId && typeof moveNodeSafely === "function" && moveNodeSafely("category", id, { beforeCat: { id: beforeId } })){
-          if (typeof saveCloudDebounced === "function") try{ saveCloudDebounced(); }catch(_){}
+        const beforeId = onSum.closest('details.cat')?.getAttribute('data-cat-id');
+        if (beforeId && typeof moveNodeSafely === 'function' && moveNodeSafely('category', id, { beforeCat: { id: beforeId } })){
+          persist();
           renderSettings();
         }
         return;
@@ -755,7 +1007,6 @@ function renderSettings(){
     }
   });
 }
-
 
 // ---- Costs page (placeholder to satisfy router & nav) ----
 function renderCosts(){


### PR DESCRIPTION
## Summary
- allow maintenance tasks to be reorganized into hierarchical structures and stay inside their categories when dragged
- add a unified task editor that renders subtasks inside their parents and supports switching between as-required and interval modes
- introduce a modal for creating new tasks with complete fields and update drag-and-drop/persistence helpers accordingly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdc1cd9a4c832591dbaa56920c118b