### PR TITLE
Add pump efficiency timeframe filter and layout improvements

### DIFF
--- a/js/pump.js
+++ b/js/pump.js
@@ -1,5 +1,14 @@
 /* =================== PUMP EFFICIENCY ======================= */
 window.pumpEff = window.pumpEff || { baselineRPM:null, baselineDateISO:null, entries:[] }; // [{dateISO:"yyyy-mm-dd", rpm:number}]
+window.pumpChartRange = window.pumpChartRange || "3m";
+
+const PUMP_RANGE_OPTIONS = [
+  { value:"1w", label:"1 week" },
+  { value:"1m", label:"1 month" },
+  { value:"3m", label:"3 months" },
+  { value:"6m", label:"6 months" },
+  { value:"1y", label:"1 year" }
+];
 
 function upsertPumpEntry(dateISO, rpm){
   const d = String(dateISO);
@@ -24,6 +33,30 @@ function pumpColorFor(pct){
   return {cls:"green",  label:`${pct.toFixed(1)}%`};
 }
 
+function pumpRangeLabel(val){
+  const opt = PUMP_RANGE_OPTIONS.find(o => o.value === val);
+  return opt ? opt.label : val;
+}
+
+function pumpFilterEntriesByRange(entries, range){
+  if (!entries.length) return [];
+  const data = entries.slice();
+  const latestDate = new Date(data[data.length - 1].dateISO + "T00:00:00");
+  const cutoff = new Date(latestDate);
+  switch(range){
+    case "1w": cutoff.setDate(cutoff.getDate() - 6); break;
+    case "1m": cutoff.setMonth(cutoff.getMonth() - 1); break;
+    case "3m": cutoff.setMonth(cutoff.getMonth() - 3); break;
+    case "6m": cutoff.setMonth(cutoff.getMonth() - 6); break;
+    case "1y": cutoff.setFullYear(cutoff.getFullYear() - 1); break;
+    default: cutoff.setMonth(cutoff.getMonth() - 3); break;
+  }
+  return data.filter(entry => {
+    const d = new Date(entry.dateISO + "T00:00:00");
+    return d >= cutoff;
+  });
+}
+
 function viewPumpWidget(){
   const latest = pumpLatest();
   const pct    = latest ? pumpPercentChange(latest.rpm) : null;
@@ -31,6 +64,8 @@ function viewPumpWidget(){
   const baselineVal = pumpEff.baselineRPM ?? "";
   const todayISO    = new Date().toISOString().slice(0,10);
   const latestTxt   = latest ? `${latest.rpm} RPM on ${latest.dateISO}` : "—";
+  const rangeValue  = window.pumpChartRange || "3m";
+  const rangeOptions = PUMP_RANGE_OPTIONS.map(opt => `<option value="${opt.value}" ${opt.value===rangeValue?"selected":""}>Last ${opt.label}</option>`).join("");
   return `
   <details class="block pump-card" open>
     <summary><b>Pump Efficiency</b> <span class="chip ${col.cls}">${col.label}</span></summary>
@@ -53,11 +88,20 @@ function viewPumpWidget(){
           <div><span class="lbl">Latest:</span> <span>${latestTxt}</span></div>
         </div>
       </div>
-      <div class="pump-col">
-        <canvas id="pumpChart" width="520" height="180"></canvas>
-        <div class="small muted" style="margin-top:6px">
-          Color codes: <span class="chip green">0–&lt;8%</span> <span class="chip yellow">8–15%</span>
-          <span class="chip orange">&gt;15–18%</span> <span class="chip red">&gt;18%</span>
+      <div class="pump-col pump-chart-col">
+        <div class="pump-chart-toolbar small muted">
+          <label for="pumpRange">Timeframe:</label>
+          <select id="pumpRange">${rangeOptions}</select>
+        </div>
+        <div class="pump-chart-wrap">
+          <canvas id="pumpChart" height="240"></canvas>
+        </div>
+        <div class="pump-legend small muted">
+          <span>Color codes:</span>
+          <span class="chip green">0–&lt;8%</span>
+          <span class="chip yellow">8–15%</span>
+          <span class="chip orange">&gt;15–18%</span>
+          <span class="chip red">&gt;18%</span>
           <span class="chip green-better">Negative = better</span>
         </div>
       </div>
@@ -83,14 +127,34 @@ function renderPumpWidget(){
     if (!d || !isFinite(rpm) || rpm <= 0) { toast("Enter date and valid RPM."); return; }
     upsertPumpEntry(d, rpm); saveCloudDebounced(); toast("Log saved"); renderPumpWidget();
   });
-  drawPumpChart(document.getElementById("pumpChart"));
+  const canvas = document.getElementById("pumpChart");
+  const wrap   = document.querySelector(".pump-chart-wrap");
+  if (canvas && wrap){
+    const targetWidth = Math.max(320, Math.floor(wrap.clientWidth - 8));
+    if (targetWidth && canvas.width !== targetWidth) canvas.width = targetWidth;
+  }
+  const rangeSelect = document.getElementById("pumpRange");
+  if (rangeSelect){
+    if (rangeSelect.value !== window.pumpChartRange) rangeSelect.value = window.pumpChartRange;
+    rangeSelect.addEventListener("change", (e)=>{
+      window.pumpChartRange = e.target.value;
+      drawPumpChart(canvas, window.pumpChartRange);
+    });
+  }
+  drawPumpChart(canvas, window.pumpChartRange);
 }
-function drawPumpChart(canvas){
+function drawPumpChart(canvas, rangeValue){
   if (!canvas) return;
   const ctx = canvas.getContext("2d"), W = canvas.width, H = canvas.height;
   ctx.clearRect(0,0,W,H); ctx.fillStyle="#fff"; ctx.fillRect(0,0,W,H);
+  ctx.font = "12px sans-serif";
+  ctx.textAlign = "left";
   if (!pumpEff.entries.length){ ctx.fillStyle="#888"; ctx.fillText("No pump logs yet.", 12, H/2); return; }
-  const data = pumpEff.entries.slice();
+  const range = rangeValue || window.pumpChartRange || "3m";
+  const dataAll = pumpEff.entries.slice();
+  const filtered = pumpFilterEntriesByRange(dataAll, range);
+  const usingFiltered = filtered.length > 0;
+  const data = usingFiltered ? filtered : [dataAll[dataAll.length - 1]];
   const dates = data.map(d=>new Date(d.dateISO+"T00:00:00"));
   const rpms  = data.map(d=>d.rpm);
   const minR  = Math.min(...rpms, pumpEff.baselineRPM ?? rpms[0]);
@@ -98,7 +162,9 @@ function drawPumpChart(canvas){
   const padY  = Math.max(5, (maxR-minR)*0.1);
   const xMin = dates[0].getTime(), xMax = dates[dates.length-1].getTime();
   const yMin = minR - padY, yMax = maxR + padY;
-  const X=t=>((t-xMin)/Math.max(1,(xMax-xMin)))*(W-40)+30;
+  const span = Math.max(1, (xMax - xMin));
+  const singlePoint = xMax === xMin;
+  const X=t=> singlePoint ? (W + 20) / 2 : ((t-xMin)/span)*(W-40)+30;
   const Y=v=>H-20-((v-yMin)/Math.max(1,(yMax-yMin)))*(H-40);
   ctx.strokeStyle="#e2e6f1"; ctx.beginPath(); ctx.moveTo(30,10); ctx.lineTo(30,H-20); ctx.lineTo(W-10,H-20); ctx.stroke();
   if (pumpEff.baselineRPM){
@@ -115,6 +181,14 @@ function drawPumpChart(canvas){
     const map={green:"#2e7d32","green-better":"#2e7d32",yellow:"#c29b00",orange:"#d9822b",red:"#c62828",gray:"#777"};
     ctx.fillStyle = map[col] || "#333";
     ctx.fillText(`Latest: ${latest.rpm} RPM (${latest.dateISO})  Δ%=${pct!=null?pct.toFixed(1):"—"}`, 34, 18);
+  }
+  ctx.fillStyle = "#4a5868";
+  ctx.textAlign = "right";
+  ctx.fillText(`Range: Last ${pumpRangeLabel(range)}`, W - 12, 18);
+  ctx.textAlign = "left";
+  if (!usingFiltered){
+    ctx.fillStyle = "#777";
+    ctx.fillText("No logs in selected range. Showing latest entry.", 34, H - 8);
   }
 }
 

--- a/js/pump.js
+++ b/js/pump.js
@@ -253,7 +253,8 @@ function renderPumpWidget(){
   const wrap   = document.querySelector(".pump-chart-wrap");
   if (canvas && wrap){
     const rect = wrap.getBoundingClientRect();
-    const targetWidth = Math.max(320, Math.floor((rect.width || wrap.clientWidth || canvas.width) - 8));
+    const availableWidth = rect.width || wrap.clientWidth || canvas.width || 320;
+    const targetWidth = Math.max(320, Math.floor(availableWidth));
     if (targetWidth && canvas.width !== targetWidth) canvas.width = targetWidth;
     const expanded = !!window.pumpChartExpanded;
     let targetHeight = expanded ? Math.max(320, Math.floor((window.innerHeight || 720) * 0.6)) : 240;

--- a/js/pump.js
+++ b/js/pump.js
@@ -2,6 +2,9 @@
 window.pumpEff = window.pumpEff || { baselineRPM:null, baselineDateISO:null, entries:[] }; // [{dateISO:"yyyy-mm-dd", rpm:number}]
 window.pumpChartRange = window.pumpChartRange || "3m";
 
+const DAY_MS = 24*60*60*1000;
+const PUMP_MONTH_NAMES = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+
 const PUMP_RANGE_OPTIONS = [
   { value:"1w", label:"1 week" },
   { value:"1m", label:"1 month" },
@@ -9,6 +12,27 @@ const PUMP_RANGE_OPTIONS = [
   { value:"6m", label:"6 months" },
   { value:"1y", label:"1 year" }
 ];
+
+const PUMP_RANGE_UNIT_COUNT = {
+  "1w": 7,
+  "1m": 5,
+  "3m": 6,
+  "6m": 6,
+  "1y": 12
+};
+
+function pumpFormatMonthDay(date){
+  const m = PUMP_MONTH_NAMES[date.getMonth()];
+  const d = String(date.getDate()).padStart(2,"0");
+  return `${m} ${d}`;
+}
+function pumpFormatMonth(date){
+  return PUMP_MONTH_NAMES[date.getMonth()];
+}
+function pumpFormatMonthYear(date){
+  const yr = String(date.getFullYear()).slice(-2);
+  return `${pumpFormatMonth(date)} '${yr}`;
+}
 
 function upsertPumpEntry(dateISO, rpm){
   const d = String(dateISO);
@@ -38,11 +62,8 @@ function pumpRangeLabel(val){
   return opt ? opt.label : val;
 }
 
-function pumpFilterEntriesByRange(entries, range){
-  if (!entries.length) return [];
-  const data = entries.slice();
-  const latestDate = new Date(data[data.length - 1].dateISO + "T00:00:00");
-  const cutoff = new Date(latestDate);
+function pumpRangeCutoff(latestDate, range){
+  const cutoff = new Date(latestDate.getTime());
   switch(range){
     case "1w": cutoff.setDate(cutoff.getDate() - 6); break;
     case "1m": cutoff.setMonth(cutoff.getMonth() - 1); break;
@@ -51,10 +72,97 @@ function pumpFilterEntriesByRange(entries, range){
     case "1y": cutoff.setFullYear(cutoff.getFullYear() - 1); break;
     default: cutoff.setMonth(cutoff.getMonth() - 3); break;
   }
+  return cutoff;
+}
+
+function pumpFilterEntriesByRange(entries, range){
+  if (!entries.length) return [];
+  const data = entries.slice();
+  const latestDate = new Date(data[data.length - 1].dateISO + "T00:00:00");
+  const cutoff = pumpRangeCutoff(latestDate, range);
   return data.filter(entry => {
     const d = new Date(entry.dateISO + "T00:00:00");
     return d >= cutoff;
   });
+}
+
+function pumpAdvanceCursor(range, cursor){
+  const next = new Date(cursor.getTime());
+  switch(range){
+    case "1w": next.setDate(next.getDate() + 1); break;
+    case "1m": next.setDate(next.getDate() + 7); break;
+    case "3m": next.setDate(next.getDate() + 14); break;
+    case "6m": next.setMonth(next.getMonth() + 1); break;
+    case "1y": next.setMonth(next.getMonth() + 1); break;
+    default: next.setDate(next.getDate() + 14); break;
+  }
+  return next;
+}
+
+function pumpTickLabel(range, index, date, startDate, endDate, isFinal){
+  const info = { label:"", subLabel:null };
+  const unitCap = PUMP_RANGE_UNIT_COUNT[range] || null;
+  const ordinal = unitCap ? Math.min(index + 1, unitCap) : (index + 1);
+  switch(range){
+    case "1w":
+      info.label = `Day ${ordinal}`;
+      info.subLabel = pumpFormatMonthDay(date);
+      break;
+    case "1m":
+      info.label = `Week ${ordinal}`;
+      info.subLabel = pumpFormatMonthDay(date);
+      break;
+    case "3m":
+      info.label = `Bi-Wk ${ordinal}`;
+      info.subLabel = pumpFormatMonthDay(date);
+      break;
+    case "6m":
+      info.label = pumpFormatMonth(date);
+      if (startDate.getFullYear() !== endDate.getFullYear() || date.getFullYear() !== startDate.getFullYear()){
+        info.subLabel = `'${String(date.getFullYear()).slice(-2)}`;
+      }
+      break;
+    case "1y":
+      info.label = pumpFormatMonthYear(date);
+      break;
+    default:
+      info.label = pumpFormatMonthDay(date);
+      break;
+  }
+  if (isFinal){
+    if (range === "1w") info.label = `Day ${unitCap ? unitCap : Math.max(index + 1, 1)}`;
+    if (range === "1m") info.label = `Week ${unitCap ? unitCap : Math.max(index + 1, 1)}`;
+    if (range === "3m") info.label = `Bi-Wk ${unitCap ? unitCap : Math.max(index + 1, 1)}`;
+  }
+  if (!info.subLabel) delete info.subLabel;
+  return info;
+}
+
+function pumpBuildTimeTicks(range, startTime, endTime){
+  const ticks = [];
+  if (!(endTime > startTime)) return ticks;
+  const startDate = new Date(startTime);
+  const endDate = new Date(endTime);
+  const unitCap = PUMP_RANGE_UNIT_COUNT[range] || null;
+  let cursor = new Date(startDate.getTime());
+  let index = 0;
+  const epsilon = 60*60*1000; // 1 hour tolerance
+  const maxIterations = 200;
+  while (cursor.getTime() <= endTime + epsilon && index < maxIterations){
+    const info = pumpTickLabel(range, index, cursor, startDate, endDate, Math.abs(cursor.getTime() - endTime) <= epsilon);
+    ticks.push({ time: cursor.getTime(), label: info.label, subLabel: info.subLabel });
+    if (unitCap && ticks.length >= Math.max(1, unitCap - 1)) break;
+    const next = pumpAdvanceCursor(range, cursor);
+    if (next.getTime() <= cursor.getTime()) break;
+    cursor = next;
+    index++;
+  }
+  const last = ticks[ticks.length - 1];
+  if (!last || Math.abs(last.time - endTime) > epsilon){
+    const endInfo = pumpTickLabel(range, ticks.length, endDate, startDate, endDate, true);
+    ticks.push({ time: endTime, label: endInfo.label, subLabel: endInfo.subLabel });
+  }
+  return ticks;
 }
 
 function viewPumpWidget(){
@@ -146,10 +254,17 @@ function renderPumpWidget(){
 function drawPumpChart(canvas, rangeValue){
   if (!canvas) return;
   const ctx = canvas.getContext("2d"), W = canvas.width, H = canvas.height;
-  ctx.clearRect(0,0,W,H); ctx.fillStyle="#fff"; ctx.fillRect(0,0,W,H);
+  ctx.clearRect(0,0,W,H);
+  ctx.fillStyle = "#fff";
+  ctx.fillRect(0,0,W,H);
   ctx.font = "12px sans-serif";
   ctx.textAlign = "left";
-  if (!pumpEff.entries.length){ ctx.fillStyle="#888"; ctx.fillText("No pump logs yet.", 12, H/2); return; }
+  ctx.textBaseline = "alphabetic";
+  if (!pumpEff.entries.length){
+    ctx.fillStyle = "#888";
+    ctx.fillText("No pump logs yet.", 14, H/2);
+    return;
+  }
   const range = rangeValue || window.pumpChartRange || "3m";
   const dataAll = pumpEff.entries.slice();
   const filtered = pumpFilterEntriesByRange(dataAll, range);
@@ -160,35 +275,123 @@ function drawPumpChart(canvas, rangeValue){
   const minR  = Math.min(...rpms, pumpEff.baselineRPM ?? rpms[0]);
   const maxR  = Math.max(...rpms, pumpEff.baselineRPM ?? rpms[0]);
   const padY  = Math.max(5, (maxR-minR)*0.1);
-  const xMin = dates[0].getTime(), xMax = dates[dates.length-1].getTime();
-  const yMin = minR - padY, yMax = maxR + padY;
-  const span = Math.max(1, (xMax - xMin));
-  const singlePoint = xMax === xMin;
-  const X=t=> singlePoint ? (W + 20) / 2 : ((t-xMin)/span)*(W-40)+30;
-  const Y=v=>H-20-((v-yMin)/Math.max(1,(yMax-yMin)))*(H-40);
-  ctx.strokeStyle="#e2e6f1"; ctx.beginPath(); ctx.moveTo(30,10); ctx.lineTo(30,H-20); ctx.lineTo(W-10,H-20); ctx.stroke();
+  const yMin = minR - padY;
+  const yMax = maxR + padY;
+  const latestDate = dates[dates.length - 1];
+  const axisEndDate = new Date(latestDate.getTime());
+  const axisStartDate = pumpRangeCutoff(axisEndDate, range);
+  let xMin = axisStartDate.getTime();
+  let xMax = axisEndDate.getTime();
+  if (xMax <= xMin) xMax = xMin + DAY_MS;
+  const ticks = pumpBuildTimeTicks(range, xMin, xMax);
+  const hasSubLabel = ticks.some(t => t.subLabel);
+  const margin = { top: 40, right: 16, bottom: hasSubLabel ? 66 : 48, left: 48 };
+  const innerW = Math.max(10, W - margin.left - margin.right);
+  const innerH = Math.max(10, H - margin.top - margin.bottom);
+  const axisY = margin.top + innerH;
+  const axisX0 = margin.left;
+  const axisX1 = W - margin.right;
+  const span = xMax - xMin;
+  const singlePoint = span < 1000;
+  const X = t => singlePoint ? (axisX0 + axisX1) / 2 : axisX0 + ((t - xMin) / span) * innerW;
+  const ySpan = Math.max(1e-6, (yMax - yMin));
+  const Y = v => axisY - ((v - yMin) / ySpan) * innerH;
+
+  ctx.strokeStyle = "#d8deeb";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(axisX0, margin.top - 4);
+  ctx.lineTo(axisX0, axisY);
+  ctx.lineTo(axisX1, axisY);
+  ctx.stroke();
+
   if (pumpEff.baselineRPM){
-    ctx.strokeStyle="#999"; ctx.setLineDash([4,4]); ctx.beginPath(); ctx.moveTo(30,Y(pumpEff.baselineRPM)); ctx.lineTo(W-10,Y(pumpEff.baselineRPM)); ctx.stroke(); ctx.setLineDash([]);
-    ctx.fillStyle="#666"; ctx.fillText(`Baseline ${pumpEff.baselineRPM} RPM`, 34, Y(pumpEff.baselineRPM)-6);
+    const baselineY = Y(pumpEff.baselineRPM);
+    ctx.strokeStyle = "#9aa5b5";
+    ctx.setLineDash([4,4]);
+    ctx.beginPath();
+    ctx.moveTo(axisX0, baselineY);
+    ctx.lineTo(axisX1, baselineY);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.fillStyle = "#666";
+    ctx.textAlign = "left";
+    ctx.textBaseline = "bottom";
+    ctx.fillText(`Baseline ${pumpEff.baselineRPM} RPM`, axisX0 + 6, baselineY - 4);
   }
-  ctx.strokeStyle="#0a63c2"; ctx.lineWidth=2; ctx.beginPath();
-  dates.forEach((d,i)=>{ const x=X(d.getTime()), y=Y(rpms[i]); if(i===0)ctx.moveTo(x,y); else ctx.lineTo(x,y); }); ctx.stroke();
-  ctx.fillStyle="#0a63c2"; dates.forEach((d,i)=>{ const x=X(d.getTime()), y=Y(rpms[i]); ctx.beginPath(); ctx.arc(x,y,3,0,Math.PI*2); ctx.fill(); });
+
+  ctx.strokeStyle = "#0a63c2";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  dates.forEach((d,i)=>{
+    const x = X(d.getTime());
+    const y = Y(rpms[i]);
+    if (i === 0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+  });
+  ctx.stroke();
+
+  ctx.fillStyle = "#0a63c2";
+  dates.forEach((d,i)=>{
+    const x = X(d.getTime());
+    const y = Y(rpms[i]);
+    ctx.beginPath();
+    ctx.arc(x,y,3,0,Math.PI*2);
+    ctx.fill();
+  });
+
+  ctx.save();
+  ctx.strokeStyle = "#9aa5b5";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ticks.forEach(t => {
+    const x = X(t.time);
+    ctx.moveTo(x, axisY);
+    ctx.lineTo(x, axisY + 7);
+  });
+  ctx.stroke();
+  ctx.restore();
+
+  ctx.save();
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  const primaryFont = "11px sans-serif";
+  const secondaryFont = "10px sans-serif";
+  const baseY = axisY + 10;
+  ticks.forEach((t,idx) => {
+    const x = X(t.time);
+    ctx.font = primaryFont;
+    ctx.fillStyle = "#4a5868";
+    ctx.fillText(t.label, x, baseY);
+    if (t.subLabel){
+      ctx.font = secondaryFont;
+      ctx.fillStyle = "#6c7a90";
+      ctx.fillText(t.subLabel, x, baseY + 13);
+    }
+  });
+  ctx.restore();
+
   const latest = pumpLatest();
   if (latest){
     const pct = pumpPercentChange(latest.rpm);
     const col = pumpColorFor(pct).cls;
     const map={green:"#2e7d32","green-better":"#2e7d32",yellow:"#c29b00",orange:"#d9822b",red:"#c62828",gray:"#777"};
+    ctx.textAlign = "left";
+    ctx.textBaseline = "middle";
     ctx.fillStyle = map[col] || "#333";
-    ctx.fillText(`Latest: ${latest.rpm} RPM (${latest.dateISO})  Δ%=${pct!=null?pct.toFixed(1):"—"}`, 34, 18);
+    ctx.fillText(`Latest: ${latest.rpm} RPM (${latest.dateISO})  Δ%=${pct!=null?pct.toFixed(1):"—"}`, axisX0 + 4, margin.top / 2);
   }
+
   ctx.fillStyle = "#4a5868";
   ctx.textAlign = "right";
-  ctx.fillText(`Range: Last ${pumpRangeLabel(range)}`, W - 12, 18);
-  ctx.textAlign = "left";
+  ctx.textBaseline = "middle";
+  ctx.fillText(`Range: Last ${pumpRangeLabel(range)}`, axisX1, margin.top / 2);
+
   if (!usingFiltered){
+    ctx.textAlign = "left";
+    ctx.textBaseline = "top";
     ctx.fillStyle = "#777";
-    ctx.fillText("No logs in selected range. Showing latest entry.", 34, H - 8);
+    const infoY = axisY + (hasSubLabel ? 32 : 20);
+    ctx.fillText("No logs in selected range. Showing latest entry.", axisX0 + 4, infoY);
   }
 }
 

--- a/js/views.js
+++ b/js/views.js
@@ -23,7 +23,7 @@ function viewDashboard(){
     </div>
 
     <!-- Pump Efficiency widget (rendered by renderPumpWidget) -->
-    <section id="pump-widget" class="block"></section>
+    <section id="pump-widget" class="block pump-wide"></section>
 
     <!-- Calendar -->
     <div class="block" style="grid-column: 1 / -1">

--- a/style.css
+++ b/style.css
@@ -1,15 +1,16 @@
 /* Pump card */
 .pump-card summary { display:flex; align-items:center; gap:8px; }
-.pump-grid { display:grid; grid-template-columns: 1fr 1fr; gap:12px; margin-top:8px; }
-.pump-col { background:#fff; border:1px solid #dde3ee; border-radius:10px; padding:12px; }
+.pump-wide { grid-column: 1 / -1; width:100%; max-width: min(1100px, 100%); justify-self:center; margin:0 auto; }
+.pump-grid { display:grid; grid-template-columns: minmax(260px, 0.9fr) minmax(420px, 1.1fr); gap:16px; margin-top:8px; align-items:stretch; }
+.pump-col { background:#fff; border:1px solid #dde3ee; border-radius:10px; padding:12px; min-width:0; }
 .pump-stats { margin-top:6px; display:grid; gap:4px; }
 .pump-stats .lbl { color:#666; display:inline-block; width:80px; }
-.pump-chart-col { display:flex; flex-direction:column; gap:10px; }
+.pump-chart-col { display:flex; flex-direction:column; gap:10px; min-width:0; }
 .pump-chart-toolbar { display:flex; justify-content:flex-end; align-items:center; gap:6px; flex-wrap:wrap; }
 .pump-chart-toolbar label { font-weight:600; }
 .pump-chart-toolbar select { width:auto; padding:4px 6px; font-size:12px; }
-.pump-chart-wrap { flex:1; display:flex; align-items:center; justify-content:center; position:relative; padding-bottom:44px; }
-.pump-chart-wrap canvas { width:100%; max-width:560px; display:block; margin:0 auto; }
+.pump-chart-wrap { flex:1; display:flex; align-items:center; justify-content:center; position:relative; padding:0 0 52px; width:100%; }
+.pump-chart-wrap canvas { width:100%; max-width:100%; display:block; margin:0 auto; }
 .pump-expand-btn {
   position:absolute;
   right:14px;
@@ -61,6 +62,12 @@
 body.pump-chart-expanded { overflow:hidden; }
 .pump-legend { display:flex; flex-wrap:wrap; gap:6px; justify-content:center; }
 .pump-legend span:first-child { font-weight:600; }
+
+@media (max-width: 960px) {
+  .pump-grid { grid-template-columns: 1fr; }
+  .pump-chart-wrap { padding:0 0 48px; }
+  .pump-chart-wrap canvas { max-width:100%; }
+}
 
 /* colored chip used in summary */
 .chip{

--- a/style.css
+++ b/style.css
@@ -4,6 +4,14 @@
 .pump-col { background:#fff; border:1px solid #dde3ee; border-radius:10px; padding:12px; }
 .pump-stats { margin-top:6px; display:grid; gap:4px; }
 .pump-stats .lbl { color:#666; display:inline-block; width:80px; }
+.pump-chart-col { display:flex; flex-direction:column; gap:10px; }
+.pump-chart-toolbar { display:flex; justify-content:flex-end; align-items:center; gap:6px; flex-wrap:wrap; }
+.pump-chart-toolbar label { font-weight:600; }
+.pump-chart-toolbar select { width:auto; padding:4px 6px; font-size:12px; }
+.pump-chart-wrap { flex:1; display:flex; align-items:center; justify-content:center; }
+.pump-chart-wrap canvas { width:100%; max-width:560px; display:block; margin:0 auto; }
+.pump-legend { display:flex; flex-wrap:wrap; gap:6px; justify-content:center; }
+.pump-legend span:first-child { font-weight:600; }
 
 /* colored chip used in summary */
 .chip{

--- a/style.css
+++ b/style.css
@@ -8,8 +8,57 @@
 .pump-chart-toolbar { display:flex; justify-content:flex-end; align-items:center; gap:6px; flex-wrap:wrap; }
 .pump-chart-toolbar label { font-weight:600; }
 .pump-chart-toolbar select { width:auto; padding:4px 6px; font-size:12px; }
-.pump-chart-wrap { flex:1; display:flex; align-items:center; justify-content:center; }
+.pump-chart-wrap { flex:1; display:flex; align-items:center; justify-content:center; position:relative; padding-bottom:44px; }
 .pump-chart-wrap canvas { width:100%; max-width:560px; display:block; margin:0 auto; }
+.pump-expand-btn {
+  position:absolute;
+  right:14px;
+  bottom:14px;
+  display:flex;
+  align-items:center;
+  gap:6px;
+  padding:6px 12px;
+  border-radius:999px;
+  border:0;
+  background:rgba(10,99,194,0.92);
+  color:#fff;
+  font-size:12px;
+  font-weight:600;
+  box-shadow:0 4px 12px rgba(10,26,60,0.25);
+  cursor:pointer;
+  transition:background 0.2s ease, transform 0.2s ease;
+}
+.pump-expand-btn:hover { background:#084f9a; transform:translateY(-1px); }
+.pump-expand-btn:active { transform:translateY(0); }
+.pump-chart-wrap.pump-chart-wrap-expanded {
+  position:fixed;
+  top:50%;
+  left:50%;
+  transform:translate(-50%,-50%);
+  width:min(1000px,92vw);
+  height:min(80vh,680px);
+  background:#fff;
+  box-shadow:0 24px 60px rgba(10,26,60,0.35);
+  border-radius:16px;
+  padding:28px 28px 68px;
+  z-index:1100;
+  flex-direction:column;
+  align-items:stretch;
+  justify-content:flex-start;
+  gap:16px;
+}
+.pump-chart-wrap.pump-chart-wrap-expanded canvas {
+  max-width:none;
+  flex:1;
+  height:100%;
+}
+.pump-chart-backdrop {
+  position:fixed;
+  inset:0;
+  background:rgba(12,23,44,0.45);
+  z-index:1000;
+}
+body.pump-chart-expanded { overflow:hidden; }
 .pump-legend { display:flex; flex-wrap:wrap; gap:6px; justify-content:center; }
 .pump-legend span:first-child { font-weight:600; }
 


### PR DESCRIPTION
## Summary
- add a timeframe selector to the pump efficiency widget and filter chart data by the chosen range
- update the canvas rendering to annotate the active range, handle single-point views, and warn when a range has no logs
- restyle the pump chart column to center the taller plot and tighten the color legend spacing

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1681b0c748325aba5101e4a9a0b9c