### PR TITLE
Add header motto and integrate candm logo

### DIFF
--- a/assets/candmlogo.svg
+++ b/assets/candmlogo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 120" role="img" aria-labelledby="title desc">
+  <title id="title">C&amp;M Concrete Precast and Construction logo</title>
+  <desc id="desc">Rounded blue badge with C and M initials and stacked text for Concrete Precast and Construction.</desc>
+  <rect x="4" y="4" width="352" height="112" rx="18" ry="18" fill="#ffffff" stroke="#0a63c2" stroke-width="4" />
+  <rect x="24" y="28" width="120" height="64" rx="18" ry="18" fill="#0a63c2" />
+  <text x="84" y="70" fill="#ffffff" font-family="'Arial Black', 'Segoe UI', sans-serif" font-size="44" font-weight="700" text-anchor="middle">C&amp;M</text>
+  <text x="168" y="56" fill="#0a63c2" font-family="'Arial Black', 'Segoe UI', sans-serif" font-size="32" font-weight="700">CONCRETE</text>
+  <text x="168" y="82" fill="#0a63c2" font-family="'Arial', 'Segoe UI', sans-serif" font-size="22" font-weight="600">PRECAST &amp; CONSTRUCTION</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,15 @@
 </head>
 <body>
   <header>
-    <h1>OMAX 1530 Maintenance Tracker</h1>
+    <div class="header-bar">
+      <h1>OMAX 1530 Maintenance Tracker</h1>
+      <img
+        class="header-logo"
+        src="assets/candmlogo.svg"
+        alt="C &amp; M Concrete Precast and Construction logo"
+      />
+      <span class="header-motto">TRY HARDER SUCK LESS</span>
+    </div>
     <nav class="nav">
       <a href="#dashboard"  id="tab-dashboard"  class="active">Dashboard</a>
       <a href="#settings"   id="tab-settings">Maintenance Settings</a>

--- a/style.css
+++ b/style.css
@@ -52,8 +52,47 @@
 * { box-sizing: border-box; }
 body { font-family: Arial, sans-serif; margin: 0; background: #f5f7fa; color: #222; }
 header { background: #0a63c2; color: #fff; padding: 16px; }
+.header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+.header-bar h1 {
+  margin: 0;
+  font-size: 22px;
+  flex: 1 1 240px;
+}
+.header-logo {
+  flex: 0 0 auto;
+  max-width: 260px;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.95);
+  border: 3px solid rgba(255, 255, 255, 0.7);
+  border-radius: 14px;
+  padding: 6px 14px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}
+.header-motto {
+  flex: 0 1 220px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #e7f0ff;
+  font-size: 13px;
+  text-align: right;
+  align-self: flex-start;
+  line-height: 1.4;
+}
 h1 { margin: 0 0 10px; font-size: 22px; }
-.nav a { color: #e7f0ff; text-decoration: none; margin-right: 12px; padding: 6px 10px; border-radius: 6px; }
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+.nav a { color: #e7f0ff; text-decoration: none; padding: 6px 10px; border-radius: 6px; }
 .nav a.active, .nav a:hover { background: #084f9a; }
 
 .container { padding: 16px; display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 12px; }


### PR DESCRIPTION
## Summary
- add a flex-based header bar with the OMAX title, a centered C&M logo, and the requested motto treatment
- create an inline SVG reproduction of the C&M Concrete logo and display it with a subtle border so it reads cleanly on the blue background
- refresh navigation spacing to align with the new header layout

## Testing
- not run (static asset change)


------
https://chatgpt.com/codex/tasks/task_e_68d1724e32b08325ad29464a58b92000