### PR TITLE
Expand cost analysis dashboard

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,6 +17,31 @@
 .chip.red{ background:#ffe1e1; color:#c62828; border-color:#ffc9c9; }
 .chip.gray{ background:#f1f3f6; color:#6b7280; border-color:#e4e7ec; }
 
+.cost-summary-grid{ display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:12px; }
+.cost-card{ display:flex; gap:12px; background:#f6f8fd; border:1px solid #dde3ee; border-radius:12px; padding:12px; align-items:flex-start; }
+.cost-card-icon{ font-size:26px; line-height:1; }
+.cost-card-body{ display:flex; flex-direction:column; gap:4px; }
+.cost-card-title{ font-weight:600; color:#1b3558; }
+.cost-card-value{ font-size:20px; font-weight:600; color:#0a63c2; }
+.cost-card-hint{ color:#566074; font-size:12px; }
+
+.cost-chart-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:8px; }
+.cost-chart-toggle{ display:flex; gap:12px; flex-wrap:wrap; font-size:13px; color:#333; }
+.cost-chart-toggle label{ display:flex; align-items:center; gap:6px; cursor:pointer; }
+.cost-chart-toggle .dot{ display:inline-block; width:12px; height:12px; border-radius:999px; }
+
+.cost-table{ width:100%; border-collapse:collapse; font-variant-numeric:tabular-nums; }
+.cost-table th, .cost-table td{ padding:8px; border:1px solid #e1e5ee; text-align:left; }
+.cost-table th{ background:#f4f7fb; font-weight:600; color:#3b475f; }
+
+.cost-history{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:8px; }
+.cost-history li{ display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:8px; padding:8px 10px; background:#f8faff; border:1px solid #e1e6f1; border-radius:10px; font-variant-numeric:tabular-nums; }
+.cost-history span:last-child{ text-align:right; font-weight:600; color:#0a63c2; }
+
+.cost-jobs-summary{ display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:8px; margin-bottom:10px; font-variant-numeric:tabular-nums; }
+.cost-jobs-summary .label{ display:block; font-size:12px; text-transform:uppercase; letter-spacing:.04em; color:#5a6478; margin-bottom:2px; }
+.cost-jobs-summary span:last-child{ font-weight:600; color:#1e2b45; }
+
 
 /* Calendar chip/bar are fully interactive */
 .cal-task, .cal-job {


### PR DESCRIPTION
## Summary
- replace the placeholder cost analysis page with a dashboard that calculates maintenance spend by window and forecasts using interval tasks
- add a combined maintenance and cutting job cost chart with dataset toggles plus recent maintenance and job efficiency summaries
- style the new cost analysis components for cards, tables, history list, and summary metrics

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d17170b1ec8325be26f6934c157d3c