### PR TITLE
Add file attachments support to cutting jobs

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -208,7 +208,8 @@ if (!Array.isArray(window.totalHistory)) window.totalHistory = [];   // [{dateIS
 if (!Array.isArray(window.tasksInterval)) window.tasksInterval = [];
 if (!Array.isArray(window.tasksAsReq))   window.tasksAsReq   = [];
 if (!Array.isArray(window.inventory))    window.inventory    = [];
-if (!Array.isArray(window.cuttingJobs))  window.cuttingJobs  = [];   // [{id,name,estimateHours,material,materialCost,materialQty,notes,startISO,dueISO,manualLogs:[{dateISO,completedHours}]}]
+if (!Array.isArray(window.cuttingJobs))  window.cuttingJobs  = [];   // [{id,name,estimateHours,material,materialCost,materialQty,notes,startISO,dueISO,manualLogs:[{dateISO,completedHours}],files:[{name,dataUrl,type,size,addedAt}]}]
+if (!Array.isArray(window.pendingNewJobFiles)) window.pendingNewJobFiles = [];
 
 if (typeof window.pumpEff !== "object" || !window.pumpEff){
   window.pumpEff = { baselineRPM:null, baselineDateISO:null, entries:[] };
@@ -294,6 +295,8 @@ function adoptState(doc){
   window.tasksAsReq = tasksAsReq;
   window.inventory = inventory;
   window.cuttingJobs = cuttingJobs;
+  if (!Array.isArray(window.pendingNewJobFiles)) window.pendingNewJobFiles = [];
+  window.pendingNewJobFiles.length = 0;
 
   // Pump efficiency (guard against reading an undefined identifier)
   const pe = (typeof window.pumpEff === "object" && window.pumpEff)

--- a/style.css
+++ b/style.css
@@ -66,6 +66,15 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 .block .danger:hover { background: #c43d3d; }
 .small { font-size: 12px; color: #777; }
 .mini-form { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.job-files { margin-top: 6px; display: flex; flex-direction: column; gap: 4px; }
+.job-file-link { color: #0a63c2; text-decoration: none; font-size: 12px; }
+.job-file-link:hover { text-decoration: underline; }
+.job-edit-files { margin-top: 8px; display: flex; flex-direction: column; gap: 6px; }
+.job-file-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
+.job-file-list li { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+.job-file-list button.link { background: none; border: none; color: #c43d3d; cursor: pointer; padding: 0; font-size: 12px; }
+.job-file-list button.link:hover { text-decoration: underline; }
+.job-files-summary { margin-top: 4px; }
 
 /* Tables */
 table { width: 100%; border-collapse: collapse; }


### PR DESCRIPTION
## Summary
- add client-side file attachment handling for cutting jobs, including buffering and persistence
- extend the jobs view to attach files when creating or editing a job and surface download links in the table
- style the new attachment controls and summaries to match the existing UI

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d17362714883259bdee925d3ead363