### PR TITLE
Add undo and redo history shortcuts

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -246,6 +246,112 @@ function snapshotState(){
   };
 }
 
+/* ======================== HISTORY ========================= */
+const HISTORY_LIMIT = 50;
+const undoStack = [];
+const redoStack = [];
+let currentSnapshotJSON = null;
+let suppressHistory = false;
+let skipNextHistoryCapture = false;
+
+function resetHistoryToCurrent(){
+  try {
+    currentSnapshotJSON = JSON.stringify(snapshotState());
+  } catch (err) {
+    console.warn("Failed to seed history snapshot:", err);
+    currentSnapshotJSON = null;
+  }
+  undoStack.length = 0;
+  redoStack.length = 0;
+}
+
+function captureHistorySnapshot(){
+  if (suppressHistory) return;
+  if (skipNextHistoryCapture){
+    skipNextHistoryCapture = false;
+    return;
+  }
+  try {
+    const nextSnapshot = JSON.stringify(snapshotState());
+    if (nextSnapshot === currentSnapshotJSON) return;
+    if (currentSnapshotJSON){
+      undoStack.push(currentSnapshotJSON);
+      if (undoStack.length > HISTORY_LIMIT) undoStack.shift();
+    }
+    currentSnapshotJSON = nextSnapshot;
+    redoStack.length = 0;
+  } catch (err) {
+    console.warn("History capture failed:", err);
+  }
+}
+
+function applyHistorySnapshot(json){
+  if (!json) return false;
+  let data;
+  try {
+    data = JSON.parse(json);
+  } catch (err) {
+    console.warn("Could not parse history snapshot:", err);
+    return false;
+  }
+  suppressHistory = true;
+  try {
+    adoptState(data);
+    currentSnapshotJSON = json;
+  } catch (err) {
+    console.warn("Failed to apply history snapshot:", err);
+    return false;
+  } finally {
+    suppressHistory = false;
+  }
+  if (typeof route === "function") {
+    try { route(); } catch (err) { console.warn("Route after history failed:", err); }
+  }
+  skipNextHistoryCapture = true;
+  saveCloudDebounced();
+  return true;
+}
+
+function undoLastChange(){
+  if (!undoStack.length){
+    toast("Nothing to undo");
+    return false;
+  }
+  const target = undoStack.pop();
+  const previous = currentSnapshotJSON;
+  if (applyHistorySnapshot(target)){
+    if (previous){
+      redoStack.push(previous);
+      if (redoStack.length > HISTORY_LIMIT) redoStack.shift();
+    }
+    toast("Undid last change");
+    return true;
+  }
+  undoStack.push(target);
+  return false;
+}
+
+function redoLastUndo(){
+  if (!redoStack.length){
+    toast("Nothing to redo");
+    return false;
+  }
+  const target = redoStack.pop();
+  const previous = currentSnapshotJSON;
+  if (applyHistorySnapshot(target)){
+    if (previous){
+      undoStack.push(previous);
+      if (undoStack.length > HISTORY_LIMIT) undoStack.shift();
+    }
+    toast("Redid change");
+    return true;
+  }
+  redoStack.push(target);
+  return false;
+}
+
+resetHistoryToCurrent();
+
 /* ======= Minimal folder model used by the explorer UI ======= */
 if (!Array.isArray(window.folders) || !window.folders.length) {
   window.folders = [
@@ -310,10 +416,14 @@ function adoptState(doc){
 }
 
 
-const saveCloudDebounced = debounce(async ()=>{
+const saveCloudInternal = debounce(async ()=>{
   if (!FB.ready || !FB.docRef) return;
   try{ await FB.docRef.set(snapshotState(), { merge:true }); }catch(e){ console.error("Cloud save failed:", e); }
 }, 300);
+function saveCloudDebounced(){
+  captureHistorySnapshot();
+  saveCloudInternal();
+}
 async function loadFromCloud(){
   if (!FB.ready || !FB.docRef) return;
   try{
@@ -335,9 +445,11 @@ async function loadFromCloud(){
           pumpEff: pe
         };
         adoptState(seeded);
+        resetHistoryToCurrent();
         await FB.docRef.set(seeded, { merge:true });
       }else{
         adoptState(data);
+        resetHistoryToCurrent();
       }
     }else{
       const pe = (typeof window.pumpEff === "object" && window.pumpEff)
@@ -345,6 +457,7 @@ async function loadFromCloud(){
         : (window.pumpEff = { baselineRPM:null, baselineDateISO:null, entries:[] });
       const seeded = { schema:APP_SCHEMA, totalHistory:[], tasksInterval:defaultIntervalTasks.slice(), tasksAsReq:defaultAsReqTasks.slice(), inventory:seedInventoryFromTasks(), cuttingJobs:[], pumpEff: pe };
       adoptState(seeded);
+      resetHistoryToCurrent();
       await FB.docRef.set(seeded);
     }
   }catch(e){
@@ -353,6 +466,7 @@ async function loadFromCloud(){
       ? window.pumpEff
       : (window.pumpEff = { baselineRPM:null, baselineDateISO:null, entries:[] });
     adoptState({ schema:APP_SCHEMA, totalHistory:[], tasksInterval:defaultIntervalTasks.slice(), tasksAsReq:defaultAsReqTasks.slice(), inventory:seedInventoryFromTasks(), cuttingJobs:[], pumpEff: pe });
+    resetHistoryToCurrent();
   }
 }
 
@@ -362,4 +476,33 @@ function seedInventoryFromTasks(){
     ...defaultAsReqTasks.map(t => ({ id:`inv_${t.id}`, name:t.name, qty:0, unit:"pcs", note:"", pn:t.pn||"", link:t.storeLink||"" })),
   ];
 }
+
+function isEditableTarget(el){
+  if (!el) return false;
+  if (el.isContentEditable) return true;
+  const tag = el.tagName;
+  if (!tag) return false;
+  const upper = tag.toUpperCase();
+  return upper === "INPUT" || upper === "TEXTAREA" || upper === "SELECT";
+}
+
+window.addEventListener("keydown", (e)=>{
+  if (!(e.ctrlKey || e.metaKey)) return;
+  const key = (e.key || "").toLowerCase();
+  if (key !== "z" && key !== "y") return;
+  if (isEditableTarget(e.target)) return;
+
+  if (key === "z" && !e.shiftKey){
+    e.preventDefault();
+    undoLastChange();
+    return;
+  }
+  if (key === "y" || (key === "z" && e.shiftKey)){
+    e.preventDefault();
+    redoLastUndo();
+  }
+});
+
+window.undoLastChange = undoLastChange;
+window.redoLastUndo = redoLastUndo;
 


### PR DESCRIPTION
## Summary
- add a lightweight state history stack so app-level changes can be undone or redone
- record history snapshots whenever data is saved and reset baselines after cloud loads
- wire global Ctrl/Cmd+Z and Ctrl/Cmd+Y (or Shift+Z) shortcuts outside of text inputs to trigger undo/redo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d176b74e208325b5572731be5a28d8