### PR TITLE
Add search bar and filtering to inventory page

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -221,6 +221,9 @@ let tasksAsReq    = window.tasksAsReq;
 let inventory     = window.inventory;
 let cuttingJobs   = window.cuttingJobs;
 
+if (typeof window.inventorySearchTerm !== "string") window.inventorySearchTerm = "";
+let inventorySearchTerm = window.inventorySearchTerm;
+
 /* ================ Jobs editing & render flags ================ */
 if (!(window.editingJobs instanceof Set)) window.editingJobs = new Set();
 if (typeof window.RENDER_TOTAL !== "number") window.RENDER_TOTAL = null;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1986,7 +1986,36 @@ function renderJobs(){
 function renderInventory(){
   const content = document.getElementById("content"); if (!content) return;
   content.innerHTML = viewInventory();
-  document.querySelector("tbody")?.addEventListener("input",(e)=>{
+  const rowsTarget = content.querySelector("[data-inventory-rows]");
+  const searchInput = content.querySelector("#inventorySearch");
+  const clearBtn = content.querySelector("#inventorySearchClear");
+
+  const refreshRows = ()=>{
+    if (!rowsTarget) return;
+    const filtered = filterInventoryItems(inventorySearchTerm);
+    rowsTarget.innerHTML = inventoryRowsHTML(filtered);
+  };
+
+  if (searchInput){
+    searchInput.addEventListener("input", ()=>{
+      inventorySearchTerm = searchInput.value;
+      window.inventorySearchTerm = inventorySearchTerm;
+      refreshRows();
+    });
+  }
+
+  if (clearBtn){
+    clearBtn.addEventListener("click", ()=>{
+      if (!inventorySearchTerm) return;
+      inventorySearchTerm = "";
+      window.inventorySearchTerm = "";
+      if (searchInput) searchInput.value = "";
+      refreshRows();
+      searchInput?.focus();
+    });
+  }
+
+  rowsTarget?.addEventListener("input",(e)=>{
     const input = e.target;
     const id = input.getAttribute("data-id");
     const k  = input.getAttribute("data-inv");

--- a/js/views.js
+++ b/js/views.js
@@ -838,8 +838,24 @@ function viewJobs(){
   </div>`;
 }
 
-function viewInventory(){
-  const rows = inventory.map(i => `
+function filterInventoryItems(term){
+  const query = (term || "").trim().toLowerCase();
+  if (!query) return inventory.slice();
+  return inventory.filter(item => {
+    const fields = [item.name, item.unit, item.pn, item.note, item.link];
+    return fields.some(f => {
+      if (f == null) return false;
+      const text = String(f).toLowerCase();
+      return text.includes(query);
+    });
+  });
+}
+
+function inventoryRowsHTML(list){
+  if (!Array.isArray(list) || !list.length){
+    return `<tr><td colspan="6" class="muted">No inventory items match your search.</td></tr>`;
+  }
+  return list.map(i => `
     <tr>
       <td>${i.name}</td>
       <td><input type="number" min="0" step="1" data-inv="qty" data-id="${i.id}" value="${i.qty}"></td>
@@ -848,13 +864,28 @@ function viewInventory(){
       <td>${i.link ? `<a href="${i.link}" target="_blank" rel="noopener">link</a>` : "—"}</td>
       <td><input type="text" data-inv="note" data-id="${i.id}" value="${i.note||""}"></td>
     </tr>`).join("");
+}
+
+function viewInventory(){
+  const filtered = filterInventoryItems(inventorySearchTerm);
+  const rows = inventoryRowsHTML(filtered);
+  const searchValue = String(inventorySearchTerm || "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
   return `
   <div class="container">
     <div class="block" style="grid-column:1 / -1">
       <h3>Inventory</h3>
+      <div class="mini-form" style="margin-bottom:8px;">
+        <input type="search" id="inventorySearch" placeholder="Search items, part numbers, notes, or links" value="${searchValue}">
+        <button type="button" id="inventorySearchClear">Clear</button>
+      </div>
+      <div class="small muted" style="margin-bottom:8px;">Results update as you type.</div>
       <table>
         <thead><tr><th>Item</th><th>Qty</th><th>Unit</th><th>PN</th><th>Link</th><th>Note</th></tr></thead>
-        <tbody>${rows}</tbody>
+        <tbody data-inventory-rows>${rows}</tbody>
       </table>
     </div>
   </div>`;


### PR DESCRIPTION
## Summary
- persist an inventory search term alongside existing global state
- render a search control and filter matching inventory rows in the view
- hook up search and clear handlers to refresh the filtered inventory table

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d19eed5f188325b13334798991abd5