### PR TITLE
Reduce header height

### DIFF
--- a/style.css
+++ b/style.css
@@ -140,7 +140,7 @@ body.pump-chart-expanded { overflow:hidden; }
 /* Base */
 * { box-sizing: border-box; }
 body { font-family: Arial, sans-serif; margin: 0; background: #f5f7fa; color: #222; }
-header { background: #0a63c2; color: #fff; padding: 14px 16px; }
+header { background: #0a63c2; color: #fff; padding: 11px 16px; }
 .header-bar {
   display: flex;
   align-items: flex-start;
@@ -184,11 +184,11 @@ header { background: #0a63c2; color: #fff; padding: 14px 16px; }
   line-height: 1.2;
 }
 h1 { margin: 0 0 10px; font-size: 22px; }
-.nav {
+.nav { 
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-top: 16px;
+  margin-top: 13px;
 }
 .nav a { color: #e7f0ff; text-decoration: none; padding: 6px 10px; border-radius: 6px; }
 .nav a.active, .nav a:hover { background: #084f9a; }


### PR DESCRIPTION
## Summary
- decrease header padding to shrink the blue top bar height by roughly 20%
- slightly tighten navigation spacing to keep layout compact without overlap

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1a4fdfb0483258e561f5227ad11dd