### PR TITLE
Add calendar add-modal and day actions

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -178,6 +178,15 @@ function renderCalendar(){
     }
   });
 
+  const downSet = new Set();
+  if (Array.isArray(window.downTimes)){
+    window.downTimes.forEach(entry => {
+      if (!entry) return;
+      const iso = typeof entry === "string" ? entry : entry.dateISO;
+      if (iso) downSet.add(String(iso));
+    });
+  }
+
   const today = new Date(); today.setHours(0,0,0,0);
   for (let m=0; m<3; m++){
     const first = new Date(today.getFullYear(), today.getMonth()+m, 1);
@@ -207,12 +216,30 @@ function renderCalendar(){
       const cell = document.createElement("div"); cell.className = "day"; if (date.getTime()===today.getTime()) cell.classList.add("today");
       cell.innerHTML = `<div class="date">${day}</div>`;
       const key = ymd(date);
+      cell.dataset.dateIso = key;
+      if (downSet.has(key)) cell.classList.add("downtime");
       (dueMap[key]||[]).forEach(ev=>{
         const chip = document.createElement("div"); chip.className="event generic cal-task"; chip.dataset.calTask = ev.id; chip.textContent = `${ev.name} (due)`; cell.appendChild(chip);
       });
       (jobsMap[key]||[]).forEach(ev=>{
         const bar = document.createElement("div"); bar.className="job-bar cal-job"; bar.dataset.calJob = ev.id; bar.textContent = ev.name; cell.appendChild(bar);
       });
+      const addBtn = document.createElement("button");
+      addBtn.type = "button";
+      addBtn.className = "day-add-bubble";
+      addBtn.textContent = "+";
+      addBtn.setAttribute("aria-label", `Add item on ${date.toDateString()}`);
+      addBtn.addEventListener("click", (ev)=>{
+        ev.stopPropagation();
+        if (typeof window.openDashboardAddPicker === "function"){
+          window.openDashboardAddPicker({ dateISO: key, step: "task" });
+        }
+      });
+      addBtn.addEventListener("focus", ()=> addBtn.classList.add("is-visible"));
+      addBtn.addEventListener("blur", ()=> addBtn.classList.remove("is-visible"));
+      cell.appendChild(addBtn);
+      cell.addEventListener("mouseenter", ()=> addBtn.classList.add("is-visible"));
+      cell.addEventListener("mouseleave", ()=> addBtn.classList.remove("is-visible"));
       grid.appendChild(cell);
     }
 

--- a/js/core.js
+++ b/js/core.js
@@ -44,7 +44,10 @@ function toast(msg){
   .block{background:#f9fbff;border:1px solid #e6ecf7;border-radius:10px;padding:12px}
   .small{font-size:12px}.muted{color:#666}.danger{color:#b00020}
   .mini-form{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
-  .calendar-toolbar{margin-bottom:8px}
+  .calendar-toolbar{margin-bottom:8px;display:flex;justify-content:flex-end;align-items:center;gap:8px}
+  .calendar-add-btn{width:34px;height:34px;border-radius:50%;border:0;display:flex;align-items:center;justify-content:center;background:#0a63c2;color:#fff;font-size:20px;cursor:pointer;box-shadow:0 4px 8px rgba(10,99,194,.2)}
+  .calendar-add-btn:hover{background:#084f9a}
+  .calendar-add-btn:active{transform:translateY(1px)}
   table{width:100%;border-collapse:collapse} th,td{border:1px solid #e6ecf7;padding:6px;text-align:left;vertical-align:top}
   .grid{width:100%}
   .month{border:1px solid #e6ecf7;border-radius:10px;overflow:hidden;margin-bottom:10px}
@@ -53,8 +56,15 @@ function toast(msg){
   .weekdays>div{padding:4px 6px;background:#f6f9fe;border-bottom:1px solid #e6ecf7;font-size:12px}
   .day{min-height:78px;position:relative;border-right:1px solid #f0f4fb;border-bottom:1px solid #f0f4fb;padding:2px}
   .day.other-month{background:#fafbfd;opacity:.6}
+  .day.downtime{background:#ffe5e5}
+  .day.downtime .date{color:#b71c1c}
   .day.today{outline:2px solid #0a63c2;outline-offset:-2px}
   .date{font-size:12px;color:#555;margin-bottom:2px}
+  .day-add-bubble{position:absolute;bottom:6px;right:6px;width:28px;height:28px;border-radius:50%;border:0;display:flex;align-items:center;justify-content:center;background:#0a63c2;color:#fff;font-size:18px;font-weight:600;cursor:pointer;box-shadow:0 6px 12px rgba(10,99,194,.25);opacity:0;transform:scale(.85);transition:opacity .18s ease,transform .18s ease;z-index:3}
+  .day-add-bubble.is-visible{opacity:1;transform:scale(1)}
+  .day-add-bubble:hover{background:#084f9a}
+  .day-add-bubble:active{transform:scale(.92)}
+  .day-add-bubble:focus-visible{outline:2px solid #fff;outline-offset:-2px;box-shadow:0 0 0 3px rgba(10,99,194,.35)}
   .event.generic,.job-bar{display:block;padding:2px 6px;margin:2px 0;border-radius:8px;cursor:pointer;border:1px solid transparent}
   .event.generic{background:#fff0d6;border-color:#ffe1a5}
   .job-bar{background:#e1efff;border-color:#cddffb}

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -43,7 +43,8 @@ function renderDashboard(){
 
   // Log hours
   document.getElementById("logBtn")?.addEventListener("click", ()=>{
-    const v = Number(document.getElementById("totalInput").value);
+    const input = document.getElementById("totalInput");
+    const v = Number(input?.value);
     if (!isFinite(v) || v < 0){ toast("Enter valid hours."); return; }
     const todayISO = new Date().toISOString().slice(0,10);
     const last = totalHistory[totalHistory.length-1];
@@ -53,8 +54,8 @@ function renderDashboard(){
       totalHistory.push({ dateISO: todayISO, hours: v });
     }
     RENDER_TOTAL = v;
-    window.RENDER_TOTAL = RENDER_TOTAL;
     RENDER_DELTA = deltaSinceLast();
+    window.RENDER_TOTAL = RENDER_TOTAL;
     window.RENDER_DELTA = RENDER_DELTA;
     saveCloudDebounced(); toast("Hours logged");
     renderDashboard();
@@ -71,20 +72,404 @@ function renderDashboard(){
     ? `<ul>${upcoming.map(x=>`<li><span class="cal-task" data-cal-task="${x.t.id}">${x.t.name}</span> — ${x.nd.days}d → ${x.nd.due.toDateString()}</li>`).join("")}</ul>`
     : `<div class="muted small">No upcoming due items.</div>`;
 
-  // Quick add task
-  document.getElementById("quickAddForm")?.addEventListener("submit",(e)=>{
-    e.preventDefault();
-    const name = document.getElementById("qa_name").value.trim();
-    const interval = Number(document.getElementById("qa_interval").value);
-    const cond = document.getElementById("qa_condition").value.trim();
-    if (!name) return;
-    if (isFinite(interval) && interval > 0){
-      tasksInterval.push({ id: genId(name), name, interval, sinceBase:null, anchorTotal:null, manualLink:"", storeLink:"" });
-    }else{
-      tasksAsReq.push({ id: genId(name), name, condition: cond || "As required", manualLink:"", storeLink:"" });
+  if (typeof window._maintOrderCounter === "undefined") window._maintOrderCounter = 0;
+
+  const escapeHtml = (str)=> String(str||"").replace(/[&<>"']/g, c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+
+  const modal            = document.getElementById("dashboardAddModal");
+  const closeBtn         = document.getElementById("dashboardModalClose");
+  const taskForm         = document.getElementById("dashTaskForm");
+  const downForm         = document.getElementById("dashDownForm");
+  const jobForm          = document.getElementById("dashJobForm");
+  const downList         = document.getElementById("dashDownList");
+  const downDateInput    = document.getElementById("dashDownDate");
+  const taskTypeSelect   = document.getElementById("dashTaskType");
+  const taskNameInput    = document.getElementById("dashTaskName");
+  const taskIntervalInput= document.getElementById("dashTaskInterval");
+  const taskLastInput    = document.getElementById("dashTaskLast");
+  const taskConditionInput = document.getElementById("dashTaskCondition");
+  const taskManualInput  = document.getElementById("dashTaskManual");
+  const taskStoreInput   = document.getElementById("dashTaskStore");
+  const taskPNInput      = document.getElementById("dashTaskPN");
+  const taskPriceInput   = document.getElementById("dashTaskPrice");
+  const categorySelect   = document.getElementById("dashTaskCategory");
+  const subtaskList      = document.getElementById("dashSubtaskList");
+  const addSubtaskBtn    = document.getElementById("dashAddSubtask");
+  const jobNameInput     = document.getElementById("dashJobName");
+  const jobEstimateInput = document.getElementById("dashJobEstimate");
+  const jobStartInput    = document.getElementById("dashJobStart");
+  const jobDueInput      = document.getElementById("dashJobDue");
+
+  const taskFreqRow      = taskForm?.querySelector("[data-task-frequency]");
+  const taskLastRow      = taskForm?.querySelector("[data-task-last]");
+  const taskConditionRow = taskForm?.querySelector("[data-task-condition]");
+  const stepSections     = modal ? Array.from(modal.querySelectorAll("[data-step]")) : [];
+  let addContextDateISO  = null;
+
+  function setContextDate(dateISO){
+    addContextDateISO = dateISO || null;
+    if (modal){
+      if (addContextDateISO){
+        modal.setAttribute("data-context-date", addContextDateISO);
+      }else{
+        modal.removeAttribute("data-context-date");
+      }
     }
-    saveCloudDebounced(); toast("Added"); renderDashboard();
+    if (downDateInput){
+      if (addContextDateISO){
+        downDateInput.value = addContextDateISO;
+      }else if (!modal || !modal.classList.contains("is-visible")){
+        downDateInput.value = "";
+      }
+    }
+  }
+
+  function ensureDownTimeArray(){
+    if (!Array.isArray(window.downTimes)) window.downTimes = [];
+    const arr = window.downTimes;
+    for (let i = arr.length - 1; i >= 0; i--){
+      const entry = arr[i];
+      if (!entry){ arr.splice(i,1); continue; }
+      if (typeof entry === "string"){ arr[i] = { dateISO: entry }; continue; }
+      if (typeof entry.dateISO !== "string") arr.splice(i,1);
+    }
+    return arr;
+  }
+
+  function refreshDownTimeList(){
+    if (!downList) return;
+    const arr = ensureDownTimeArray().slice().sort((a,b)=> String(a.dateISO).localeCompare(String(b.dateISO)));
+    if (!arr.length){
+      downList.innerHTML = `<div class="small muted">No down time days yet.</div>`;
+      return;
+    }
+    downList.innerHTML = "";
+    arr.forEach(item => {
+      const row = document.createElement("div");
+      row.className = "down-item";
+      const label = document.createElement("span");
+      const parsed = new Date(item.dateISO + "T00:00:00");
+      label.textContent = isNaN(parsed.getTime()) ? item.dateISO : parsed.toLocaleDateString();
+      row.appendChild(label);
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "down-remove-btn";
+      btn.textContent = "Remove";
+      btn.addEventListener("click", ()=>{ removeDownTime(item.dateISO); });
+      row.appendChild(btn);
+      downList.appendChild(row);
+    });
+  }
+
+  function removeDownTime(dateISO){
+    const arr = ensureDownTimeArray();
+    const idx = arr.findIndex(dt => dt.dateISO === dateISO);
+    if (idx < 0) return;
+    arr.splice(idx,1);
+    saveCloudDebounced();
+    toast("Down time removed");
+    refreshDownTimeList();
+    renderCalendar();
+  }
+
+  function populateCategoryOptions(){
+    if (!categorySelect) return;
+    const folders = Array.isArray(window.settingsFolders) ? window.settingsFolders : [];
+    const byParent = new Map();
+    folders.forEach(f => {
+      const key = String(f.parent ?? "");
+      if (!byParent.has(key)) byParent.set(key, []);
+      byParent.get(key).push(f);
+    });
+    byParent.forEach(list => list.sort((a,b)=> (Number(a.order||0) - Number(b.order||0)) || String(a.name||"").localeCompare(String(b.name||""))));
+    const opts = ['<option value="">(No Category)</option>'];
+    const walk = (parent, prefix)=>{
+      const key = String(parent ?? "");
+      const children = byParent.get(key) || [];
+      for (const child of children){
+        const label = `${prefix}${child.name}`;
+        opts.push(`<option value="${escapeHtml(String(child.id))}">${escapeHtml(label)}</option>`);
+        walk(child.id, `${prefix}${child.name} / `);
+      }
+    };
+    walk(null, "");
+    categorySelect.innerHTML = opts.join("");
+  }
+
+  function syncTaskMode(mode){
+    if (!taskFreqRow || !taskLastRow || !taskConditionRow) return;
+    if (mode === "asreq"){
+      taskFreqRow.hidden = true;
+      taskLastRow.hidden = true;
+      taskConditionRow.hidden = false;
+    }else{
+      taskFreqRow.hidden = false;
+      taskLastRow.hidden = false;
+      taskConditionRow.hidden = true;
+    }
+  }
+
+  function resetTaskForm(){
+    taskForm?.reset();
+    subtaskList?.replaceChildren();
+    syncTaskMode(taskTypeSelect?.value || "interval");
+  }
+
+  function showStep(step){
+    stepSections.forEach(section => {
+      if (!section) return;
+      section.hidden = section.dataset.step !== step;
+    });
+    if (step === "task"){
+      populateCategoryOptions();
+      syncTaskMode(taskTypeSelect?.value || "interval");
+    }
+    if (step === "downtime"){
+      refreshDownTimeList();
+      if (addContextDateISO && downDateInput){
+        downDateInput.value = addContextDateISO;
+      }
+    }
+  }
+
+  function showBackdrop(step){
+    if (!modal) return;
+    ensureDownTimeArray();
+    modal.classList.add("is-visible");
+    modal.removeAttribute("hidden");
+    modal.setAttribute("aria-hidden", "false");
+    document.body?.classList.add("modal-open");
+    showStep(step);
+  }
+
+  function hideBackdrop(){
+    if (!modal) return;
+    modal.classList.remove("is-visible");
+    modal.setAttribute("hidden", "");
+    modal.setAttribute("aria-hidden", "true");
+    document.body?.classList.remove("modal-open");
+  }
+
+  function openModal(step="picker", opts={}){
+    if (opts && Object.prototype.hasOwnProperty.call(opts, "dateISO")){
+      setContextDate(opts.dateISO);
+    }else{
+      setContextDate(null);
+    }
+    const desiredStep = opts?.step || step;
+    showBackdrop(desiredStep);
+    if (desiredStep === "downtime" && addContextDateISO && downDateInput){
+      downDateInput.value = addContextDateISO;
+    }
+  }
+
+  function closeModal(){
+    hideBackdrop();
+    showStep("picker");
+    resetTaskForm();
+    downForm?.reset();
+    jobForm?.reset();
+    setContextDate(null);
+  }
+
+  window.openDashboardAddPicker = (opts={}) => {
+    const obj = typeof opts === "object" && opts !== null ? opts : {};
+    openModal(obj.step || "picker", obj);
+  };
+
+  window.dashboardRemoveDownTime = removeDownTime;
+
+  downDateInput?.addEventListener("input", ()=>{
+    if (!downDateInput) return;
+    const val = downDateInput.value;
+    addContextDateISO = val || null;
+    if (modal){
+      if (addContextDateISO){
+        modal.setAttribute("data-context-date", addContextDateISO);
+      }else{
+        modal.removeAttribute("data-context-date");
+      }
+    }
   });
+
+  function createSubtaskRow(defaultType){
+    if (!subtaskList) return null;
+    const row = document.createElement("div");
+    row.className = "subtask-row";
+    row.dataset.subtaskRow = "1";
+    row.innerHTML = `
+      <div class="subtask-row-top">
+        <strong>Sub-task</strong>
+        <button type="button" class="subtask-remove" data-remove-subtask>Remove</button>
+      </div>
+      <div class="modal-grid subtask-grid">
+        <label>Sub-task name<input type="text" data-subtask-name placeholder="Name" required></label>
+        <label>Type<select data-subtask-type>
+          <option value="interval">Per interval</option>
+          <option value="asreq">As required</option>
+        </select></label>
+        <label data-subtask-frequency>Frequency (hrs)<input type="number" min="1" step="1" data-subtask-interval placeholder="e.g. 20"></label>
+        <label data-subtask-last>Last serviced at (hrs)<input type="number" min="0" step="0.01" data-subtask-last placeholder="optional"></label>
+        <label data-subtask-condition hidden>Condition / trigger<input type="text" data-subtask-condition-input placeholder="e.g. When needed"></label>
+      </div>`;
+    const typeSel = row.querySelector("[data-subtask-type]");
+    const freqRow = row.querySelector("[data-subtask-frequency]");
+    const lastRow = row.querySelector("[data-subtask-last]");
+    const condRow = row.querySelector("[data-subtask-condition]");
+    if (typeSel) typeSel.value = defaultType || "interval";
+    const sync = ()=>{
+      if (!typeSel) return;
+      const mode = typeSel.value === "asreq" ? "asreq" : "interval";
+      if (freqRow) freqRow.hidden = mode !== "interval";
+      if (lastRow) lastRow.hidden = mode !== "interval";
+      if (condRow) condRow.hidden = mode !== "asreq";
+    };
+    typeSel?.addEventListener("change", sync);
+    sync();
+    row.querySelector("[data-remove-subtask]")?.addEventListener("click", ()=> row.remove());
+    return row;
+  }
+
+  closeBtn?.addEventListener("click", closeModal);
+  modal?.addEventListener("click", (e)=>{ if (e.target === modal) closeModal(); });
+
+  modal?.querySelectorAll("[data-choice]")?.forEach(btn => {
+    btn.addEventListener("click", ()=>{
+      const choice = btn.getAttribute("data-choice");
+      showStep(choice === "task" ? "task" : choice === "downtime" ? "downtime" : "job");
+    });
+  });
+
+  modal?.querySelectorAll("[data-step-back]")?.forEach(btn => {
+    btn.addEventListener("click", ()=> showStep("picker"));
+  });
+
+  taskTypeSelect?.addEventListener("change", ()=> syncTaskMode(taskTypeSelect.value));
+  syncTaskMode(taskTypeSelect?.value || "interval");
+  populateCategoryOptions();
+
+  addSubtaskBtn?.addEventListener("click", ()=>{
+    const row = createSubtaskRow(taskTypeSelect?.value || "interval");
+    if (row) subtaskList?.appendChild(row);
+  });
+
+  taskForm?.addEventListener("submit", (e)=>{
+    e.preventDefault();
+    if (!taskForm) return;
+    const name = (taskNameInput?.value || "").trim();
+    if (!name){ alert("Task name is required."); return; }
+    const mode = (taskTypeSelect?.value === "asreq") ? "asreq" : "interval";
+    const manual = (taskManualInput?.value || "").trim();
+    const store  = (taskStoreInput?.value || "").trim();
+    const pn     = (taskPNInput?.value || "").trim();
+    const priceVal = taskPriceInput?.value;
+    const price  = priceVal === "" ? null : Number(priceVal);
+    const catId  = (categorySelect?.value || "").trim() || null;
+    const id     = genId(name);
+    const base = {
+      id,
+      name,
+      manualLink: manual,
+      storeLink: store,
+      pn,
+      price: isFinite(price) ? price : null,
+      cat: catId,
+      parentTask: null,
+      order: ++window._maintOrderCounter
+    };
+    if (mode === "interval"){
+      let interval = Number(taskIntervalInput?.value);
+      if (!isFinite(interval) || interval <= 0) interval = 8;
+      const task = Object.assign({}, base, { mode:"interval", interval, sinceBase:null, anchorTotal:null });
+      const lastVal = taskLastInput?.value;
+      if (lastVal !== undefined && lastVal !== ""){
+        const v = Number(lastVal);
+        if (isFinite(v)){ task.anchorTotal = v; task.sinceBase = 0; }
+      }
+      tasksInterval.unshift(task);
+    }else{
+      const condition = (taskConditionInput?.value || "").trim() || "As required";
+      const task = Object.assign({}, base, { mode:"asreq", condition });
+      tasksAsReq.unshift(task);
+    }
+
+    const parentInterval = Number(taskIntervalInput?.value);
+    const subRows = subtaskList ? Array.from(subtaskList.querySelectorAll("[data-subtask-row]")) : [];
+    subRows.forEach(row => {
+      const subName = (row.querySelector("[data-subtask-name]")?.value || "").trim();
+      if (!subName) return;
+      const subTypeSel = row.querySelector("[data-subtask-type]");
+      const subMode = subTypeSel && subTypeSel.value === "asreq" ? "asreq" : "interval";
+      const subBase = {
+        id: genId(subName),
+        name: subName,
+        manualLink: "",
+        storeLink: "",
+        pn: "",
+        price: null,
+        cat: catId,
+        parentTask: id,
+        order: ++window._maintOrderCounter
+      };
+      if (subMode === "interval"){
+        const intervalField = row.querySelector("[data-subtask-interval]");
+        let subInterval = Number(intervalField?.value);
+        if (!isFinite(subInterval) || subInterval <= 0){
+          subInterval = isFinite(parentInterval) && parentInterval > 0 ? parentInterval : 8;
+        }
+        const subTask = Object.assign({}, subBase, { mode:"interval", interval: subInterval, sinceBase:null, anchorTotal:null });
+        const lastField = row.querySelector("[data-subtask-last]");
+        const lastVal = lastField?.value;
+        if (lastVal){
+          const v = Number(lastVal);
+          if (isFinite(v)){ subTask.anchorTotal = v; subTask.sinceBase = 0; }
+        }
+        tasksInterval.unshift(subTask);
+      }else{
+        const condInput = row.querySelector("[data-subtask-condition-input]");
+        const subTask = Object.assign({}, subBase, { mode:"asreq", condition: (condInput?.value || "").trim() || "As required" });
+        tasksAsReq.unshift(subTask);
+      }
+    });
+
+    saveCloudDebounced();
+    toast("Task added");
+    closeModal();
+    renderDashboard();
+  });
+
+  downForm?.addEventListener("submit", (e)=>{
+    e.preventDefault();
+    const arr = ensureDownTimeArray();
+    const dateISO = downDateInput?.value;
+    if (!dateISO){ toast("Pick a date"); return; }
+    if (arr.some(dt => dt.dateISO === dateISO)){ toast("Day already marked as down time"); return; }
+    arr.push({ dateISO });
+    arr.sort((a,b)=> String(a.dateISO).localeCompare(String(b.dateISO)));
+    saveCloudDebounced();
+    toast("Down time saved");
+    if (downDateInput) downDateInput.value = "";
+    refreshDownTimeList();
+    renderCalendar();
+  });
+
+  jobForm?.addEventListener("submit", (e)=>{
+    e.preventDefault();
+    const name = (jobNameInput?.value || "").trim();
+    const est  = Number(jobEstimateInput?.value);
+    const start = jobStartInput?.value;
+    const due   = jobDueInput?.value;
+    if (!name || !isFinite(est) || est <= 0 || !start || !due){ toast("Fill job fields."); return; }
+    cuttingJobs.push({ id: genId(name), name, estimateHours: est, startISO: start, dueISO: due, material:"", materialCost:0, materialQty:0, notes:"", manualLogs:[] });
+    saveCloudDebounced();
+    toast("Cutting job added");
+    closeModal();
+    renderDashboard();
+  });
+
+  refreshDownTimeList();
+
+  document.getElementById("calendarAddBtn")?.addEventListener("click", ()=> openModal("picker"));
 
   renderCalendar();
   renderPumpWidget();

--- a/js/views.js
+++ b/js/views.js
@@ -30,17 +30,91 @@ function viewDashboard(){
       <h3>Calendar (Current + Next 2 Months)</h3>
 
       <div class="calendar-toolbar">
-        <form id="quickAddForm" class="mini-form">
-          <strong>Quick add task:</strong>
-          <input type="text" id="qa_name" placeholder="Task name" required>
-          <input type="number" id="qa_interval" placeholder="Interval (hrs, blank = As Required)" min="0">
-          <input type="text" id="qa_condition" placeholder="Condition (for As Required)">
-          <button type="submit">Add</button>
-        </form>
+        <button type="button" class="calendar-add-btn" id="calendarAddBtn" title="Add maintenance task, down time, or job">+</button>
       </div>
 
       <div id="months"></div>
       <div class="small">Hover a due item for actions. Click to pin the bubble.</div>
+    </div>
+  </div>
+
+  <div class="modal-backdrop" id="dashboardAddModal" hidden>
+    <div class="modal-card dashboard-modal-card">
+      <button type="button" class="modal-close" id="dashboardModalClose">×</button>
+
+      <section class="dash-modal-step" data-step="picker">
+        <h4>What would you like to add?</h4>
+        <div class="dash-choice-grid">
+          <button type="button" class="dash-choice" data-choice="task">Maintenance Task</button>
+          <button type="button" class="dash-choice" data-choice="downtime">Down Time</button>
+          <button type="button" class="dash-choice" data-choice="job">Cutting Job</button>
+        </div>
+      </section>
+
+      <section class="dash-modal-step" data-step="task" hidden>
+        <h4>Add maintenance task</h4>
+        <form id="dashTaskForm" class="modal-form">
+          <div class="modal-grid">
+            <label>Task name<input id="dashTaskName" required placeholder="Task"></label>
+            <label>Type<select id="dashTaskType">
+              <option value="interval">Per interval</option>
+              <option value="asreq">As required</option>
+            </select></label>
+            <label data-task-frequency>Frequency (hrs)<input type="number" min="1" step="1" id="dashTaskInterval" placeholder="e.g. 40"></label>
+            <label data-task-last>Last serviced at (hrs)<input type="number" min="0" step="0.01" id="dashTaskLast" placeholder="optional"></label>
+            <label data-task-condition hidden>Condition / trigger<input id="dashTaskCondition" placeholder="e.g. When clogged"></label>
+            <label>Manual link<input type="url" id="dashTaskManual" placeholder="https://..."></label>
+            <label>Store link<input type="url" id="dashTaskStore" placeholder="https://..."></label>
+            <label>Part #<input id="dashTaskPN" placeholder="Part number"></label>
+            <label>Price ($)<input type="number" min="0" step="0.01" id="dashTaskPrice" placeholder="optional"></label>
+            <label>Category<select id="dashTaskCategory"></select></label>
+          </div>
+
+          <div class="subtask-section">
+            <div class="subtask-header">
+              <h5>Sub-tasks</h5>
+              <button type="button" id="dashAddSubtask" class="subtask-add-btn">+ Add sub-task</button>
+            </div>
+            <div id="dashSubtaskList" class="subtask-list"></div>
+            <p class="small muted">Sub-tasks inherit the calendar display and live under the main task.</p>
+          </div>
+
+          <div class="modal-actions">
+            <button type="button" class="secondary" data-step-back>Back</button>
+            <button type="submit" class="primary">Create Task</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="dash-modal-step" data-step="downtime" hidden>
+        <h4>Mark machine down time</h4>
+        <form id="dashDownForm" class="modal-form">
+          <div class="modal-grid">
+            <label>Down time date<input type="date" id="dashDownDate" required></label>
+          </div>
+          <div class="modal-actions">
+            <button type="button" class="secondary" data-step-back>Back</button>
+            <button type="submit" class="primary">Save</button>
+          </div>
+        </form>
+        <div id="dashDownList" class="down-list"></div>
+      </section>
+
+      <section class="dash-modal-step" data-step="job" hidden>
+        <h4>Add cutting job</h4>
+        <form id="dashJobForm" class="modal-form">
+          <div class="modal-grid">
+            <label>Job name<input id="dashJobName" required placeholder="Job"></label>
+            <label>Estimate (hrs)<input type="number" min="1" step="0.1" id="dashJobEstimate" required placeholder="e.g. 12"></label>
+            <label>Start date<input type="date" id="dashJobStart" required></label>
+            <label>Due date<input type="date" id="dashJobDue" required></label>
+          </div>
+          <div class="modal-actions">
+            <button type="button" class="secondary" data-step-back>Back</button>
+            <button type="submit" class="primary">Add Job</button>
+          </div>
+        </form>
+      </section>
     </div>
   </div>`;
 }

--- a/style.css
+++ b/style.css
@@ -230,7 +230,25 @@ th { background: #f7f9fc; }
 .day .date { font-weight: bold; font-size: 12px; color: #444; }
 .day.today { background: #fff7d6; }
 .day.other-month { background: #f8f9fb; color: #aaa; }
-.calendar-toolbar { margin-bottom: 10px; }
+.day.downtime { background: #ffe5e5; }
+.day.downtime .date { color: #b71c1c; }
+.calendar-toolbar { margin-bottom: 10px; display:flex; justify-content:flex-end; align-items:center; gap:8px; }
+.calendar-add-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0a63c2;
+  color: #fff;
+  font-size: 22px;
+  cursor: pointer;
+  box-shadow: 0 4px 8px rgba(10, 99, 194, 0.2);
+}
+.calendar-add-btn:hover { background: #084f9a; }
+.calendar-add-btn:active { transform: translateY(1px); }
 
 /* Calendar items — make the ENTIRE chip/bar interactive */
 .event, .job-bar, .cal-task, .cal-job {
@@ -255,6 +273,37 @@ th { background: #f7f9fc; }
 }
 .event.generic:hover, .cal-task:hover {
   filter: brightness(0.95);
+}
+
+.day-add-bubble {
+  position: absolute;
+  bottom: 6px;
+  right: 6px;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0a63c2;
+  color: #fff;
+  font-size: 18px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 8px 14px rgba(10, 99, 194, 0.25);
+  opacity: 0;
+  transform: scale(0.85);
+  transition: opacity .18s ease, transform .18s ease;
+  z-index: 3;
+}
+.day-add-bubble.is-visible { opacity: 1; transform: scale(1); }
+.day-add-bubble:hover { background: #084f9a; }
+.day-add-bubble:active { transform: scale(0.92); }
+.day-add-bubble:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 3px rgba(10, 99, 194, 0.35);
 }
 
 /* Cutting job bar */


### PR DESCRIPTION
## Summary
- replace the dashboard calendar toolbar with a plus button that opens a multi-step add modal
- wire the dashboard renderer to drive the new modal for tasks, downtime entries, and cutting jobs
- surface inline add controls on each calendar day and refresh supporting styles

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1b0c3aa188325ada45aea309aadf5