### PR TITLE
Reduce header height by 30 percent

### DIFF
--- a/style.css
+++ b/style.css
@@ -140,57 +140,58 @@ body.pump-chart-expanded { overflow:hidden; }
 /* Base */
 * { box-sizing: border-box; }
 body { font-family: Arial, sans-serif; margin: 0; background: #f5f7fa; color: #222; }
-header { background: #0a63c2; color: #fff; padding: 5px 16px; }
+header { background: #0a63c2; color: #fff; padding: 0 16px 4px; }
 .header-bar {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
-  column-gap: 18px;
-  row-gap: 12px;
+  column-gap: 12px;
+  row-gap: 4px;
 }
 .header-bar h1 {
   margin: 0;
-  font-size: 22px;
-  flex: 1 1 260px;
+  font-size: 20px;
+  flex: 1 1 240px;
 }
 .header-brand {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 10px;
+  gap: 6px;
   flex: 0 0 auto;
+  transform: translateY(4px);
 }
 .header-logo {
   flex: 0 0 auto;
-  width: clamp(180px, 29vw, 345px);
+  width: clamp(110px, 18vw, 220px);
   max-width: 100%;
   height: auto;
   display: block;
   margin: 0;
-  border: 6px solid #073a83;
-  border-radius: 38px;
+  border: 3px solid #073a83;
+  border-radius: 26px;
 }
 .header-motto {
   flex: 0 0 auto;
-  min-width: 220px;
+  min-width: 200px;
   font-weight: 800;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   color: #e7f0ff;
-  font-size: clamp(16px, 2.4vw, 22px);
+  font-size: clamp(14px, 2vw, 18px);
   text-align: right;
   align-self: flex-end;
   line-height: 1.2;
 }
 h1 { margin: 0 0 10px; font-size: 22px; }
-.nav { 
+.nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 13px;
+  gap: 6px;
+  margin-top: 6px;
 }
-.nav a { color: #e7f0ff; text-decoration: none; padding: 6px 10px; border-radius: 6px; }
+.nav a { color: #e7f0ff; text-decoration: none; padding: 3px 8px; border-radius: 6px; font-size: 13px; }
 .nav a.active, .nav a:hover { background: #084f9a; }
 
 .container { padding: 16px; display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 12px; }


### PR DESCRIPTION
## Summary
- tighten header padding and spacing again to make the blue bar even slimmer
- scale down the logo, motto, and nav link padding to keep the more compact profile cohesive
- nudge the header brand down slightly so the logo and motto sit more centered in the blue bar

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1b28623188325ac3f056e5495915a