### PR TITLE
Add maintenance job tracker placeholder to cost analysis page

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1547,6 +1547,34 @@ function computeCostModel(){
       : formatterCurrency(0, { decimals: 0 })
   };
 
+  const maintenanceTasks = Array.isArray(tasksInterval) ? tasksInterval : [];
+  const maintenanceJobs = maintenanceTasks.map(task => {
+    const name = task?.name || "Untitled maintenance job";
+    const intervalRaw = Number(task?.interval);
+    const priceRaw = Number(task?.price);
+    const manualLink = typeof task?.manualLink === "string" ? task.manualLink.trim() : "";
+    const storeLink  = typeof task?.storeLink === "string" ? task.storeLink.trim() : "";
+    const linkCount = [manualLink, storeLink].filter(Boolean).length;
+    const intervalLabel = (isFinite(intervalRaw) && intervalRaw > 0)
+      ? `${intervalRaw} hr`
+      : "—";
+    const costLabel = (isFinite(priceRaw) && priceRaw > 0)
+      ? formatterCurrency(priceRaw, { decimals: priceRaw < 1000 ? 2 : 0 })
+      : "—";
+    const linkLabel = linkCount
+      ? `${linkCount} link${linkCount === 1 ? "" : "s"} configured`
+      : "Link via Settings (coming soon)";
+    return {
+      name,
+      intervalLabel,
+      costLabel,
+      linkLabel
+    };
+  });
+
+  const maintenanceJobsNote = "Group recurring maintenance work here while the dedicated planner is finalized.";
+  const maintenanceJobsEmpty = "Add interval maintenance tasks from the Settings tab (coming soon) to populate this tracker.";
+
   const timeframeNote = "Maintenance projections use interval tasks only; as-required items remain excluded from forecasts.";
   const historyEmpty = parsedHistory.length
     ? "Log additional machine hours to expand the maintenance cost timeline."
@@ -1564,6 +1592,9 @@ function computeCostModel(){
     jobSummary,
     jobBreakdown,
     jobEmpty,
+    maintenanceJobs,
+    maintenanceJobsNote,
+    maintenanceJobsEmpty,
     chartNote,
     chartColors: COST_CHART_COLORS,
     maintenanceSeries,

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1547,33 +1547,10 @@ function computeCostModel(){
       : formatterCurrency(0, { decimals: 0 })
   };
 
-  const maintenanceTasks = Array.isArray(tasksInterval) ? tasksInterval : [];
-  const maintenanceJobs = maintenanceTasks.map(task => {
-    const name = task?.name || "Untitled maintenance job";
-    const intervalRaw = Number(task?.interval);
-    const priceRaw = Number(task?.price);
-    const manualLink = typeof task?.manualLink === "string" ? task.manualLink.trim() : "";
-    const storeLink  = typeof task?.storeLink === "string" ? task.storeLink.trim() : "";
-    const linkCount = [manualLink, storeLink].filter(Boolean).length;
-    const intervalLabel = (isFinite(intervalRaw) && intervalRaw > 0)
-      ? `${intervalRaw} hr`
-      : "—";
-    const costLabel = (isFinite(priceRaw) && priceRaw > 0)
-      ? formatterCurrency(priceRaw, { decimals: priceRaw < 1000 ? 2 : 0 })
-      : "—";
-    const linkLabel = linkCount
-      ? `${linkCount} link${linkCount === 1 ? "" : "s"} configured`
-      : "Link via Settings (coming soon)";
-    return {
-      name,
-      intervalLabel,
-      costLabel,
-      linkLabel
-    };
-  });
+  const maintenanceJobs = [];
 
-  const maintenanceJobsNote = "Group recurring maintenance work here while the dedicated planner is finalized.";
-  const maintenanceJobsEmpty = "Add interval maintenance tasks from the Settings tab (coming soon) to populate this tracker.";
+  const maintenanceJobsNote = "Maintenance job tracker will consolidate every job once the Jobs integration is complete.";
+  const maintenanceJobsEmpty = "Tracker setup is in progress. This space will list all maintenance jobs when the data wiring is finished.";
 
   const timeframeNote = "Maintenance projections use interval tasks only; as-required items remain excluded from forecasts.";
   const historyEmpty = parsedHistory.length

--- a/js/views.js
+++ b/js/views.js
@@ -578,7 +578,6 @@ function viewCosts(model){
   const historyRows = Array.isArray(data.historyRows) ? data.historyRows : [];
   const jobBreakdown = Array.isArray(data.jobBreakdown) ? data.jobBreakdown : [];
   const jobSummary = data.jobSummary || { countLabel:"0", totalLabel:"$0", averageLabel:"$0", rollingLabel:"$0" };
-  const maintenanceJobs = Array.isArray(data.maintenanceJobs) ? data.maintenanceJobs : [];
   const maintenanceJobsNote = data.maintenanceJobsNote || "";
   const maintenanceJobsEmpty = data.maintenanceJobsEmpty || "";
   const chartColors = data.chartColors || { maintenance:"#0a63c2", jobs:"#2e7d32" };
@@ -651,22 +650,7 @@ function viewCosts(model){
     <div class="block">
       <h3>Maintenance Job Tracker</h3>
       ${maintenanceJobsNote ? `<p class="small muted">${esc(maintenanceJobsNote)}</p>` : ""}
-      <p class="small muted">Settings link <span class="muted">(coming soon)</span>. Use the Settings tab later to edit assignments.</p>
-      ${maintenanceJobs.length ? `
-        <table class="cost-table">
-          <thead><tr><th>Job</th><th>Target interval</th><th>Estimated cost</th><th>Links</th></tr></thead>
-          <tbody>
-            ${maintenanceJobs.map(job => `
-              <tr>
-                <td>${esc(job.name || "")}</td>
-                <td>${esc(job.intervalLabel || "")}</td>
-                <td>${esc(job.costLabel || "")}</td>
-                <td>${esc(job.linkLabel || "")}</td>
-              </tr>
-            `).join("")}
-          </tbody>
-        </table>
-      ` : `<p class="small muted">${esc(maintenanceJobsEmpty || "Add interval maintenance tasks from Settings (coming soon) to populate this tracker.")}</p>`}
+      ${maintenanceJobsEmpty ? `<p class="small muted">${esc(maintenanceJobsEmpty)}</p>` : ""}
     </div>
 
     <div class="block">

--- a/js/views.js
+++ b/js/views.js
@@ -578,6 +578,9 @@ function viewCosts(model){
   const historyRows = Array.isArray(data.historyRows) ? data.historyRows : [];
   const jobBreakdown = Array.isArray(data.jobBreakdown) ? data.jobBreakdown : [];
   const jobSummary = data.jobSummary || { countLabel:"0", totalLabel:"$0", averageLabel:"$0", rollingLabel:"$0" };
+  const maintenanceJobs = Array.isArray(data.maintenanceJobs) ? data.maintenanceJobs : [];
+  const maintenanceJobsNote = data.maintenanceJobsNote || "";
+  const maintenanceJobsEmpty = data.maintenanceJobsEmpty || "";
   const chartColors = data.chartColors || { maintenance:"#0a63c2", jobs:"#2e7d32" };
 
   return `
@@ -643,6 +646,27 @@ function viewCosts(model){
           `).join("")}
         </ul>
       ` : `<p class="small muted">${esc(data.historyEmpty || "No usage history yet. Log machine hours to estimate maintenance spend.")}</p>`}
+    </div>
+
+    <div class="block">
+      <h3>Maintenance Job Tracker</h3>
+      ${maintenanceJobsNote ? `<p class="small muted">${esc(maintenanceJobsNote)}</p>` : ""}
+      <p class="small muted">Settings link <span class="muted">(coming soon)</span>. Use the Settings tab later to edit assignments.</p>
+      ${maintenanceJobs.length ? `
+        <table class="cost-table">
+          <thead><tr><th>Job</th><th>Target interval</th><th>Estimated cost</th><th>Links</th></tr></thead>
+          <tbody>
+            ${maintenanceJobs.map(job => `
+              <tr>
+                <td>${esc(job.name || "")}</td>
+                <td>${esc(job.intervalLabel || "")}</td>
+                <td>${esc(job.costLabel || "")}</td>
+                <td>${esc(job.linkLabel || "")}</td>
+              </tr>
+            `).join("")}
+          </tbody>
+        </table>
+      ` : `<p class="small muted">${esc(maintenanceJobsEmpty || "Add interval maintenance tasks from Settings (coming soon) to populate this tracker.")}</p>`}
     </div>
 
     <div class="block">


### PR DESCRIPTION
## Summary
- surface maintenance interval task data in the cost analysis model for a forthcoming tracker
- render a maintenance job tracker section on the cost analysis page with a Settings reference placeholder

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1b2f724148325a734c4908e3b6c2f