### PR TITLE
Tighten total hours block layout

### DIFF
--- a/js/views.js
+++ b/js/views.js
@@ -3,27 +3,33 @@ function viewDashboard(){
   const cur   = RENDER_TOTAL ?? currentTotal();
   const prev  = previousTotal();
   const delta = RENDER_DELTA ?? deltaSinceLast();
+  const lastEntry = totalHistory.length ? totalHistory[totalHistory.length - 1] : null;
+  const lastUpdated = cur!=null && lastEntry && lastEntry.dateISO
+    ? new Date(lastEntry.dateISO).toLocaleString()
+    : "—";
   return `
   <div class="container">
-    <!-- Total hours -->
-    <div class="block">
-      <h3>Total Hours</h3>
-      <div class="total-hours-controls mini-form">
-        <label class="total-hours-label">Enter total hours now:
-          <input type="number" id="totalInput" value="${cur!=null?cur:""}" />
-        </label>
-        <button id="logBtn">Log Hours</button>
+    <div class="dashboard-top">
+      <!-- Total hours -->
+      <div class="block total-hours-block">
+        <h3>Total Hours</h3>
+        <div class="total-hours-controls mini-form">
+          <label class="total-hours-label"><span>Enter total hours now:</span>
+            <input type="number" id="totalInput" value="${cur!=null?cur:""}" />
+          </label>
+          <button id="logBtn">Log Hours</button>
+        </div>
+        <div class="total-hours-meta" aria-live="polite">
+          <span class="hint">Last updated: ${lastUpdated}</span>
+          <span class="small">Δ since last: <b>${(delta||0).toFixed(0)} hrs</b>${prev!=null? " (prev "+prev+")":""}</span>
+        </div>
       </div>
-      <div class="total-hours-meta">
-        <div class="hint">Last updated: ${cur!=null? new Date(totalHistory[totalHistory.length-1].dateISO).toLocaleString(): "—"}</div>
-        <div class="small">Δ since last: <b>${(delta||0).toFixed(0)} hrs</b>${prev!=null? " (prev "+prev+")":""}</div>
-      </div>
-    </div>
 
-    <!-- Next due -->
-    <div class="block">
-      <h3>Next Due</h3>
-      <div id="nextDueBox">Calculating…</div>
+      <!-- Next due -->
+      <div class="block next-due-block">
+        <h3>Next Due</h3>
+        <div id="nextDueBox">Calculating…</div>
+      </div>
     </div>
 
     <!-- Pump Efficiency widget (rendered by renderPumpWidget) -->

--- a/js/views.js
+++ b/js/views.js
@@ -8,12 +8,16 @@ function viewDashboard(){
     <!-- Total hours -->
     <div class="block">
       <h3>Total Hours</h3>
-      <label>Enter total hours now:
-        <input type="number" id="totalInput" value="${cur!=null?cur:""}" />
-      </label>
-      <button id="logBtn">Log Hours</button>
-      <div class="hint">Last updated: ${cur!=null? new Date(totalHistory[totalHistory.length-1].dateISO).toLocaleString(): "—"}</div>
-      <div class="small">Δ since last: <b>${(delta||0).toFixed(0)} hrs</b>${prev!=null? " (prev "+prev+")":""}</div>
+      <div class="total-hours-controls mini-form">
+        <label class="total-hours-label">Enter total hours now:
+          <input type="number" id="totalInput" value="${cur!=null?cur:""}" />
+        </label>
+        <button id="logBtn">Log Hours</button>
+      </div>
+      <div class="total-hours-meta">
+        <div class="hint">Last updated: ${cur!=null? new Date(totalHistory[totalHistory.length-1].dateISO).toLocaleString(): "—"}</div>
+        <div class="small">Δ since last: <b>${(delta||0).toFixed(0)} hrs</b>${prev!=null? " (prev "+prev+")":""}</div>
+      </div>
     </div>
 
     <!-- Next due -->

--- a/style.css
+++ b/style.css
@@ -203,10 +203,17 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 .block .danger:hover { background: #c43d3d; }
 .small { font-size: 12px; color: #777; }
 .mini-form { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
-.total-hours-controls { align-items: center; margin-bottom: 4px; }
-.total-hours-label { display: flex; align-items: center; gap: 6px; margin: 0; font-weight: 600; }
-.total-hours-label input { width: 140px; }
-.total-hours-meta { display: flex; flex-direction: column; gap: 2px; }
+.dashboard-top { grid-column: 1 / -1; display: flex; gap: 12px; align-items: flex-start; flex-wrap: wrap; }
+.total-hours-block { flex: 1 1 260px; max-width: 360px; }
+.next-due-block { flex: 1 1 220px; max-width: 320px; margin-left: auto; }
+.total-hours-controls { align-items: flex-end; flex-wrap: nowrap; gap: 6px; margin-bottom: 2px; }
+.total-hours-label { display: flex; align-items: flex-end; gap: 6px; margin: 0; font-weight: 600; flex: 1 1 auto; font-size: 13px; line-height: 1.2; }
+.total-hours-label span { white-space: nowrap; }
+.total-hours-label input { width: 120px; padding: 5px 6px; }
+.total-hours-controls button { align-self: flex-end; padding: 5px 10px; }
+.total-hours-meta { display: flex; flex-wrap: wrap; gap: 4px 12px; align-items: baseline; margin: 2px 0 0; }
+.total-hours-meta span { display: inline-flex; align-items: baseline; line-height: 1.2; }
+.total-hours-meta span + span::before { content: "•"; margin-right: 6px; color: #9aa4b2; }
 .total-hours-meta .hint,
 .total-hours-meta .small { margin: 0; }
 .job-files { margin-top: 6px; display: flex; flex-direction: column; gap: 4px; }
@@ -218,6 +225,15 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 .job-file-list button.link { background: none; border: none; color: #c43d3d; cursor: pointer; padding: 0; font-size: 12px; }
 .job-file-list button.link:hover { text-decoration: underline; }
 .job-files-summary { margin-top: 4px; }
+
+@media (max-width: 720px) {
+  .dashboard-top { flex-direction: column; }
+  .total-hours-block,
+  .next-due-block { max-width: none; margin-left: 0; }
+  .total-hours-controls { flex-wrap: wrap; }
+  .total-hours-label { flex: 1 1 160px; }
+  .total-hours-label span { white-space: normal; }
+}
 
 /* Tables */
 table { width: 100%; border-collapse: collapse; }

--- a/style.css
+++ b/style.css
@@ -203,6 +203,12 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 .block .danger:hover { background: #c43d3d; }
 .small { font-size: 12px; color: #777; }
 .mini-form { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.total-hours-controls { align-items: center; margin-bottom: 4px; }
+.total-hours-label { display: flex; align-items: center; gap: 6px; margin: 0; font-weight: 600; }
+.total-hours-label input { width: 140px; }
+.total-hours-meta { display: flex; flex-direction: column; gap: 2px; }
+.total-hours-meta .hint,
+.total-hours-meta .small { margin: 0; }
 .job-files { margin-top: 6px; display: flex; flex-direction: column; gap: 4px; }
 .job-file-link { color: #0a63c2; text-decoration: none; font-size: 12px; }
 .job-file-link:hover { text-decoration: underline; }


### PR DESCRIPTION
## Summary
- compress the total hours dashboard block with a tighter flex layout
- add targeted styles so the input, button, and metadata stack with minimal wasted space

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1b3fd31d8832599ab7cd39f7e4552