### PR TITLE
Enlarge the main header title

### DIFF
--- a/style.css
+++ b/style.css
@@ -151,7 +151,8 @@ header { background: #0a63c2; color: #fff; padding: 0 16px 4px; }
 }
 .header-bar h1 {
   margin: 0;
-  font-size: 20px;
+  font-size: clamp(26px, 4vw, 46px);
+  line-height: 1.15;
   flex: 1 1 240px;
 }
 .header-brand {


### PR DESCRIPTION
## Summary
- enlarge the main header title text by using a responsive clamp-based font size
- add a slightly taller line-height so the larger title stays legible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1b51f6c788325920c04a346e4d267