### PR TITLE
Preserve parentTask values during maintenance graph repair

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -136,7 +136,9 @@ function repairMaintenanceGraph(){
 
         if (!task.mode) task.mode = type;
         else task.mode = type; // enforce consistency with owning list
-        task.parentTask = parentId != null ? parentId : null;
+        if (parentId != null){
+          task.parentTask = parentId;
+        }
         if (!isFinite(task.order)) task.order = 0;
 
         flat.push(task);


### PR DESCRIPTION
## Summary
- prevent the repairMaintenanceGraph flattening step from overwriting existing parentTask pointers except when processing legacy .sub children
- retain the logic that keeps a child task's folder in sync with a valid parent

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1b9230da483258622f73b2ffb9713