### PR TITLE
tidy dashboard view formatting

### DIFF
--- a/js/views.js
+++ b/js/views.js
@@ -25,18 +25,6 @@ function viewDashboard(){
         </div>
       </div>
 
-
-
-
-
-
-
-
-
-
-
-
-
       <!-- Next due -->
       <div class="block next-due-block">
         <h3>Next Due</h3>


### PR DESCRIPTION
## Summary
- remove excessive blank lines after the total hours block in the dashboard view template to keep formatting compact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2cad558a083259d1bf0dbd6d2b7fc