### PR TITLE
Enable drag reordering for maintenance categories

### DIFF
--- a/style.css
+++ b/style.css
@@ -196,6 +196,20 @@ header { background: #0a63c2; color: #fff; padding: 0 16px 4px; }
   align-self: flex-end;
   line-height: 1.2;
 }
+
+.folder-dropzone {
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.folder-dropzone.dragover {
+  background: #e6f0ff !important;
+  border-color: #0a63c2 !important;
+  color: #0a3365 !important;
+}
+
+.folder-dropzone-line {
+  display: block;
+}
 h1 { margin: 0 0 10px; font-size: 22px; }
 .nav {
   display: flex;


### PR DESCRIPTION
## Summary
- add drag-and-drop targets before and after maintenance category folders so they can be reordered within the settings view
- persist folder order updates when dropping, including fallbacks when the shared mover helper is unavailable
- polish folder dropzone styling so users get visual feedback while dragging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2fe916b7883258923b54c33646652