### PR TITLE
Add gradient blue theme and highlight OMAX branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 <body>
   <header>
     <div class="header-bar">
-      <h1>OMAX 1530 Maintenance Tracker</h1>
+      <h1><span class="brand-emblem">OMAX</span> 1530 Maintenance Tracker</h1>
       <div class="header-brand">
         <span class="header-motto">&ldquo;TRY HARDER SUCK LESS&rdquo;</span>
         <img

--- a/style.css
+++ b/style.css
@@ -2,7 +2,16 @@
 .pump-card summary { display:flex; align-items:center; gap:8px; }
 .pump-wide { grid-column: 1 / -1; width:100%; max-width: min(1100px, 100%); justify-self:center; margin:0 auto; }
 .pump-grid { display:grid; grid-template-columns: minmax(260px, 0.9fr) minmax(420px, 1.1fr); gap:16px; margin-top:8px; align-items:stretch; }
-.pump-col { background:#fff; border:1px solid #dde3ee; border-radius:10px; padding:12px; min-width:0; }
+.pump-col {
+  background: var(--brand-card-bg);
+  border: 1px solid var(--brand-card-border);
+  border-radius: 18px;
+  padding: 18px;
+  min-width: 0;
+  box-shadow: var(--brand-card-shadow);
+  backdrop-filter: blur(8px);
+  color: #0b1f3d;
+}
 .pump-stats { margin-top:6px; display:grid; gap:4px; }
 .pump-stats .lbl { color:#666; display:inline-block; width:80px; }
 .pump-chart-col { display:flex; flex-direction:column; gap:10px; min-width:0; }
@@ -21,7 +30,7 @@
   padding:6px 12px;
   border-radius:999px;
   border:0;
-  background:rgba(10,99,194,0.92);
+  background:linear-gradient(135deg, rgba(10, 99, 194, 0.95), rgba(61, 165, 245, 0.95));
   color:#fff;
   font-size:12px;
   font-weight:600;
@@ -29,7 +38,10 @@
   cursor:pointer;
   transition:background 0.2s ease, transform 0.2s ease;
 }
-.pump-expand-btn:hover { background:#084f9a; transform:translateY(-1px); }
+.pump-expand-btn:hover {
+  transform:translateY(-1px);
+  box-shadow:0 10px 20px rgba(6, 28, 76, 0.3);
+}
 .pump-expand-btn:active { transform:translateY(0); }
 .pump-chart-wrap.pump-chart-wrap-expanded {
   position:fixed;
@@ -38,10 +50,10 @@
   transform:translate(-50%,-50%);
   width:min(1000px,92vw);
   height:min(80vh,680px);
-  background:#fff;
-  box-shadow:0 24px 60px rgba(10,26,60,0.35);
-  border-radius:16px;
-  padding:28px 28px 68px;
+  background:var(--brand-card-bg);
+  box-shadow:0 40px 70px rgba(3, 19, 54, 0.45);
+  border-radius:24px;
+  padding:32px 32px 80px;
   z-index:1100;
   flex-direction:column;
   align-items:stretch;
@@ -82,12 +94,22 @@ body.pump-chart-expanded { overflow:hidden; }
 .chip.gray{ background:#f1f3f6; color:#6b7280; border-color:#e4e7ec; }
 
 .cost-summary-grid{ display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:12px; }
-.cost-card{ display:flex; gap:12px; background:#f6f8fd; border:1px solid #dde3ee; border-radius:12px; padding:12px; align-items:flex-start; }
+.cost-card{
+  display:flex;
+  gap:12px;
+  background:linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(210, 230, 255, 0.65));
+  border:1px solid rgba(255, 255, 255, 0.45);
+  border-radius:16px;
+  padding:14px 16px;
+  align-items:flex-start;
+  box-shadow:0 18px 36px rgba(7, 30, 78, 0.28);
+  backdrop-filter: blur(6px);
+}
 .cost-card-icon{ font-size:26px; line-height:1; }
 .cost-card-body{ display:flex; flex-direction:column; gap:4px; }
-.cost-card-title{ font-weight:600; color:#1b3558; }
-.cost-card-value{ font-size:20px; font-weight:600; color:#0a63c2; }
-.cost-card-hint{ color:#566074; font-size:12px; }
+.cost-card-title{ font-weight:600; color:#13294a; }
+.cost-card-value{ font-size:22px; font-weight:700; color:var(--brand-blue-400); text-shadow:0 3px 10px rgba(16, 70, 150, 0.35); }
+.cost-card-hint{ color:#1e3352; font-size:12px; opacity:0.7; }
 
 .cost-chart-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:8px; }
 .cost-chart-toggle{ display:flex; gap:12px; flex-wrap:wrap; font-size:13px; color:#333; }
@@ -99,8 +121,18 @@ body.pump-chart-expanded { overflow:hidden; }
 .cost-table th{ background:#f4f7fb; font-weight:600; color:#3b475f; }
 
 .cost-history{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:8px; }
-.cost-history li{ display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:8px; padding:8px 10px; background:#f8faff; border:1px solid #e1e6f1; border-radius:10px; font-variant-numeric:tabular-nums; }
-.cost-history span:last-child{ text-align:right; font-weight:600; color:#0a63c2; }
+.cost-history li{
+  display:grid;
+  grid-template-columns:repeat(3,minmax(0,1fr));
+  gap:8px;
+  padding:10px 12px;
+  background:rgba(255, 255, 255, 0.75);
+  border:1px solid rgba(255, 255, 255, 0.35);
+  border-radius:12px;
+  font-variant-numeric:tabular-nums;
+  box-shadow:0 12px 24px rgba(6, 24, 64, 0.18);
+}
+.cost-history span:last-child{ text-align:right; font-weight:600; color:var(--brand-blue-400); }
 
 .cost-jobs-summary{ display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:8px; margin-bottom:10px; font-variant-numeric:tabular-nums; }
 .cost-jobs-summary .label{ display:block; font-size:12px; text-transform:uppercase; letter-spacing:.04em; color:#5a6478; margin-bottom:2px; }
@@ -142,12 +174,78 @@ body.pump-chart-expanded { overflow:hidden; }
   --header-logo-width-min: 110px;
   --header-logo-width-ideal: 18vw;
   --header-logo-width-max: 220px;
+  --brand-blue-900: #031336;
+  --brand-blue-800: #04255f;
+  --brand-blue-700: #0a3f9b;
+  --brand-blue-500: #1f75d4;
+  --brand-blue-400: #3da5f5;
+  --brand-cyan-300: #4ad0ff;
+  --brand-card-bg: rgba(255, 255, 255, 0.88);
+  --brand-card-border: rgba(255, 255, 255, 0.42);
+  --brand-card-shadow: 0 24px 45px rgba(8, 28, 72, 0.32);
 }
 
 /* Base */
 * { box-sizing: border-box; }
-body { font-family: Arial, sans-serif; margin: 0; background: #f5f7fa; color: #222; }
-header { background: #0a63c2; color: #fff; padding: 0 16px 4px; }
+body {
+  font-family: "Segoe UI", Arial, sans-serif;
+  margin: 0;
+  color: #f1f5ff;
+  min-height: 100vh;
+  background:
+    radial-gradient(1200px 1200px at -5% -10%, rgba(255, 255, 255, 0.28), transparent 60%),
+    radial-gradient(900px 900px at 110% -5%, rgba(74, 208, 255, 0.35), transparent 70%),
+    linear-gradient(135deg, var(--brand-blue-900) 0%, var(--brand-blue-700) 50%, var(--brand-blue-500) 100%);
+  background-attachment: fixed;
+  position: relative;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  z-index: 0;
+  pointer-events: none;
+  border-radius: 50%;
+  filter: blur(0);
+  opacity: 0.75;
+}
+
+body::before {
+  width: 420px;
+  height: 420px;
+  top: -160px;
+  left: -140px;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0));
+}
+
+body::after {
+  width: 520px;
+  height: 520px;
+  bottom: -240px;
+  right: -160px;
+  background: radial-gradient(circle, rgba(33, 182, 255, 0.4), rgba(33, 182, 255, 0));
+}
+
+header {
+  position: relative;
+  background: linear-gradient(135deg, rgba(7, 47, 120, 0.95), rgba(15, 118, 230, 0.88));
+  color: #fff;
+  padding: 0 16px 16px;
+  box-shadow: 0 18px 34px rgba(3, 19, 54, 0.35);
+  overflow: hidden;
+}
+
+header::after {
+  content: "";
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  top: -140px;
+  right: -80px;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0));
+  transform: rotate(25deg);
+}
 .header-bar {
   display: flex;
   align-items: center;
@@ -161,6 +259,37 @@ header { background: #0a63c2; color: #fff; padding: 0 16px 4px; }
   font-size: clamp(26px, 4vw, 46px);
   line-height: 1.15;
   flex: 1 1 240px;
+  color: #f7faff;
+  position: relative;
+  z-index: 1;
+}
+
+.brand-emblem {
+  display: inline-block;
+  margin-right: 10px;
+  padding: 4px 14px 4px 16px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  position: relative;
+  overflow: hidden;
+  color: transparent;
+  background-image: linear-gradient(135deg, #ff1744 0%, #ff6b6b 45%, #ffffff 75%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  text-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+}
+
+.brand-emblem::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-shadow: inset 0 1px 6px rgba(255, 255, 255, 0.35);
+  pointer-events: none;
 }
 .header-brand {
   display: flex;
@@ -197,6 +326,66 @@ header { background: #0a63c2; color: #fff; padding: 0 16px 4px; }
   line-height: 1.2;
 }
 
+main {
+  position: relative;
+  z-index: 1;
+  padding: 26px 18px 80px;
+  color: #0a1f3f;
+  overflow: visible;
+}
+
+main::before,
+main::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+  z-index: -1;
+  filter: blur(0);
+}
+
+main::before {
+  top: -120px;
+  left: 50%;
+  width: min(920px, 92%);
+  height: 260px;
+  transform: translateX(-50%);
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0));
+  opacity: 0.7;
+}
+
+main::after {
+  bottom: -140px;
+  right: -80px;
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(circle, rgba(74, 208, 255, 0.35), rgba(74, 208, 255, 0));
+  opacity: 0.6;
+}
+
+@media (min-width: 960px) {
+  main {
+    padding: 38px 40px 100px;
+  }
+}
+
+#content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+footer {
+  position: relative;
+  z-index: 1;
+  padding: 20px 16px;
+  text-align: center;
+  color: rgba(241, 245, 255, 0.78);
+  background: linear-gradient(135deg, rgba(4, 28, 74, 0.92), rgba(13, 63, 145, 0.85));
+  box-shadow: 0 -12px 30px rgba(0, 17, 46, 0.4);
+}
+
 .folder-dropzone {
   transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
@@ -211,21 +400,89 @@ header { background: #0a63c2; color: #fff; padding: 0 16px 4px; }
   display: block;
 }
 h1 { margin: 0 0 10px; font-size: 22px; }
+#authBar {
+  background: rgba(255, 255, 255, 0.22);
+  border-top: 1px solid rgba(255, 255, 255, 0.35) !important;
+  box-shadow: 0 -12px 26px rgba(4, 28, 74, 0.24);
+  backdrop-filter: blur(12px);
+  color: #0a1f3f;
+}
+
+#authBar button {
+  background: linear-gradient(135deg, rgba(10, 99, 194, 0.95), rgba(61, 165, 245, 0.95));
+  color: #fff;
+  border: 0;
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 22px rgba(6, 28, 76, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+#authBar button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(6, 28, 76, 0.35);
+}
+
+#authBar button#authClose {
+  background: rgba(10, 99, 194, 0.12);
+  color: #0a1f3f;
+  box-shadow: none;
+}
+
 .nav {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   margin-top: 6px;
 }
-.nav a { color: #e7f0ff; text-decoration: none; padding: 3px 8px; border-radius: 6px; font-size: 16px; }
-.nav a.active, .nav a:hover { background: #084f9a; }
+.nav a {
+  color: rgba(243, 247, 255, 0.86);
+  text-decoration: none;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 16px;
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  background: rgba(10, 99, 194, 0.2);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+.nav a.active,
+.nav a:hover {
+  background: linear-gradient(135deg, rgba(9, 85, 190, 0.9), rgba(33, 182, 255, 0.8));
+  color: #ffffff;
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(6, 28, 76, 0.25);
+}
 
 .container { padding: 16px; display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 12px; }
-.block { background: #fff; border: 1px solid #dde3ee; border-radius: 10px; padding: 12px; }
+.block {
+  background: var(--brand-card-bg);
+  border: 1px solid var(--brand-card-border);
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: var(--brand-card-shadow);
+  backdrop-filter: blur(6px);
+  color: #0a1f3f;
+}
 .block h3 { margin: 0 0 8px; font-size: 16px; }
 .block input, .block select { padding: 6px; width: 200px; }
-.block button { padding: 6px 10px; background: #0a63c2; color: #fff; border: 0; border-radius: 6px; cursor: pointer; }
-.block button:hover { background: #084f9a; }
+.block button {
+  padding: 6px 14px;
+  background: linear-gradient(135deg, rgba(10, 99, 194, 0.95), rgba(61, 165, 245, 0.95));
+  color: #fff;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  box-shadow: 0 10px 20px rgba(9, 65, 150, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.block button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(8, 28, 76, 0.3);
+}
 .block .danger { background: #e14b4b; }
 .block .danger:hover { background: #c43d3d; }
 .small { font-size: 12px; color: #777; }
@@ -358,22 +615,59 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 }
 
 /* Tables */
-table { width: 100%; border-collapse: collapse; }
-th, td { border: 1px solid #e1e5ee; padding: 8px; text-align: left; }
-th { background: #f7f9fc; }
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 16px 32px rgba(6, 24, 64, 0.22);
+}
+th, td { border: 1px solid rgba(9, 38, 88, 0.12); padding: 8px; text-align: left; }
+th { background: linear-gradient(135deg, rgba(9, 68, 165, 0.85), rgba(33, 182, 255, 0.7)); color: #fff; }
 
 .inv-toolbar { display:flex; gap:8px; margin-bottom:8px; }
 
 /* Calendar */
-.month { margin-bottom: 16px; background: #fff; border: 1px solid #ddd; border-radius: 8px; overflow: hidden; }
-.month-header { background: #f0f3f7; padding: 8px 12px; font-weight: bold; border-bottom: 1px solid #ddd; }
+.month {
+  margin-bottom: 16px;
+  background: var(--brand-card-bg);
+  border: 1px solid var(--brand-card-border);
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow: var(--brand-card-shadow);
+  backdrop-filter: blur(6px);
+}
+.month-header {
+  background: linear-gradient(135deg, rgba(9, 68, 165, 0.82), rgba(33, 182, 255, 0.65));
+  padding: 10px 16px;
+  font-weight: bold;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.35);
+  color: #fff;
+  letter-spacing: 0.04em;
+}
 .weekdays, .week { display: grid; grid-template-columns: repeat(7, 1fr); }
-.weekdays div { background: #fafbfc; border-bottom: 1px solid #eee; padding: 6px 8px; font-size: 12px; font-weight: bold; color: #666; text-align: center; }
-.day { border-right: 1px solid #eee; border-bottom: 1px solid #eee; min-height: 110px; padding: 6px; position: relative; }
+.weekdays div {
+  background: rgba(255, 255, 255, 0.35);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+  padding: 6px 8px;
+  font-size: 12px;
+  font-weight: bold;
+  color: #0b1e3d;
+  text-align: center;
+}
+.day {
+  border-right: 1px solid rgba(9, 38, 88, 0.08);
+  border-bottom: 1px solid rgba(9, 38, 88, 0.08);
+  min-height: 110px;
+  padding: 6px;
+  position: relative;
+  background: rgba(255, 255, 255, 0.55);
+}
 .day:last-child { border-right: none; }
 .day .date { font-weight: bold; font-size: 12px; color: #444; }
 .day.today { background: #fff7d6; }
-.day.other-month { background: #f8f9fb; color: #aaa; }
+.day.other-month { background: rgba(255, 255, 255, 0.28); color: rgba(10, 30, 64, 0.55); }
 .day.downtime { background: #ffe5e5; }
 .day.downtime .date { color: #b71c1c; }
 .calendar-toolbar { margin-bottom: 10px; display:flex; justify-content:flex-end; align-items:center; gap:8px; }
@@ -385,13 +679,17 @@ th { background: #f7f9fc; }
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #0a63c2;
+  background: linear-gradient(135deg, rgba(10, 99, 194, 0.95), rgba(61, 165, 245, 0.95));
   color: #fff;
   font-size: 22px;
   cursor: pointer;
-  box-shadow: 0 4px 8px rgba(10, 99, 194, 0.2);
+  box-shadow: 0 10px 24px rgba(6, 28, 76, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
-.calendar-add-btn:hover { background: #084f9a; }
+.calendar-add-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(6, 28, 76, 0.4);
+}
 .calendar-add-btn:active { transform: translateY(1px); }
 
 /* Calendar items — make the ENTIRE chip/bar interactive */


### PR DESCRIPTION
## Summary
- refresh the global layout with a blue gradient backdrop, floating widgets, and glassmorphism cards
- style the header with a red-to-white "OMAX" emblem and gradient navigation accents
- modernize supporting components such as tables, calendar, cost cards, and auth toolbar to match the new scheme

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3090694a48325867834ba39ba405f