### PR TITLE
Revamp next due dashboard widget

### DIFF
--- a/style.css
+++ b/style.css
@@ -232,80 +232,201 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 .mini-form { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
 .dashboard-top { grid-column: 1 / -1; display: flex; gap: 12px; align-items: flex-start; flex-wrap: wrap; }
 .total-hours-block { flex: 1 1 260px; max-width: 360px; }
-.next-due-block { flex: 1 1 220px; max-width: 320px; margin-left: auto; }
+.next-due-block { flex: 1 1 280px; max-width: 420px; margin-left: auto; }
+.next-due-window {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(236, 185, 70, 0.55);
+  background: linear-gradient(140deg, rgba(255, 249, 210, 0.95), rgba(255, 232, 156, 0.92));
+  box-shadow: 0 12px 26px rgba(217, 170, 44, 0.25);
+  overflow: hidden;
+}
+.next-due-window::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.5), transparent 60%);
+  opacity: 0.8;
+}
+.next-due-window > * { position: relative; z-index: 1; }
+.next-due-window-preview {
+  box-shadow: 0 10px 22px rgba(217, 170, 44, 0.18);
+}
 .next-due-list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 10px;
 }
 .next-due-task {
+  appearance: none;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 8px;
+  gap: 12px;
   width: 100%;
-  border: 1px solid #f1d88a;
-  background: #fff7cc;
-  color: #3f2a00;
-  border-radius: 8px;
-  padding: 8px 10px;
+  border: 1px solid rgba(236, 185, 70, 0.55);
+  background: rgba(255, 253, 232, 0.95);
+  color: #4a3200;
+  border-radius: 14px;
+  padding: 10px 14px;
   font-size: 13px;
-  line-height: 1.35;
+  line-height: 1.4;
   cursor: pointer;
   text-align: left;
-  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+  font-variant-numeric: tabular-nums;
 }
 .next-due-task .next-due-name {
   font-weight: 600;
   flex: 1 1 auto;
+  min-width: 0;
+  word-break: break-word;
 }
 .next-due-task .next-due-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
   color: #7a5c00;
-  font-variant-numeric: tabular-nums;
   font-size: 12px;
+  text-align: right;
 }
+.next-due-meta-line { display: block; }
+.next-due-meta-hours { font-weight: 600; }
 .next-due-task:hover,
 .next-due-task:focus {
-  background: #ffe48a;
-  border-color: #e1b941;
-  box-shadow: 0 0 0 2px rgba(225, 185, 65, 0.25);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(217, 170, 44, 0.28);
+  background: rgba(255, 247, 194, 0.98);
+  border-color: rgba(210, 155, 32, 0.7);
   outline: none;
 }
 .next-due-task:focus-visible {
   outline: 2px solid #b47b00;
-  outline-offset: 2px;
+  outline-offset: 3px;
   box-shadow: none;
 }
 .next-due-task::-moz-focus-inner {
   border: 0;
 }
-.next-due-preview-note {
-  margin: 0 0 8px;
-  color: #80630c;
+.next-due-task.is-due-now {
+  border-color: rgba(236, 106, 70, 0.7);
+  background: rgba(255, 228, 216, 0.96);
+  color: #641f00;
+}
+.next-due-task.is-due-now .next-due-meta { color: #a63c14; }
+.next-due-task.is-due-soon {
+  border-color: rgba(236, 185, 70, 0.7);
+  background: rgba(255, 243, 188, 0.96);
+  color: #4d3100;
+}
+.next-due-task.is-due-later {
+  border-color: rgba(214, 185, 96, 0.6);
+  background: rgba(255, 252, 226, 0.94);
+  color: #3e2b00;
+}
+.next-due-task.is-due-later .next-due-meta { color: #7d6600; }
+.next-due-featured {
+  align-items: center;
+  gap: 16px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  box-shadow: 0 10px 22px rgba(217, 170, 44, 0.24);
+  background: rgba(255, 255, 255, 0.85);
+}
+.next-due-featured .next-due-name { font-size: 17px; }
+.next-due-featured .next-due-meta { color: #805300; }
+.next-due-featured-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.next-due-eyebrow {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #a87400;
+}
+.next-due-countdown {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 72px;
+  padding: 8px 10px;
+  border-radius: 14px;
+  border: 1px solid rgba(236, 185, 70, 0.6);
+  background: rgba(255, 223, 128, 0.35);
+  color: #8a5a00;
+  font-weight: 700;
+  text-transform: uppercase;
+  gap: 4px;
+}
+.next-due-count { font-size: 26px; line-height: 1; }
+.next-due-count-label { font-size: 11px; letter-spacing: 0.08em; }
+.next-due-task.is-due-now .next-due-countdown {
+  background: rgba(244, 151, 122, 0.24);
+  border-color: rgba(236, 106, 70, 0.7);
+  color: #8b2c0c;
+}
+.next-due-subtitle {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8a6500;
+}
+.next-due-empty {
+  margin: 0;
   font-size: 12px;
   line-height: 1.45;
+  color: #7a5c00;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px dashed rgba(236, 185, 70, 0.6);
+  border-radius: 12px;
+  padding: 10px 12px;
 }
-.next-due-preview-mode .next-due-list {
-  opacity: 0.92;
+.next-due-preview-note {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #7a5c00;
+  background: rgba(255, 255, 255, 0.65);
+  border-radius: 12px;
+  padding: 10px 12px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+.next-due-preview-mode .next-due-window {
+  opacity: 0.98;
 }
 .next-due-task.next-due-task-preview {
   cursor: default;
+  pointer-events: none;
   border-style: dashed;
-  background: #fff9db;
-  border-color: #f1d88a;
-  color: #5a4300;
-}
-.next-due-task.next-due-task-preview .next-due-meta {
-  color: #8a6800;
+  box-shadow: none;
+  transform: none;
 }
 .next-due-task.next-due-task-preview:hover,
 .next-due-task.next-due-task-preview:focus {
-  background: #fff9db;
-  border-color: #f1d88a;
   box-shadow: none;
+  transform: none;
+  border-color: rgba(236, 185, 70, 0.55);
+}
+.next-due-window-preview .next-due-featured {
+  box-shadow: 0 6px 16px rgba(217, 170, 44, 0.18);
+}
+.next-due-window-preview .next-due-task {
+  background: rgba(255, 253, 230, 0.88);
 }
 .signed-out-container {
   grid-template-columns: minmax(280px, 480px);
@@ -316,17 +437,19 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 }
 .next-due-preview-card {
   margin-top: 16px;
-  border: 1px solid #f2d98b;
-  border-radius: 10px;
-  padding: 12px;
-  background: #fff6d1;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(236, 185, 70, 0.55);
+  border-radius: 16px;
+  padding: 16px;
+  background: linear-gradient(140deg, rgba(255, 249, 210, 0.85), rgba(255, 233, 158, 0.88));
+  box-shadow: 0 10px 22px rgba(217, 170, 44, 0.18);
 }
 .next-due-preview-title {
-  margin: 0 0 8px;
+  margin: 0 0 10px;
   font-size: 14px;
-  font-weight: 600;
-  color: #1e2b45;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #7a5600;
 }
 .total-hours-controls { align-items: flex-end; flex-wrap: nowrap; gap: 6px; margin-bottom: 2px; }
 .total-hours-label { display: flex; align-items: flex-end; gap: 6px; margin: 0; font-weight: 600; flex: 1 1 auto; font-size: 13px; line-height: 1.2; }


### PR DESCRIPTION
## Summary
- redesign the dashboard "Next Due" card to highlight the next task with a countdown and upcoming list
- update the preview renderer so the signed-out view matches the new window layout and status styling
- refresh the CSS to create a yellow task window with state-aware colors and improved preview card visuals

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d30899a834832586675abb5ed6f7b7