### PR TITLE
Refresh Next Due dashboard styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -494,12 +494,13 @@ h1 { margin: 0 0 10px; font-size: 22px; }
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  padding: 16px;
-  border-radius: 18px;
-  border: 1px solid rgba(236, 185, 70, 0.55);
-  background: linear-gradient(140deg, rgba(255, 249, 210, 0.95), rgba(255, 232, 156, 0.92));
-  box-shadow: 0 12px 26px rgba(217, 170, 44, 0.25);
+  gap: 16px;
+  padding: 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(61, 165, 245, 0.5);
+  background: linear-gradient(150deg, rgba(8, 33, 78, 0.92), rgba(28, 95, 182, 0.88));
+  box-shadow: 0 20px 40px rgba(6, 30, 78, 0.35);
+  color: #e8f3ff;
   overflow: hidden;
 }
 .next-due-window::after {
@@ -507,12 +508,14 @@ h1 { margin: 0 0 10px; font-size: 22px; }
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.5), transparent 60%);
-  opacity: 0.8;
+  background:
+    radial-gradient(circle at top right, rgba(74, 208, 255, 0.35), transparent 58%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), transparent 46%);
+  opacity: 1;
 }
 .next-due-window > * { position: relative; z-index: 1; }
 .next-due-window-preview {
-  box-shadow: 0 10px 22px rgba(217, 170, 44, 0.18);
+  box-shadow: 0 16px 34px rgba(5, 28, 76, 0.38);
 }
 .next-due-list {
   list-style: none;
@@ -529,20 +532,21 @@ h1 { margin: 0 0 10px; font-size: 22px; }
   justify-content: space-between;
   gap: 12px;
   width: 100%;
-  border: 1px solid rgba(236, 185, 70, 0.55);
-  background: rgba(255, 253, 232, 0.95);
-  color: #4a3200;
-  border-radius: 14px;
-  padding: 10px 14px;
-  font-size: 13px;
+  border: 1px solid rgba(236, 185, 70, 0.7);
+  background: rgba(255, 253, 232, 0.96);
+  color: #3e2b00;
+  border-radius: 16px;
+  padding: 12px 16px;
+  font-size: 13.5px;
   line-height: 1.4;
   cursor: pointer;
   text-align: left;
   transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
   font-variant-numeric: tabular-nums;
+  box-shadow: 0 10px 20px rgba(36, 22, 0, 0.12);
 }
 .next-due-task .next-due-name {
-  font-weight: 600;
+  font-weight: 700;
   flex: 1 1 auto;
   min-width: 0;
   word-break: break-word;
@@ -551,23 +555,23 @@ h1 { margin: 0 0 10px; font-size: 22px; }
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 2px;
-  color: #7a5c00;
-  font-size: 12px;
+  gap: 3px;
+  color: #4e3900;
+  font-size: 12.5px;
   text-align: right;
 }
-.next-due-meta-line { display: block; }
+.next-due-meta-line { display: block; line-height: 1.3; }
 .next-due-meta-hours { font-weight: 600; }
 .next-due-task:hover,
 .next-due-task:focus {
   transform: translateY(-1px);
-  box-shadow: 0 8px 18px rgba(217, 170, 44, 0.28);
-  background: rgba(255, 247, 194, 0.98);
-  border-color: rgba(210, 155, 32, 0.7);
+  box-shadow: 0 14px 26px rgba(217, 170, 44, 0.3);
+  background: rgba(255, 247, 194, 0.99);
+  border-color: rgba(210, 155, 32, 0.82);
   outline: none;
 }
 .next-due-task:focus-visible {
-  outline: 2px solid #b47b00;
+  outline: 2px solid rgba(61, 165, 245, 0.8);
   outline-offset: 3px;
   box-shadow: none;
 }
@@ -581,9 +585,9 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 }
 .next-due-task.is-due-now .next-due-meta { color: #a63c14; }
 .next-due-task.is-due-soon {
-  border-color: rgba(236, 185, 70, 0.7);
-  background: rgba(255, 243, 188, 0.96);
-  color: #4d3100;
+  border-color: rgba(236, 185, 70, 0.78);
+  background: rgba(255, 243, 188, 0.97);
+  color: #3f2a00;
 }
 .next-due-task.is-due-later {
   border-color: rgba(214, 185, 96, 0.6);
@@ -594,13 +598,14 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 .next-due-featured {
   align-items: center;
   gap: 16px;
-  padding: 14px 16px;
-  border-radius: 16px;
-  box-shadow: 0 10px 22px rgba(217, 170, 44, 0.24);
-  background: rgba(255, 255, 255, 0.85);
+  padding: 16px 18px;
+  border-radius: 18px;
+  box-shadow: 0 18px 32px rgba(6, 30, 78, 0.32);
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(61, 165, 245, 0.35);
 }
-.next-due-featured .next-due-name { font-size: 17px; }
-.next-due-featured .next-due-meta { color: #805300; }
+.next-due-featured .next-due-name { font-size: 17px; color: #10294f; }
+.next-due-featured .next-due-meta { color: #1f3d6b; }
 .next-due-featured-copy {
   display: flex;
   flex-direction: column;
@@ -611,8 +616,8 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 .next-due-eyebrow {
   font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #a87400;
+  letter-spacing: 0.12em;
+  color: rgba(74, 208, 255, 0.85);
 }
 .next-due-countdown {
   display: flex;
@@ -620,14 +625,15 @@ h1 { margin: 0 0 10px; font-size: 22px; }
   align-items: center;
   justify-content: center;
   min-width: 72px;
-  padding: 8px 10px;
+  padding: 10px 12px;
   border-radius: 14px;
-  border: 1px solid rgba(236, 185, 70, 0.6);
-  background: rgba(255, 223, 128, 0.35);
-  color: #8a5a00;
+  border: 1px solid rgba(61, 165, 245, 0.6);
+  background: rgba(255, 255, 255, 0.16);
+  color: #ebf4ff;
   font-weight: 700;
   text-transform: uppercase;
   gap: 4px;
+  text-shadow: 0 1px 2px rgba(3, 19, 54, 0.45);
 }
 .next-due-count { font-size: 26px; line-height: 1; }
 .next-due-count-label { font-size: 11px; letter-spacing: 0.08em; }
@@ -639,29 +645,30 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 .next-due-subtitle {
   font-size: 12px;
   font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #8a6500;
+  color: rgba(210, 230, 255, 0.9);
 }
 .next-due-empty {
   margin: 0;
   font-size: 12px;
   line-height: 1.45;
-  color: #7a5c00;
-  background: rgba(255, 255, 255, 0.6);
-  border: 1px dashed rgba(236, 185, 70, 0.6);
+  color: #e8f3ff;
+  background: rgba(16, 47, 92, 0.6);
+  border: 1px dashed rgba(74, 208, 255, 0.45);
   border-radius: 12px;
   padding: 10px 12px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2);
 }
 .next-due-preview-note {
   margin: 0;
   font-size: 12px;
   line-height: 1.5;
-  color: #7a5c00;
-  background: rgba(255, 255, 255, 0.65);
+  color: #102a4f;
+  background: rgba(255, 255, 255, 0.76);
   border-radius: 12px;
   padding: 10px 12px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85);
 }
 .next-due-preview-mode .next-due-window {
   opacity: 0.98;
@@ -680,10 +687,10 @@ h1 { margin: 0 0 10px; font-size: 22px; }
   border-color: rgba(236, 185, 70, 0.55);
 }
 .next-due-window-preview .next-due-featured {
-  box-shadow: 0 6px 16px rgba(217, 170, 44, 0.18);
+  box-shadow: 0 12px 26px rgba(6, 30, 78, 0.28);
 }
 .next-due-window-preview .next-due-task {
-  background: rgba(255, 253, 230, 0.88);
+  background: rgba(255, 253, 230, 0.9);
 }
 .signed-out-container {
   grid-template-columns: minmax(280px, 480px);
@@ -694,19 +701,20 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 }
 .next-due-preview-card {
   margin-top: 16px;
-  border: 1px solid rgba(236, 185, 70, 0.55);
-  border-radius: 16px;
-  padding: 16px;
-  background: linear-gradient(140deg, rgba(255, 249, 210, 0.85), rgba(255, 233, 158, 0.88));
-  box-shadow: 0 10px 22px rgba(217, 170, 44, 0.18);
+  border: 1px solid rgba(61, 165, 245, 0.45);
+  border-radius: 18px;
+  padding: 18px;
+  background: linear-gradient(150deg, rgba(10, 42, 96, 0.92), rgba(35, 112, 196, 0.85));
+  box-shadow: 0 14px 30px rgba(6, 30, 78, 0.32);
+  color: #e8f3ff;
 }
 .next-due-preview-title {
-  margin: 0 0 10px;
+  margin: 0 0 12px;
   font-size: 14px;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #7a5600;
+  color: rgba(210, 230, 255, 0.9);
 }
 .total-hours-controls { align-items: flex-end; flex-wrap: nowrap; gap: 6px; margin-bottom: 2px; }
 .total-hours-label { display: flex; align-items: flex-end; gap: 6px; margin: 0; font-weight: 600; flex: 1 1 auto; font-size: 13px; line-height: 1.2; }


### PR DESCRIPTION
## Summary
- restyle the dashboard "Next Due" window with a blue glassmorphism treatment that matches the surrounding layout
- keep the task entries yellow while sharpening typography, spacing, and hover/focus contrast for easier scanning
- refresh preview states and countdown badge styling to align with the updated palette

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d30e08455c83259f7117057a061049