### PR TITLE
Add editable dashboard layout with draggable, resizable windows

### DIFF
--- a/js/pump.js
+++ b/js/pump.js
@@ -284,6 +284,9 @@ function renderPumpWidget(){
     renderPumpWidget();
   });
   drawPumpChart(canvas, window.pumpChartRange);
+  if (typeof notifyDashboardLayoutContentChanged === "function"){
+    notifyDashboardLayoutContentChanged();
+  }
 }
 function drawPumpChart(canvas, rangeValue){
   if (!canvas) return;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -124,6 +124,409 @@ function buildNextDuePreview({ includeNote = true, noteText = "Preview of tracke
   `.trim();
 }
 
+const DASHBOARD_LAYOUT_STORAGE_KEY = "dashboard_layout_windows_v1";
+const DASHBOARD_WINDOW_MIN_WIDTH   = 240;
+const DASHBOARD_WINDOW_MIN_HEIGHT  = 160;
+
+function dashboardLayoutStorage(){
+  try {
+    if (typeof localStorage !== "undefined") return localStorage;
+  } catch (err){
+    console.warn("localStorage unavailable", err);
+  }
+  return null;
+}
+
+function loadDashboardLayoutFromStorage(){
+  const storage = dashboardLayoutStorage();
+  if (!storage) return { layout:{}, stored:false };
+  try {
+    const raw = storage.getItem(DASHBOARD_LAYOUT_STORAGE_KEY);
+    if (!raw) return { layout:{}, stored:false };
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") return { layout: parsed, stored: true };
+  } catch (err){
+    console.warn("Unable to load dashboard layout", err);
+  }
+  return { layout:{}, stored:false };
+}
+
+function getDashboardLayoutState(){
+  if (!window.dashboardLayoutState){
+    const loaded = loadDashboardLayoutFromStorage();
+    window.dashboardLayoutState = {
+      layoutById: loaded.layout,
+      layoutStored: !!loaded.stored,
+      editing: false,
+      zCounter: 50,
+      root: null,
+      windows: [],
+      editButton: null,
+      hintEl: null,
+      boundResize: false
+    };
+  }
+  return window.dashboardLayoutState;
+}
+
+function hasSavedDashboardLayout(state){
+  return !!(state && state.layoutStored);
+}
+
+function persistDashboardLayout(state){
+  if (!state) return;
+  const storage = dashboardLayoutStorage();
+  if (!storage) return;
+  try {
+    if (state.layoutById && Object.keys(state.layoutById).length){
+      storage.setItem(DASHBOARD_LAYOUT_STORAGE_KEY, JSON.stringify(state.layoutById));
+      state.layoutStored = true;
+    }else{
+      storage.removeItem(DASHBOARD_LAYOUT_STORAGE_KEY);
+      state.layoutStored = false;
+    }
+  } catch (err){
+    console.warn("Unable to persist dashboard layout", err);
+  }
+}
+
+function captureDashboardWindowRect(win, rootRect){
+  if (!win || !rootRect) return null;
+  const rect = win.getBoundingClientRect();
+  const width = Math.max(DASHBOARD_WINDOW_MIN_WIDTH, Math.round(rect.width) || DASHBOARD_WINDOW_MIN_WIDTH);
+  const height = Math.max(DASHBOARD_WINDOW_MIN_HEIGHT, Math.round(rect.height) || DASHBOARD_WINDOW_MIN_HEIGHT);
+  return {
+    x: Math.round(rect.left - rootRect.left),
+    y: Math.round(rect.top - rootRect.top),
+    width,
+    height
+  };
+}
+
+function dashboardLayoutMaxBottom(layout){
+  let maxBottom = 0;
+  if (layout){
+    Object.values(layout).forEach(box => {
+      if (!box) return;
+      const bottom = Number(box.y || 0) + Number(box.height || 0);
+      if (isFinite(bottom)) maxBottom = Math.max(maxBottom, bottom);
+    });
+  }
+  return maxBottom;
+}
+
+function syncDashboardLayoutEntries(state){
+  if (!state.root) return;
+  if (!state.layoutById || typeof state.layoutById !== "object") state.layoutById = {};
+  const layout = state.layoutById;
+  const rootRect = state.root.getBoundingClientRect();
+  const useExisting = state.root.classList.contains("has-custom-layout") && Object.keys(layout).length;
+  const seen = new Set();
+  state.windows.forEach(win => {
+    if (!win || !win.dataset) return;
+    const id = String(win.dataset.dashboardWindow || "");
+    if (!id) return;
+    seen.add(id);
+    if (!layout[id]){
+      if (useExisting){
+        const fallbackWidth = Math.max(DASHBOARD_WINDOW_MIN_WIDTH, Math.round(win.offsetWidth) || DASHBOARD_WINDOW_MIN_WIDTH);
+        const fallbackHeight = Math.max(DASHBOARD_WINDOW_MIN_HEIGHT, Math.round(win.offsetHeight) || DASHBOARD_WINDOW_MIN_HEIGHT);
+        const offsetY = dashboardLayoutMaxBottom(layout) + 24;
+        layout[id] = { x: 0, y: offsetY, width: fallbackWidth, height: fallbackHeight };
+      }else{
+        layout[id] = captureDashboardWindowRect(win, rootRect);
+      }
+    }
+  });
+  Object.keys(layout).forEach(id => { if (!seen.has(id)) delete layout[id]; });
+}
+
+function setDashboardWindowStyle(win, box){
+  if (!win || !box) return;
+  win.style.left = `${box.x}px`;
+  win.style.top = `${box.y}px`;
+  win.style.width = `${box.width}px`;
+  win.style.height = `${box.height}px`;
+}
+
+function updateDashboardRootSize(state){
+  if (!state.root) return;
+  if (!state.root.classList.contains("has-custom-layout")){
+    state.root.style.minHeight = "";
+    state.root.style.paddingBottom = "";
+    return;
+  }
+  const maxBottom = dashboardLayoutMaxBottom(state.layoutById);
+  const extra = state.editing ? 160 : 60;
+  state.root.style.minHeight = `${Math.max(0, Math.ceil(maxBottom + extra))}px`;
+  state.root.style.paddingBottom = state.editing ? "120px" : "48px";
+}
+
+function applyDashboardLayout(state){
+  if (!state.root) return;
+  if (!state.root.classList.contains("has-custom-layout")){
+    state.windows.forEach(win => {
+      if (!win) return;
+      win.style.left = "";
+      win.style.top = "";
+      win.style.width = "";
+      win.style.height = "";
+    });
+    updateDashboardRootSize(state);
+    return;
+  }
+  state.windows.forEach(win => {
+    if (!win || !win.dataset) return;
+    const id = String(win.dataset.dashboardWindow || "");
+    const box = state.layoutById[id];
+    if (box){ setDashboardWindowStyle(win, box); }
+  });
+  updateDashboardRootSize(state);
+}
+
+function updateDashboardEditUi(state){
+  if (state.editButton){
+    const label = state.editing ? "Done" : "Edit layout";
+    state.editButton.textContent = label;
+    state.editButton.setAttribute("aria-pressed", state.editing ? "true" : "false");
+  }
+  if (state.hintEl){
+    state.hintEl.hidden = !state.editing;
+  }
+}
+
+function bringDashboardWindowToFront(state, win){
+  if (!state) return;
+  state.zCounter = (state.zCounter || 50) + 1;
+  if (win) win.style.zIndex = String(state.zCounter);
+}
+
+function removeDashboardWindowElevation(win){
+  if (win) win.style.zIndex = "";
+}
+
+function addDashboardWindowHandles(state){
+  state.windows.forEach(win => {
+    if (!win) return;
+    const id = String(win.dataset.dashboardWindow || "");
+    if (!id) return;
+    if (!win.querySelector(":scope > .dashboard-drag-handle")){
+      const handle = document.createElement("div");
+      handle.className = "dashboard-drag-handle";
+      handle.title = "Drag to move";
+      handle.innerHTML = "<span>Drag</span>";
+      handle.setAttribute("aria-hidden", "true");
+      handle.addEventListener("pointerdown", (event)=> startDashboardWindowDrag(state, win, event));
+      win.appendChild(handle);
+    }
+    const resizeTypes = ["n","s","e","w","ne","nw","se","sw"];
+    resizeTypes.forEach(type => {
+      if (win.querySelector(`:scope > .dashboard-resize-${type}`)) return;
+      const handle = document.createElement("div");
+      handle.className = `dashboard-resize-handle dashboard-resize-${type}`;
+      handle.dataset.resize = type;
+      handle.title = "Drag to resize";
+      handle.setAttribute("aria-hidden", "true");
+      handle.addEventListener("pointerdown", (event)=> startDashboardWindowResize(state, win, type, event));
+      win.appendChild(handle);
+    });
+  });
+}
+
+function removeDashboardWindowHandles(state){
+  state.windows.forEach(win => {
+    if (!win) return;
+    win.querySelectorAll(":scope > .dashboard-drag-handle, :scope > .dashboard-resize-handle").forEach(el => el.remove());
+    removeDashboardWindowElevation(win);
+  });
+}
+
+function clampDashboardX(state, desiredX, width){
+  if (!state.root) return desiredX;
+  const rootWidth = state.root.clientWidth || state.root.getBoundingClientRect().width || width;
+  if (!isFinite(rootWidth) || rootWidth <= 0) return Math.max(0, desiredX);
+  const maxX = Math.max(0, rootWidth - width);
+  return Math.min(Math.max(0, desiredX), maxX);
+}
+
+function startDashboardWindowDrag(state, win, event){
+  if (!state || !win || !state.root) return;
+  const id = String(win.dataset.dashboardWindow || "");
+  if (!id) return;
+  const box = state.layoutById[id];
+  if (!box) return;
+  if (event.button !== 0 && event.pointerType !== "touch") return;
+  event.preventDefault();
+  bringDashboardWindowToFront(state, win);
+  const startX = event.clientX;
+  const startY = event.clientY;
+  const baseX = box.x;
+  const baseY = box.y;
+  const pointerId = event.pointerId;
+  const move = (ev)=>{
+    const dx = ev.clientX - startX;
+    const dy = ev.clientY - startY;
+    const nextX = clampDashboardX(state, baseX + dx, box.width);
+    const nextY = Math.max(0, baseY + dy);
+    box.x = Math.round(nextX);
+    box.y = Math.round(nextY);
+    setDashboardWindowStyle(win, box);
+    updateDashboardRootSize(state);
+  };
+  const stop = ()=>{
+    window.removeEventListener("pointermove", move);
+    window.removeEventListener("pointerup", stop);
+    window.removeEventListener("pointercancel", stop);
+    win.releasePointerCapture?.(pointerId);
+    persistDashboardLayout(state);
+  };
+  window.addEventListener("pointermove", move);
+  window.addEventListener("pointerup", stop);
+  window.addEventListener("pointercancel", stop);
+  win.setPointerCapture?.(pointerId);
+}
+
+function startDashboardWindowResize(state, win, direction, event){
+  if (!state || !win || !state.root) return;
+  const id = String(win.dataset.dashboardWindow || "");
+  if (!id) return;
+  const box = state.layoutById[id];
+  if (!box) return;
+  if (event.button !== 0 && event.pointerType !== "touch") return;
+  event.preventDefault();
+  bringDashboardWindowToFront(state, win);
+  const startX = event.clientX;
+  const startY = event.clientY;
+  const startBox = { x: box.x, y: box.y, width: box.width, height: box.height };
+  const pointerId = event.pointerId;
+  const resize = (ev)=>{
+    const dx = ev.clientX - startX;
+    const dy = ev.clientY - startY;
+    let nextX = startBox.x;
+    let nextY = startBox.y;
+    let nextWidth = startBox.width;
+    let nextHeight = startBox.height;
+    if (direction.includes("e")){
+      nextWidth = Math.max(DASHBOARD_WINDOW_MIN_WIDTH, startBox.width + dx);
+      const maxWidth = (state.root.clientWidth || state.root.getBoundingClientRect().width || nextWidth) - startBox.x;
+      if (isFinite(maxWidth) && maxWidth > 0) nextWidth = Math.min(nextWidth, maxWidth);
+    }
+    if (direction.includes("s")){
+      nextHeight = Math.max(DASHBOARD_WINDOW_MIN_HEIGHT, startBox.height + dy);
+    }
+    if (direction.includes("w")){
+      const desiredX = startBox.x + dx;
+      const maxX = startBox.x + startBox.width - DASHBOARD_WINDOW_MIN_WIDTH;
+      nextX = Math.max(0, Math.min(desiredX, maxX));
+      nextWidth = Math.max(DASHBOARD_WINDOW_MIN_WIDTH, startBox.width + (startBox.x - nextX));
+    }
+    if (direction.includes("n")){
+      const desiredY = startBox.y + dy;
+      const maxY = startBox.y + startBox.height - DASHBOARD_WINDOW_MIN_HEIGHT;
+      nextY = Math.max(0, Math.min(desiredY, maxY));
+      nextHeight = Math.max(DASHBOARD_WINDOW_MIN_HEIGHT, startBox.height + (startBox.y - nextY));
+    }
+    nextX = clampDashboardX(state, nextX, nextWidth);
+    if (nextHeight < DASHBOARD_WINDOW_MIN_HEIGHT) nextHeight = DASHBOARD_WINDOW_MIN_HEIGHT;
+    box.x = Math.round(nextX);
+    box.y = Math.round(nextY);
+    box.width = Math.round(nextWidth);
+    box.height = Math.round(nextHeight);
+    setDashboardWindowStyle(win, box);
+    updateDashboardRootSize(state);
+  };
+  const stop = ()=>{
+    window.removeEventListener("pointermove", resize);
+    window.removeEventListener("pointerup", stop);
+    window.removeEventListener("pointercancel", stop);
+    win.releasePointerCapture?.(pointerId);
+    persistDashboardLayout(state);
+  };
+  window.addEventListener("pointermove", resize);
+  window.addEventListener("pointerup", stop);
+  window.addEventListener("pointercancel", stop);
+  win.setPointerCapture?.(pointerId);
+}
+
+function ensureDashboardLayoutBoundResize(state){
+  if (state.boundResize) return;
+  state.boundResize = true;
+  window.addEventListener("resize", ()=>{
+    const curState = getDashboardLayoutState();
+    if (!curState.root || !curState.root.classList.contains("has-custom-layout")) return;
+    const rootWidth = curState.root.clientWidth || curState.root.getBoundingClientRect().width;
+    let changed = false;
+    Object.entries(curState.layoutById || {}).forEach(([id, box]) => {
+      if (!box) return;
+      const maxX = Math.max(0, (rootWidth || box.width) - box.width);
+      if (box.x > maxX){ box.x = Math.max(0, Math.round(maxX)); changed = true; }
+    });
+    if (changed){
+      applyDashboardLayout(curState);
+      persistDashboardLayout(curState);
+    }
+  });
+}
+
+function setDashboardEditing(state, editing){
+  state.editing = !!editing;
+  if (!state.root) return;
+  if (editing){
+    if (!state.root.classList.contains("has-custom-layout")){
+      state.root.classList.add("has-custom-layout");
+      syncDashboardLayoutEntries(state);
+    }
+    addDashboardWindowHandles(state);
+    state.root.classList.add("is-editing");
+  }else{
+    state.root.classList.remove("is-editing");
+    removeDashboardWindowHandles(state);
+  }
+  applyDashboardLayout(state);
+  updateDashboardEditUi(state);
+  if (!editing) persistDashboardLayout(state);
+}
+
+function toggleDashboardEditing(){
+  const state = getDashboardLayoutState();
+  setDashboardEditing(state, !state.editing);
+}
+
+function setupDashboardLayout(){
+  const state = getDashboardLayoutState();
+  state.root = document.getElementById("dashboardLayout") || null;
+  state.editButton = document.getElementById("dashboardEditToggle") || null;
+  state.hintEl = document.getElementById("dashboardEditHint") || null;
+  state.windows = state.root ? Array.from(state.root.querySelectorAll("[data-dashboard-window]")) : [];
+  if (!state.root){
+    updateDashboardEditUi(state);
+    return;
+  }
+  ensureDashboardLayoutBoundResize(state);
+  if (hasSavedDashboardLayout(state)){
+    state.root.classList.add("has-custom-layout");
+  }
+  syncDashboardLayoutEntries(state);
+  applyDashboardLayout(state);
+  updateDashboardEditUi(state);
+  if (state.editing){
+    addDashboardWindowHandles(state);
+    state.root.classList.add("is-editing");
+  }
+  if (state.editButton && !state.editButton.dataset.bound){
+    state.editButton.dataset.bound = "1";
+    state.editButton.addEventListener("click", ()=> toggleDashboardEditing());
+  }
+}
+
+function notifyDashboardLayoutContentChanged(){
+  const state = getDashboardLayoutState();
+  if (!state.root || !state.root.classList.contains("has-custom-layout")) return;
+  requestAnimationFrame(()=>{
+    applyDashboardLayout(state);
+  });
+}
+
 function renderDashboard(){
   const content = $("#content"); if (!content) return;
   content.innerHTML = viewDashboard();
@@ -698,8 +1101,10 @@ function renderDashboard(){
 
   document.getElementById("calendarAddBtn")?.addEventListener("click", ()=> openModal("picker"));
 
+  setupDashboardLayout();
   renderCalendar();
   renderPumpWidget();
+  notifyDashboardLayoutContentChanged();
 }
 
 function openJobsEditor(jobId){

--- a/js/views.js
+++ b/js/views.js
@@ -9,34 +9,41 @@ function viewDashboard(){
     : "—";
   return `
   <div class="container">
-    <div class="dashboard-top">
-      <!-- Total hours -->
-      <div class="block total-hours-block">
-        <h3>Total Hours</h3>
-        <div class="total-hours-controls mini-form">
-          <label class="total-hours-label"><span>Enter total hours now:</span>
-            <input type="number" id="totalInput" value="${cur!=null?cur:""}" />
-          </label>
-          <button id="logBtn">Log Hours</button>
-        </div>
-        <div class="total-hours-meta" aria-live="polite">
-          <span class="hint">Last updated: ${lastUpdated}</span>
-          <span class="small">Δ since last: <b>${(delta||0).toFixed(0)} hrs</b>${prev!=null? " (prev "+prev+")":""}</span>
+    <div class="dashboard-toolbar">
+      <button type="button" class="dashboard-edit-btn" id="dashboardEditToggle" aria-pressed="false">Edit layout</button>
+      <span class="dashboard-edit-hint" id="dashboardEditHint" hidden>Drag windows to rearrange and resize. Calendar stays fixed.</span>
+    </div>
+
+    <div class="dashboard-layout" id="dashboardLayout">
+      <div class="dashboard-window" data-dashboard-window="totalHours">
+        <div class="block total-hours-block">
+          <h3>Total Hours</h3>
+          <div class="total-hours-controls mini-form">
+            <label class="total-hours-label"><span>Enter total hours now:</span>
+              <input type="number" id="totalInput" value="${cur!=null?cur:""}" />
+            </label>
+            <button id="logBtn">Log Hours</button>
+          </div>
+          <div class="total-hours-meta" aria-live="polite">
+            <span class="hint">Last updated: ${lastUpdated}</span>
+            <span class="small">Δ since last: <b>${(delta||0).toFixed(0)} hrs</b>${prev!=null? " (prev "+prev+")":""}</span>
+          </div>
         </div>
       </div>
 
-      <!-- Next due -->
-      <div class="block next-due-block">
-        <h3>Next Due</h3>
-        <div id="nextDueBox">Calculating…</div>
+      <div class="dashboard-window" data-dashboard-window="nextDue">
+        <div class="block next-due-block">
+          <h3>Next Due</h3>
+          <div id="nextDueBox">Calculating…</div>
+        </div>
+      </div>
+
+      <div class="dashboard-window" data-dashboard-window="pump">
+        <section id="pump-widget" class="block pump-wide"></section>
       </div>
     </div>
 
-    <!-- Pump Efficiency widget (rendered by renderPumpWidget) -->
-    <section id="pump-widget" class="block pump-wide"></section>
-
-    <!-- Calendar -->
-    <div class="block" style="grid-column: 1 / -1">
+    <div class="block calendar-block">
       <h3>Calendar (Current + Next 2 Months)</h3>
 
       <div class="calendar-toolbar">

--- a/style.css
+++ b/style.css
@@ -515,6 +515,109 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 }
 
 .container { padding: 16px; display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 12px; }
+.dashboard-toolbar { grid-column: 1 / -1; display: flex; flex-wrap: wrap; align-items: center; gap: 10px; justify-content: space-between; }
+.dashboard-edit-btn {
+  padding: 8px 18px;
+  border-radius: 999px;
+  border: 0;
+  background: linear-gradient(135deg, rgba(10, 99, 194, 0.95), rgba(61, 165, 245, 0.95));
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(8, 28, 76, 0.28);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.dashboard-edit-btn:hover { transform: translateY(-1px); box-shadow: 0 16px 28px rgba(8, 28, 76, 0.32); }
+.dashboard-edit-btn:active { transform: translateY(0); }
+.dashboard-edit-btn[aria-pressed="true"] { background: linear-gradient(135deg, rgba(7, 72, 143, 0.95), rgba(24, 118, 217, 0.95)); }
+.dashboard-edit-hint { flex: 1 1 auto; font-size: 13px; color: #244068; }
+.dashboard-layout {
+  grid-column: 1 / -1;
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 12px;
+  transition: min-height 0.2s ease;
+}
+.dashboard-layout.has-custom-layout {
+  display: block;
+}
+.dashboard-layout.has-custom-layout .dashboard-window {
+  position: absolute;
+}
+.dashboard-layout:not(.has-custom-layout) .dashboard-window[data-dashboard-window="pump"] {
+  grid-column: 1 / -1;
+}
+.dashboard-layout.is-editing .dashboard-window {
+  cursor: default;
+}
+.dashboard-window {
+  position: relative;
+  transition: box-shadow 0.18s ease, transform 0.18s ease;
+}
+.dashboard-window > .block {
+  height: 100%;
+  overflow: auto;
+}
+.dashboard-layout.has-custom-layout .dashboard-window > .block {
+  max-height: 100%;
+}
+.dashboard-layout.is-editing .dashboard-window {
+  box-shadow: 0 18px 34px rgba(8, 28, 76, 0.28);
+}
+.dashboard-drag-handle {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(10, 63, 155, 0.14);
+  color: #0a3f9b;
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  display: none;
+  align-items: center;
+  gap: 6px;
+  cursor: grab;
+  z-index: 20;
+  pointer-events: auto;
+  backdrop-filter: blur(4px);
+}
+.dashboard-drag-handle::before {
+  content: "";
+  width: 18px;
+  height: 4px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.6;
+}
+.dashboard-drag-handle:active { cursor: grabbing; }
+.dashboard-layout.is-editing .dashboard-drag-handle { display: inline-flex; }
+.dashboard-resize-handle {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: rgba(10, 63, 155, 0.85);
+  border: 2px solid #fff;
+  display: none;
+  z-index: 20;
+  pointer-events: auto;
+}
+.dashboard-layout.is-editing .dashboard-resize-handle { display: block; }
+.dashboard-resize-n { top: -8px; left: 50%; transform: translate(-50%, -50%); cursor: ns-resize; }
+.dashboard-resize-s { bottom: -8px; left: 50%; transform: translate(-50%, 50%); cursor: ns-resize; }
+.dashboard-resize-e { right: -8px; top: 50%; transform: translate(50%, -50%); cursor: ew-resize; }
+.dashboard-resize-w { left: -8px; top: 50%; transform: translate(-50%, -50%); cursor: ew-resize; }
+.dashboard-resize-ne { top: -8px; right: -8px; cursor: nesw-resize; }
+.dashboard-resize-nw { top: -8px; left: -8px; cursor: nwse-resize; }
+.dashboard-resize-se { bottom: -8px; right: -8px; cursor: nwse-resize; }
+.dashboard-resize-sw { bottom: -8px; left: -8px; cursor: nesw-resize; }
+.calendar-block { grid-column: 1 / -1; }
 .block {
   background: var(--brand-card-bg);
   border: 1px solid var(--brand-card-border);


### PR DESCRIPTION
## Summary
- add a dashboard layout toolbar with an edit toggle and convert dashboard sections into individually managed windows
- implement client-side layout persistence that enables dragging and edge-based resizing while leaving the calendar fixed in place
- update styling and pump widget refresh hooks so resized panels fill their containers without breaking existing visuals

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3140ef84c8325b9b3ecae31785d37