### PR TITLE
Improve auth modal contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,23 +55,23 @@
   </footer>
 
   <!-- Auth toolbar + modal (NEW) -->
-  <div id="authBar" style="display:flex; gap:8px; align-items:center; padding:8px 12px; border-top:1px solid #eee; margin-top:18px;">
+  <div id="authBar" class="auth-bar">
     <span id="authStatus">Not signed in</span>
-    <button id="btnSignIn">Sign In</button>
-    <button id="btnSignOut" style="display:none;">Sign Out</button>
+    <button id="btnSignIn" class="auth-button auth-button-primary">Sign In</button>
+    <button id="btnSignOut" class="auth-button auth-button-secondary" style="display:none;">Sign Out</button>
   </div>
 
-  <div id="authModal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,.4); align-items:center; justify-content:center; z-index:9999;">
-    <div style="background:#fff; padding:16px; border-radius:10px; width:min(420px, 90%); box-shadow:0 10px 30px rgba(0,0,0,.2);">
-      <h3 style="margin:0 0 8px;">Sign in to workspace</h3>
-      <p style="margin:0 0 10px;">Use the same email on all devices to see the same shared data.</p>
-      <form id="authForm" style="display:grid; gap:8px;">
+  <div id="authModal" class="auth-modal-backdrop" style="display:none;">
+    <div class="auth-modal-dialog">
+      <h3>Sign in to workspace</h3>
+      <p>Use the same email on all devices to see the same shared data.</p>
+      <form id="authForm" class="auth-form">
         <input id="authEmail" type="email" placeholder="you@example.com" required />
         <input id="authPass" type="password" placeholder="Password" required />
-        <button type="submit">Sign In</button>
-        <button type="button" id="authClose">Cancel</button>
+        <button type="submit" class="auth-button auth-button-primary">Sign In</button>
+        <button type="button" id="authClose" class="auth-button auth-button-secondary">Cancel</button>
       </form>
-      <small style="color:#666; display:block; margin-top:8px;">First time with an email? The account will be created automatically.</small>
+      <small class="auth-modal-hint">First time with an email? The account will be created automatically.</small>
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -458,35 +458,145 @@ footer {
   display: block;
 }
 h1 { margin: 0 0 10px; font-size: 22px; }
-#authBar {
-  background: rgba(255, 255, 255, 0.22);
-  border-top: 1px solid rgba(255, 255, 255, 0.35) !important;
-  box-shadow: 0 -12px 26px rgba(4, 28, 74, 0.24);
-  backdrop-filter: blur(12px);
+.auth-bar {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 10px 16px;
+  margin-top: 18px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.26), rgba(255, 255, 255, 0.1));
+  border-top: 1px solid rgba(255, 255, 255, 0.38);
+  box-shadow: 0 -14px 28px rgba(4, 28, 74, 0.28);
+  backdrop-filter: blur(14px);
   color: #0a1f3f;
+  position: sticky;
+  bottom: 0;
+  z-index: 900;
 }
 
-#authBar button {
-  background: linear-gradient(135deg, rgba(10, 99, 194, 0.95), rgba(61, 165, 245, 0.95));
-  color: #fff;
+.auth-bar #authStatus {
+  font-weight: 600;
+  color: #05245a;
+}
+
+.auth-button {
   border: 0;
   border-radius: 999px;
-  padding: 6px 14px;
+  padding: 7px 16px;
   font-weight: 600;
   cursor: pointer;
-  box-shadow: 0 10px 22px rgba(6, 28, 76, 0.3);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  font-size: 14px;
+  letter-spacing: 0.01em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
 }
 
-#authBar button:hover {
+.auth-button-primary {
+  background: linear-gradient(135deg, #0a3f9b, #3da5f5);
+  color: #ffffff;
+  box-shadow: 0 10px 24px rgba(6, 28, 76, 0.35);
+}
+
+.auth-button-primary:hover,
+.auth-button-primary:focus-visible {
   transform: translateY(-1px);
-  box-shadow: 0 14px 28px rgba(6, 28, 76, 0.35);
+  box-shadow: 0 16px 30px rgba(6, 28, 76, 0.4);
 }
 
-#authBar button#authClose {
-  background: rgba(10, 99, 194, 0.12);
-  color: #0a1f3f;
-  box-shadow: none;
+.auth-button-secondary {
+  background: rgba(10, 63, 155, 0.12);
+  color: #043170;
+  border: 1px solid rgba(10, 63, 155, 0.35);
+  box-shadow: 0 4px 12px rgba(6, 28, 76, 0.18);
+}
+
+.auth-button-secondary:hover,
+.auth-button-secondary:focus-visible {
+  background: rgba(10, 63, 155, 0.18);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(6, 28, 76, 0.2);
+}
+
+.auth-button:focus-visible {
+  outline: 3px solid rgba(61, 165, 245, 0.6);
+  outline-offset: 2px;
+}
+
+.auth-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: radial-gradient(circle at top, rgba(12, 38, 84, 0.85), rgba(3, 15, 42, 0.9));
+  backdrop-filter: blur(2px);
+  z-index: 9999;
+}
+
+.auth-modal-dialog {
+  width: min(420px, 92vw);
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(223, 235, 255, 0.98));
+  border-radius: 18px;
+  padding: 26px 26px 22px;
+  box-shadow: 0 32px 55px rgba(3, 19, 54, 0.55);
+  border: 1px solid rgba(10, 63, 155, 0.25);
+  color: #082149;
+  position: relative;
+}
+
+.auth-modal-dialog::before {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  pointer-events: none;
+}
+
+.auth-modal-dialog h3 {
+  margin: 0 0 10px;
+  font-size: 22px;
+  color: #04245b;
+}
+
+.auth-modal-dialog p {
+  margin: 0 0 14px;
+  color: #0a2f62;
+  line-height: 1.45;
+}
+
+.auth-form {
+  display: grid;
+  gap: 10px;
+}
+
+.auth-form input {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(9, 55, 128, 0.28);
+  font-size: 15px;
+  color: #041b44;
+  background: rgba(255, 255, 255, 0.94);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-form input:focus-visible {
+  outline: none;
+  border-color: #0a63c2;
+  box-shadow: 0 0 0 3px rgba(61, 165, 245, 0.35);
+}
+
+.auth-modal-hint {
+  display: block;
+  margin-top: 14px;
+  color: #1b335e;
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .nav {


### PR DESCRIPTION
## Summary
- restyle the auth toolbar buttons with high-contrast primary and secondary variants
- redesign the sign-in modal with stronger backdrop, dialog, and input styling to improve legibility

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d45194326883258e82fec62c059c36