### PR TITLE
Add Garnet cleaning scheduling to dashboard calendar

### DIFF
--- a/js/views.js
+++ b/js/views.js
@@ -57,6 +57,7 @@ function viewDashboard(){
         <div class="dash-choice-grid">
           <button type="button" class="dash-choice" data-choice="task">Maintenance Task</button>
           <button type="button" class="dash-choice" data-choice="downtime">Down Time</button>
+          <button type="button" class="dash-choice" data-choice="garnet">Garnet Cleaning</button>
           <button type="button" class="dash-choice" data-choice="job">Cutting Job</button>
         </div>
       </section>
@@ -108,6 +109,26 @@ function viewDashboard(){
           </div>
         </form>
         <div id="dashDownList" class="down-list"></div>
+      </section>
+
+      <section class="dash-modal-step" data-step="garnet" hidden>
+        <h4>Schedule Garnet cleaning</h4>
+        <form id="dashGarnetForm" class="modal-form">
+          <div class="modal-grid">
+            <label>Date<input type="date" id="dashGarnetDate" required></label>
+            <label>Start time<input type="time" id="dashGarnetStart" required value="08:00"></label>
+            <label>End time<input type="time" id="dashGarnetEnd" required value="12:00"></label>
+            <label>Notes<input id="dashGarnetNote" placeholder="Optional note"></label>
+          </div>
+          <div class="modal-actions garnet-actions">
+            <button type="button" class="secondary" data-step-back>Back</button>
+            <div class="garnet-action-buttons">
+              <button type="button" class="secondary" id="dashGarnetCancel" hidden>Cancel edit</button>
+              <button type="submit" class="primary" id="dashGarnetSubmit">Add Cleaning</button>
+            </div>
+          </div>
+        </form>
+        <div id="dashGarnetList" class="garnet-list"></div>
       </section>
 
       <section class="dash-modal-step" data-step="job" hidden>

--- a/style.css
+++ b/style.css
@@ -1224,6 +1224,97 @@ body.modal-open {
 
 .down-remove-btn:hover { background: #c43d3d; }
 
+.garnet-actions {
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.garnet-action-buttons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.garnet-list {
+  margin-top: 16px;
+  display: grid;
+  gap: 10px;
+}
+
+.garnet-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid #f0d6b8;
+  border-radius: 10px;
+  background: #fff4e6;
+}
+
+.garnet-item.is-complete {
+  opacity: 0.7;
+}
+
+.garnet-item-title {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-weight: 600;
+  color: #a14d00;
+}
+
+.garnet-item-note {
+  font-size: 0.85rem;
+  color: #714224;
+}
+
+.garnet-item-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.garnet-item-actions button {
+  border: 0;
+  border-radius: 6px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.garnet-complete-btn {
+  background: #0a63c2;
+  color: #fff;
+}
+
+.garnet-complete-btn:hover { background: #084f9a; }
+
+.garnet-edit-btn {
+  background: #f0f4ff;
+  color: #0a63c2;
+}
+
+.garnet-edit-btn:hover { background: #e2ebff; }
+
+.garnet-remove-btn {
+  background: #e14b4b;
+  color: #fff;
+}
+
+.garnet-remove-btn:hover { background: #c43d3d; }
+
+.event.garnet {
+  background: #ffe4c4;
+  border-color: #ffce96;
+  color: #a14d00;
+  font-weight: 600;
+}
+
+.event.garnet.is-complete {
+  opacity: 0.65;
+  text-decoration: line-through;
+}
+
 /* highlight a row briefly when Edit is clicked */
 tr.row-editing {
   outline: 2px solid rgba(0, 120, 255, 0.4);


### PR DESCRIPTION
## Summary
- add a dedicated Garnet Cleaning flow to the dashboard modal, including date/time inputs, editing, completion toggles, and removal controls
- persist scheduled cleanings in shared state and render them as orange calendar items with bubble actions
- add styling for Garnet Cleaning chips and list items to distinguish them from other events

## Testing
- no automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d44f314ce08325a0bab9df6eda6059