### PR TITLE
Add completed cutting jobs tracking and past jobs view

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -298,6 +298,7 @@ if (!Array.isArray(window.tasksInterval)) window.tasksInterval = [];
 if (!Array.isArray(window.tasksAsReq))   window.tasksAsReq   = [];
 if (!Array.isArray(window.inventory))    window.inventory    = [];
 if (!Array.isArray(window.cuttingJobs))  window.cuttingJobs  = [];   // [{id,name,estimateHours,material,materialCost,materialQty,notes,startISO,dueISO,manualLogs:[{dateISO,completedHours}],files:[{name,dataUrl,type,size,addedAt}]}]
+if (!Array.isArray(window.completedCuttingJobs)) window.completedCuttingJobs = [];
 if (!Array.isArray(window.pendingNewJobFiles)) window.pendingNewJobFiles = [];
 if (!Array.isArray(window.orderRequests)) window.orderRequests = [];
 if (!Array.isArray(window.garnetCleanings)) window.garnetCleanings = [];
@@ -312,6 +313,7 @@ let tasksInterval = window.tasksInterval;
 let tasksAsReq    = window.tasksAsReq;
 let inventory     = window.inventory;
 let cuttingJobs   = window.cuttingJobs;
+let completedCuttingJobs = window.completedCuttingJobs;
 let orderRequests = window.orderRequests;
 let orderRequestTab = window.orderRequestTab;
 let garnetCleanings = window.garnetCleanings;
@@ -341,6 +343,7 @@ function snapshotState(){
     tasksAsReq,
     inventory,
     cuttingJobs,
+    completedCuttingJobs,
     orderRequests,
     orderRequestTab,
     garnetCleanings,
@@ -515,6 +518,7 @@ function adoptState(doc){
     : defaultAsReqTasks.slice();
   inventory = Array.isArray(data.inventory) ? data.inventory : seedInventoryFromTasks();
   cuttingJobs = Array.isArray(data.cuttingJobs) ? data.cuttingJobs : [];
+  completedCuttingJobs = Array.isArray(data.completedCuttingJobs) ? data.completedCuttingJobs : [];
   orderRequests = normalizeOrderRequests(Array.isArray(data.orderRequests) ? data.orderRequests : []);
   if (!orderRequests.some(req => req && req.status === "draft")){
     orderRequests.push(createOrderRequest());
@@ -526,6 +530,7 @@ function adoptState(doc){
   window.tasksAsReq = tasksAsReq;
   window.inventory = inventory;
   window.cuttingJobs = cuttingJobs;
+  window.completedCuttingJobs = completedCuttingJobs;
   window.orderRequests = orderRequests;
   window.garnetCleanings = garnetCleanings;
   if (!Array.isArray(window.pendingNewJobFiles)) window.pendingNewJobFiles = [];
@@ -581,6 +586,7 @@ async function loadFromCloud(){
           tasksAsReq: Array.isArray(data.tasksAsReq) && data.tasksAsReq.length ? data.tasksAsReq : defaultAsReqTasks.slice(),
           inventory: Array.isArray(data.inventory) && data.inventory.length ? data.inventory : seedInventoryFromTasks(),
           cuttingJobs: Array.isArray(data.cuttingJobs) ? data.cuttingJobs : [],
+          completedCuttingJobs: Array.isArray(data.completedCuttingJobs) ? data.completedCuttingJobs : [],
           garnetCleanings: Array.isArray(data.garnetCleanings) ? data.garnetCleanings : [],
           orderRequests: Array.isArray(data.orderRequests) ? normalizeOrderRequests(data.orderRequests) : [createOrderRequest()],
           orderRequestTab: typeof data.orderRequestTab === "string" ? data.orderRequestTab : "active",
@@ -597,7 +603,7 @@ async function loadFromCloud(){
       const pe = (typeof window.pumpEff === "object" && window.pumpEff)
         ? window.pumpEff
         : (window.pumpEff = { baselineRPM:null, baselineDateISO:null, entries:[] });
-      const seeded = { schema:APP_SCHEMA, totalHistory:[], tasksInterval:defaultIntervalTasks.slice(), tasksAsReq:defaultAsReqTasks.slice(), inventory:seedInventoryFromTasks(), cuttingJobs:[], orderRequests:[createOrderRequest()], orderRequestTab:"active", pumpEff: pe };
+      const seeded = { schema:APP_SCHEMA, totalHistory:[], tasksInterval:defaultIntervalTasks.slice(), tasksAsReq:defaultAsReqTasks.slice(), inventory:seedInventoryFromTasks(), cuttingJobs:[], completedCuttingJobs:[], orderRequests:[createOrderRequest()], orderRequestTab:"active", pumpEff: pe };
       seeded.garnetCleanings = [];
       adoptState(seeded);
       resetHistoryToCurrent();
@@ -608,7 +614,7 @@ async function loadFromCloud(){
     const pe = (typeof window.pumpEff === "object" && window.pumpEff)
       ? window.pumpEff
       : (window.pumpEff = { baselineRPM:null, baselineDateISO:null, entries:[] });
-    adoptState({ schema:APP_SCHEMA, totalHistory:[], tasksInterval:defaultIntervalTasks.slice(), tasksAsReq:defaultAsReqTasks.slice(), inventory:seedInventoryFromTasks(), cuttingJobs:[], orderRequests:[createOrderRequest()], orderRequestTab:"active", pumpEff: pe, garnetCleanings: [] });
+    adoptState({ schema:APP_SCHEMA, totalHistory:[], tasksInterval:defaultIntervalTasks.slice(), tasksAsReq:defaultAsReqTasks.slice(), inventory:seedInventoryFromTasks(), cuttingJobs:[], completedCuttingJobs:[], orderRequests:[createOrderRequest()], orderRequestTab:"active", pumpEff: pe, garnetCleanings: [] });
     resetHistoryToCurrent();
   }
 }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -2431,6 +2431,63 @@ function computeCostModel(){
   const jobsInfo = [];
   const jobSeriesRaw = [];
   let totalGainLoss = 0;
+  let completedCount = 0;
+
+  const completedJobsList = Array.isArray(completedCuttingJobs) ? completedCuttingJobs : [];
+  if (completedJobsList.length){
+    for (const job of completedJobsList){
+      if (!job) continue;
+      const eff = job.efficiency || (typeof computeJobEfficiency === "function" ? computeJobEfficiency(job) : null);
+      const gainLoss = eff && Number.isFinite(eff.gainLoss) ? Number(eff.gainLoss) : 0;
+      const deltaHours = eff && Number.isFinite(eff.deltaHours) ? Number(eff.deltaHours) : 0;
+      let date = null;
+      if (job.completedAtISO){
+        const completedDate = parseDateLocal(job.completedAtISO) || new Date(job.completedAtISO);
+        if (completedDate instanceof Date && !Number.isNaN(completedDate.getTime())){
+          date = completedDate;
+        }
+      }
+      if (!date && job.dueISO){
+        const due = parseDateLocal(job.dueISO);
+        if (due) date = due;
+      }
+      if (!date && job.startISO){
+        const start = parseDateLocal(job.startISO);
+        if (start) date = start;
+      }
+      if (!date){
+        const fallback = parsedHistory.length ? parsedHistory[parsedHistory.length-1].date : new Date();
+        date = new Date(fallback);
+      }
+      const milestone = job.completedAtISO
+        ? parseDateLocal(job.completedAtISO) || new Date(job.completedAtISO)
+        : parseDateLocal(job.dueISO || job.startISO || "");
+      const milestoneLabel = (milestone instanceof Date && !Number.isNaN(milestone))
+        ? milestone.toLocaleDateString()
+        : "—";
+      let statusDetail = "Finished on estimate";
+      if (Math.abs(deltaHours) > 0.1){
+        const prefix = deltaHours > 0 ? "Finished ahead" : "Finished behind";
+        statusDetail = `${prefix} (${deltaHours>0?"+":"-"}${Math.abs(deltaHours).toFixed(1)} hr)`;
+      }
+
+      jobsInfo.push({
+        name: job.name || "Untitled job",
+        date,
+        milestoneLabel,
+        gainLoss,
+        status: "Completed",
+        statusDetail
+      });
+
+      if (date instanceof Date && !Number.isNaN(date.getTime())){
+        jobSeriesRaw.push({ date, rawValue: gainLoss, label: job.name || "Job" });
+      }
+
+      totalGainLoss += gainLoss;
+      completedCount += 1;
+    }
+  }
 
   if (Array.isArray(cuttingJobs)){
     for (const job of cuttingJobs){
@@ -2468,12 +2525,6 @@ function computeCostModel(){
         status,
         statusDetail
       });
-
-      if (!Number.isNaN(date.getTime())){
-        jobSeriesRaw.push({ date, rawValue: gainLoss, label: job.name || "Job" });
-      }
-
-      totalGainLoss += gainLoss;
     }
   }
 
@@ -2487,7 +2538,7 @@ function computeCostModel(){
     });
   }
 
-  const jobCount = jobsInfo.length;
+  const jobCount = completedCount;
   const averageGainLoss = jobCount ? (totalGainLoss / jobCount) : 0;
 
   const formatterCurrency = (value, { showPlus=false, decimals=null } = {})=>{
@@ -2558,7 +2609,7 @@ function computeCostModel(){
       title: "Cutting jobs efficiency",
       value: formatterCurrency(totalGainLoss, { decimals: 0, showPlus: true }),
       hint: jobCount
-        ? `Average gain/loss ${formatterCurrency(averageGainLoss, { decimals: 0, showPlus: true })} across ${jobCount} job${jobCount===1?"":"s"}.`
+        ? `Average gain/loss ${formatterCurrency(averageGainLoss, { decimals: 0, showPlus: true })} across ${jobCount} completed job${jobCount===1?"":"s"}.`
         : "No cutting jobs logged yet."
     },
     {
@@ -2570,7 +2621,7 @@ function computeCostModel(){
   ];
 
   const jobSummary = {
-    countLabel: String(jobCount),
+    countLabel: jobCount ? `${jobCount} completed` : "0",
     totalLabel: formatterCurrency(totalGainLoss, { decimals: 0, showPlus: true }),
     averageLabel: formatterCurrency(averageGainLoss, { decimals: 0, showPlus: true }),
     rollingLabel: jobSeries.length
@@ -2913,6 +2964,16 @@ function renderJobs(){
     }
   });
 
+  content.querySelector("tbody")?.addEventListener("input", (e)=>{
+    if (e.target.matches("textarea[data-job-note]")){
+      const id = e.target.getAttribute("data-job-note");
+      const j = cuttingJobs.find(x=>x.id===id);
+      if (!j) return;
+      j.notes = e.target.value;
+      saveCloudDebounced();
+    }
+  });
+
   // 6) Edit/Remove/Save/Cancel + Log panel + Apply spent/remaining
   content.querySelector("tbody")?.addEventListener("click",(e)=>{
     const upload = e.target.closest("[data-upload-job]");
@@ -2941,6 +3002,7 @@ function renderJobs(){
     const sv = e.target.closest("[data-save-job]");
     const ca = e.target.closest("[data-cancel-job]");
     const lg = e.target.closest("[data-log-job]");
+    const complete = e.target.closest("[data-complete-job]");
     const apSpent  = e.target.closest("[data-log-apply-spent]");
     const apRemain = e.target.closest("[data-log-apply-remain]");
 
@@ -2951,7 +3013,59 @@ function renderJobs(){
     if (rm){
       const id = rm.getAttribute("data-remove-job");
       cuttingJobs = cuttingJobs.filter(x=>x.id!==id);
-      saveCloudDebounced(); toast("Removed"); renderJobs(); 
+      saveCloudDebounced(); toast("Removed"); renderJobs();
+      return;
+    }
+
+    if (complete){
+      const id = complete.getAttribute("data-complete-job");
+      const idx = cuttingJobs.findIndex(x=>x.id===id);
+      if (idx < 0) return;
+      const job = cuttingJobs[idx];
+      const eff = typeof computeJobEfficiency === "function" ? computeJobEfficiency(job) : null;
+      const now = new Date();
+      const completionISO = now.toISOString();
+      const efficiencySummary = eff ? {
+        rate: eff.rate ?? JOB_RATE_PER_HOUR,
+        expectedHours: eff.expectedHours ?? null,
+        actualHours: eff.actualHours ?? null,
+        expectedRemaining: eff.expectedRemaining ?? null,
+        actualRemaining: eff.actualRemaining ?? null,
+        deltaHours: eff.deltaHours ?? null,
+        gainLoss: eff.gainLoss ?? null
+      } : {
+        rate: JOB_RATE_PER_HOUR,
+        expectedHours: null,
+        actualHours: null,
+        expectedRemaining: null,
+        actualRemaining: null,
+        deltaHours: null,
+        gainLoss: null
+      };
+
+      const completed = {
+        id: job.id,
+        name: job.name,
+        estimateHours: job.estimateHours,
+        startISO: job.startISO,
+        dueISO: job.dueISO,
+        completedAtISO: completionISO,
+        notes: job.notes || "",
+        material: job.material || "",
+        materialCost: Number(job.materialCost)||0,
+        materialQty: Number(job.materialQty)||0,
+        manualLogs: Array.isArray(job.manualLogs) ? job.manualLogs.slice() : [],
+        files: Array.isArray(job.files) ? job.files.map(f=>({ ...f })) : [],
+        actualHours: eff && Number.isFinite(eff.actualHours) ? eff.actualHours : null,
+        efficiency: efficiencySummary
+      };
+
+      completedCuttingJobs.push(completed);
+      cuttingJobs.splice(idx, 1);
+      editingJobs.delete(id);
+      saveCloudDebounced();
+      toast("Job marked complete");
+      renderJobs();
       return;
     }
 

--- a/style.css
+++ b/style.css
@@ -919,6 +919,64 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 .job-file-list button.link { background: none; border: none; color: #c43d3d; cursor: pointer; padding: 0; font-size: 12px; }
 .job-file-list button.link:hover { text-decoration: underline; }
 .job-files-summary { margin-top: 4px; }
+.job-note-inline { margin-top: 8px; }
+.job-note-inline textarea {
+  width: 100%;
+  min-height: 52px;
+  resize: vertical;
+  font-size: 13px;
+  line-height: 1.4;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid rgba(9, 38, 88, 0.18);
+  box-shadow: inset 0 1px 2px rgba(6, 24, 64, 0.08);
+}
+.job-note-inline textarea:focus {
+  outline: 2px solid rgba(33, 150, 243, 0.45);
+  border-color: rgba(33, 150, 243, 0.6);
+}
+
+.past-jobs-block { grid-column: 1 / -1; }
+.past-jobs-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 18px;
+  margin-bottom: 10px;
+}
+.past-jobs-summary div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: rgba(10, 51, 116, 0.08);
+  color: #0c2448;
+}
+.past-jobs-summary .label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(12, 36, 72, 0.68);
+}
+.past-jobs-summary span:last-child {
+  font-size: 14px;
+  font-weight: 600;
+}
+.past-jobs-table {
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 12px 28px rgba(6, 24, 64, 0.16);
+}
+.past-jobs-table td:last-child {
+  min-width: 160px;
+  color: #1f3252;
+  font-size: 13px;
+  line-height: 1.4;
+}
+.past-jobs-table td:last-child .muted { color: rgba(31, 50, 82, 0.55); }
+.past-jobs-table td {
+  vertical-align: top;
+}
 
 @media (max-width: 720px) {
   .dashboard-top { flex-direction: column; }


### PR DESCRIPTION
## Summary
- add persisted storage for completed cutting jobs alongside active jobs
- enable marking cutting jobs complete, editing inline notes, and display a past jobs history block
- feed completed job efficiency metrics into the cost analysis summary and styling for the new sections

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d4559e817083258e0668002e69c3fa