### PR TITLE
Simplify cutting jobs layout

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -298,6 +298,7 @@ if (!Array.isArray(window.tasksInterval)) window.tasksInterval = [];
 if (!Array.isArray(window.tasksAsReq))   window.tasksAsReq   = [];
 if (!Array.isArray(window.inventory))    window.inventory    = [];
 if (!Array.isArray(window.cuttingJobs))  window.cuttingJobs  = [];   // [{id,name,estimateHours,material,materialCost,materialQty,notes,startISO,dueISO,manualLogs:[{dateISO,completedHours}],files:[{name,dataUrl,type,size,addedAt}]}]
+if (!Array.isArray(window.completedCuttingJobs)) window.completedCuttingJobs = [];
 if (!Array.isArray(window.pendingNewJobFiles)) window.pendingNewJobFiles = [];
 if (!Array.isArray(window.orderRequests)) window.orderRequests = [];
 if (!Array.isArray(window.garnetCleanings)) window.garnetCleanings = [];
@@ -312,6 +313,7 @@ let tasksInterval = window.tasksInterval;
 let tasksAsReq    = window.tasksAsReq;
 let inventory     = window.inventory;
 let cuttingJobs   = window.cuttingJobs;
+let completedCuttingJobs = window.completedCuttingJobs;
 let orderRequests = window.orderRequests;
 let orderRequestTab = window.orderRequestTab;
 let garnetCleanings = window.garnetCleanings;
@@ -341,6 +343,7 @@ function snapshotState(){
     tasksAsReq,
     inventory,
     cuttingJobs,
+    completedCuttingJobs,
     orderRequests,
     orderRequestTab,
     garnetCleanings,
@@ -515,6 +518,7 @@ function adoptState(doc){
     : defaultAsReqTasks.slice();
   inventory = Array.isArray(data.inventory) ? data.inventory : seedInventoryFromTasks();
   cuttingJobs = Array.isArray(data.cuttingJobs) ? data.cuttingJobs : [];
+  completedCuttingJobs = Array.isArray(data.completedCuttingJobs) ? data.completedCuttingJobs : [];
   orderRequests = normalizeOrderRequests(Array.isArray(data.orderRequests) ? data.orderRequests : []);
   if (!orderRequests.some(req => req && req.status === "draft")){
     orderRequests.push(createOrderRequest());
@@ -526,6 +530,7 @@ function adoptState(doc){
   window.tasksAsReq = tasksAsReq;
   window.inventory = inventory;
   window.cuttingJobs = cuttingJobs;
+  window.completedCuttingJobs = completedCuttingJobs;
   window.orderRequests = orderRequests;
   window.garnetCleanings = garnetCleanings;
   if (!Array.isArray(window.pendingNewJobFiles)) window.pendingNewJobFiles = [];
@@ -581,6 +586,7 @@ async function loadFromCloud(){
           tasksAsReq: Array.isArray(data.tasksAsReq) && data.tasksAsReq.length ? data.tasksAsReq : defaultAsReqTasks.slice(),
           inventory: Array.isArray(data.inventory) && data.inventory.length ? data.inventory : seedInventoryFromTasks(),
           cuttingJobs: Array.isArray(data.cuttingJobs) ? data.cuttingJobs : [],
+          completedCuttingJobs: Array.isArray(data.completedCuttingJobs) ? data.completedCuttingJobs : [],
           garnetCleanings: Array.isArray(data.garnetCleanings) ? data.garnetCleanings : [],
           orderRequests: Array.isArray(data.orderRequests) ? normalizeOrderRequests(data.orderRequests) : [createOrderRequest()],
           orderRequestTab: typeof data.orderRequestTab === "string" ? data.orderRequestTab : "active",
@@ -597,7 +603,7 @@ async function loadFromCloud(){
       const pe = (typeof window.pumpEff === "object" && window.pumpEff)
         ? window.pumpEff
         : (window.pumpEff = { baselineRPM:null, baselineDateISO:null, entries:[] });
-      const seeded = { schema:APP_SCHEMA, totalHistory:[], tasksInterval:defaultIntervalTasks.slice(), tasksAsReq:defaultAsReqTasks.slice(), inventory:seedInventoryFromTasks(), cuttingJobs:[], orderRequests:[createOrderRequest()], orderRequestTab:"active", pumpEff: pe };
+      const seeded = { schema:APP_SCHEMA, totalHistory:[], tasksInterval:defaultIntervalTasks.slice(), tasksAsReq:defaultAsReqTasks.slice(), inventory:seedInventoryFromTasks(), cuttingJobs:[], completedCuttingJobs:[], orderRequests:[createOrderRequest()], orderRequestTab:"active", pumpEff: pe };
       seeded.garnetCleanings = [];
       adoptState(seeded);
       resetHistoryToCurrent();
@@ -608,7 +614,7 @@ async function loadFromCloud(){
     const pe = (typeof window.pumpEff === "object" && window.pumpEff)
       ? window.pumpEff
       : (window.pumpEff = { baselineRPM:null, baselineDateISO:null, entries:[] });
-    adoptState({ schema:APP_SCHEMA, totalHistory:[], tasksInterval:defaultIntervalTasks.slice(), tasksAsReq:defaultAsReqTasks.slice(), inventory:seedInventoryFromTasks(), cuttingJobs:[], orderRequests:[createOrderRequest()], orderRequestTab:"active", pumpEff: pe, garnetCleanings: [] });
+    adoptState({ schema:APP_SCHEMA, totalHistory:[], tasksInterval:defaultIntervalTasks.slice(), tasksAsReq:defaultAsReqTasks.slice(), inventory:seedInventoryFromTasks(), cuttingJobs:[], completedCuttingJobs:[], orderRequests:[createOrderRequest()], orderRequestTab:"active", pumpEff: pe, garnetCleanings: [] });
     resetHistoryToCurrent();
   }
 }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -2431,6 +2431,63 @@ function computeCostModel(){
   const jobsInfo = [];
   const jobSeriesRaw = [];
   let totalGainLoss = 0;
+  let completedCount = 0;
+
+  const completedJobsList = Array.isArray(completedCuttingJobs) ? completedCuttingJobs : [];
+  if (completedJobsList.length){
+    for (const job of completedJobsList){
+      if (!job) continue;
+      const eff = job.efficiency || (typeof computeJobEfficiency === "function" ? computeJobEfficiency(job) : null);
+      const gainLoss = eff && Number.isFinite(eff.gainLoss) ? Number(eff.gainLoss) : 0;
+      const deltaHours = eff && Number.isFinite(eff.deltaHours) ? Number(eff.deltaHours) : 0;
+      let date = null;
+      if (job.completedAtISO){
+        const completedDate = parseDateLocal(job.completedAtISO) || new Date(job.completedAtISO);
+        if (completedDate instanceof Date && !Number.isNaN(completedDate.getTime())){
+          date = completedDate;
+        }
+      }
+      if (!date && job.dueISO){
+        const due = parseDateLocal(job.dueISO);
+        if (due) date = due;
+      }
+      if (!date && job.startISO){
+        const start = parseDateLocal(job.startISO);
+        if (start) date = start;
+      }
+      if (!date){
+        const fallback = parsedHistory.length ? parsedHistory[parsedHistory.length-1].date : new Date();
+        date = new Date(fallback);
+      }
+      const milestone = job.completedAtISO
+        ? parseDateLocal(job.completedAtISO) || new Date(job.completedAtISO)
+        : parseDateLocal(job.dueISO || job.startISO || "");
+      const milestoneLabel = (milestone instanceof Date && !Number.isNaN(milestone))
+        ? milestone.toLocaleDateString()
+        : "—";
+      let statusDetail = "Finished on estimate";
+      if (Math.abs(deltaHours) > 0.1){
+        const prefix = deltaHours > 0 ? "Finished ahead" : "Finished behind";
+        statusDetail = `${prefix} (${deltaHours>0?"+":"-"}${Math.abs(deltaHours).toFixed(1)} hr)`;
+      }
+
+      jobsInfo.push({
+        name: job.name || "Untitled job",
+        date,
+        milestoneLabel,
+        gainLoss,
+        status: "Completed",
+        statusDetail
+      });
+
+      if (date instanceof Date && !Number.isNaN(date.getTime())){
+        jobSeriesRaw.push({ date, rawValue: gainLoss, label: job.name || "Job" });
+      }
+
+      totalGainLoss += gainLoss;
+      completedCount += 1;
+    }
+  }
 
   if (Array.isArray(cuttingJobs)){
     for (const job of cuttingJobs){
@@ -2468,12 +2525,6 @@ function computeCostModel(){
         status,
         statusDetail
       });
-
-      if (!Number.isNaN(date.getTime())){
-        jobSeriesRaw.push({ date, rawValue: gainLoss, label: job.name || "Job" });
-      }
-
-      totalGainLoss += gainLoss;
     }
   }
 
@@ -2487,7 +2538,7 @@ function computeCostModel(){
     });
   }
 
-  const jobCount = jobsInfo.length;
+  const jobCount = completedCount;
   const averageGainLoss = jobCount ? (totalGainLoss / jobCount) : 0;
 
   const formatterCurrency = (value, { showPlus=false, decimals=null } = {})=>{
@@ -2558,7 +2609,7 @@ function computeCostModel(){
       title: "Cutting jobs efficiency",
       value: formatterCurrency(totalGainLoss, { decimals: 0, showPlus: true }),
       hint: jobCount
-        ? `Average gain/loss ${formatterCurrency(averageGainLoss, { decimals: 0, showPlus: true })} across ${jobCount} job${jobCount===1?"":"s"}.`
+        ? `Average gain/loss ${formatterCurrency(averageGainLoss, { decimals: 0, showPlus: true })} across ${jobCount} completed job${jobCount===1?"":"s"}.`
         : "No cutting jobs logged yet."
     },
     {
@@ -2570,7 +2621,7 @@ function computeCostModel(){
   ];
 
   const jobSummary = {
-    countLabel: String(jobCount),
+    countLabel: jobCount ? `${jobCount} completed` : "0",
     totalLabel: formatterCurrency(totalGainLoss, { decimals: 0, showPlus: true }),
     averageLabel: formatterCurrency(averageGainLoss, { decimals: 0, showPlus: true }),
     rollingLabel: jobSeries.length
@@ -2913,6 +2964,16 @@ function renderJobs(){
     }
   });
 
+  content.querySelector("tbody")?.addEventListener("input", (e)=>{
+    if (e.target.matches("textarea[data-job-note]")){
+      const id = e.target.getAttribute("data-job-note");
+      const j = cuttingJobs.find(x=>x.id===id);
+      if (!j) return;
+      j.notes = e.target.value;
+      saveCloudDebounced();
+    }
+  });
+
   // 6) Edit/Remove/Save/Cancel + Log panel + Apply spent/remaining
   content.querySelector("tbody")?.addEventListener("click",(e)=>{
     const upload = e.target.closest("[data-upload-job]");
@@ -2941,6 +3002,7 @@ function renderJobs(){
     const sv = e.target.closest("[data-save-job]");
     const ca = e.target.closest("[data-cancel-job]");
     const lg = e.target.closest("[data-log-job]");
+    const complete = e.target.closest("[data-complete-job]");
     const apSpent  = e.target.closest("[data-log-apply-spent]");
     const apRemain = e.target.closest("[data-log-apply-remain]");
 
@@ -2951,7 +3013,59 @@ function renderJobs(){
     if (rm){
       const id = rm.getAttribute("data-remove-job");
       cuttingJobs = cuttingJobs.filter(x=>x.id!==id);
-      saveCloudDebounced(); toast("Removed"); renderJobs(); 
+      saveCloudDebounced(); toast("Removed"); renderJobs();
+      return;
+    }
+
+    if (complete){
+      const id = complete.getAttribute("data-complete-job");
+      const idx = cuttingJobs.findIndex(x=>x.id===id);
+      if (idx < 0) return;
+      const job = cuttingJobs[idx];
+      const eff = typeof computeJobEfficiency === "function" ? computeJobEfficiency(job) : null;
+      const now = new Date();
+      const completionISO = now.toISOString();
+      const efficiencySummary = eff ? {
+        rate: eff.rate ?? JOB_RATE_PER_HOUR,
+        expectedHours: eff.expectedHours ?? null,
+        actualHours: eff.actualHours ?? null,
+        expectedRemaining: eff.expectedRemaining ?? null,
+        actualRemaining: eff.actualRemaining ?? null,
+        deltaHours: eff.deltaHours ?? null,
+        gainLoss: eff.gainLoss ?? null
+      } : {
+        rate: JOB_RATE_PER_HOUR,
+        expectedHours: null,
+        actualHours: null,
+        expectedRemaining: null,
+        actualRemaining: null,
+        deltaHours: null,
+        gainLoss: null
+      };
+
+      const completed = {
+        id: job.id,
+        name: job.name,
+        estimateHours: job.estimateHours,
+        startISO: job.startISO,
+        dueISO: job.dueISO,
+        completedAtISO: completionISO,
+        notes: job.notes || "",
+        material: job.material || "",
+        materialCost: Number(job.materialCost)||0,
+        materialQty: Number(job.materialQty)||0,
+        manualLogs: Array.isArray(job.manualLogs) ? job.manualLogs.slice() : [],
+        files: Array.isArray(job.files) ? job.files.map(f=>({ ...f })) : [],
+        actualHours: eff && Number.isFinite(eff.actualHours) ? eff.actualHours : null,
+        efficiency: efficiencySummary
+      };
+
+      completedCuttingJobs.push(completed);
+      cuttingJobs.splice(idx, 1);
+      editingJobs.delete(id);
+      saveCloudDebounced();
+      toast("Job marked complete");
+      renderJobs();
       return;
     }
 
@@ -2993,7 +3107,7 @@ function renderJobs(){
       trForm.className = "manual-log-row";
       trForm.setAttribute("data-log-row", id);
       trForm.innerHTML = `
-        <td colspan="8">
+        <td colspan="5">
           <div class="mini-form" style="display:grid; gap:8px; align-items:end; grid-template-columns: repeat(6, minmax(0,1fr));">
             <div style="grid-column:1/7">
               <strong>Manual Log for: ${j.name}</strong>

--- a/style.css
+++ b/style.css
@@ -910,15 +910,360 @@ h1 { margin: 0 0 10px; font-size: 22px; }
 .total-hours-meta span + span::before { content: "•"; margin-right: 6px; color: #9aa4b2; }
 .total-hours-meta .hint,
 .total-hours-meta .small { margin: 0; }
-.job-files { margin-top: 6px; display: flex; flex-direction: column; gap: 4px; }
-.job-file-link { color: #0a63c2; text-decoration: none; font-size: 12px; }
-.job-file-link:hover { text-decoration: underline; }
 .job-edit-files { margin-top: 8px; display: flex; flex-direction: column; gap: 6px; }
 .job-file-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
 .job-file-list li { display: flex; align-items: center; gap: 8px; font-size: 12px; }
 .job-file-list button.link { background: none; border: none; color: #c43d3d; cursor: pointer; padding: 0; font-size: 12px; }
 .job-file-list button.link:hover { text-decoration: underline; }
 .job-files-summary { margin-top: 4px; }
+
+.job-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.job-table thead th {
+  text-align: left;
+  font-size: 13px;
+  font-weight: 600;
+  color: #354157;
+  background: #f4f6fb;
+  padding: 10px;
+  border-bottom: 1px solid #e0e6f2;
+}
+.job-table td {
+  padding: 12px 10px;
+  border-bottom: 1px solid #e7ecf6;
+  vertical-align: top;
+  background: #fff;
+}
+.job-row + .job-detail-row td {
+  border-top: 0;
+}
+.job-cell {
+  min-width: 0;
+}
+.job-cell-main {
+  width: 24%;
+}
+.job-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.job-material-label { margin-top: 4px; }
+.job-cell-materials {
+  width: 24%;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  align-items: end;
+}
+.job-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.job-metric input {
+  width: 100%;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid rgba(15, 52, 104, 0.2);
+  font-size: 14px;
+  box-shadow: inset 0 1px 2px rgba(13, 36, 72, 0.08);
+}
+.job-metric input:focus {
+  outline: 2px solid rgba(33, 150, 243, 0.35);
+  border-color: rgba(33, 150, 243, 0.55);
+}
+.job-metric-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #5a6b85;
+}
+.job-metric-value {
+  font-weight: 600;
+  color: #1c2d4a;
+}
+.job-metric-total .job-metric-value { font-size: 15px; }
+.job-cell-progress {
+  width: 22%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.job-inline-actions { margin-top: auto; }
+.job-inline-actions button {
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid #c9d3e6;
+  background: #f4f7fb;
+  font-weight: 600;
+  cursor: pointer;
+}
+.job-inline-actions button:hover { background: #e7eefb; }
+.job-cell-efficiency {
+  width: 18%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.job-cell-actions {
+  width: 16%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.job-cell-actions button {
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid #c9d3e6;
+  background: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.job-cell-actions button:hover { background: #f3f6fb; }
+.job-cell-actions .danger {
+  border-color: rgba(196, 61, 61, 0.28);
+  color: #b53939;
+}
+.job-cell-actions .danger:hover { background: rgba(244, 224, 224, 0.6); }
+.job-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(10, 99, 194, 0.08);
+  color: #0b3a7a;
+  font-size: 12px;
+  font-weight: 600;
+}
+.job-chip.danger {
+  background: rgba(196, 61, 61, 0.12);
+  color: #a12a2a;
+}
+.job-detail-row td {
+  background: #f6f8fd;
+  border-bottom: 1px solid #e0e6f2;
+}
+.job-detail-card {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  padding: 16px;
+  background: #f1f4fb;
+  border: 1px solid #dbe2f2;
+  border-radius: 12px;
+  align-items: flex-start;
+}
+.job-detail-note textarea {
+  width: 100%;
+  min-height: 60px;
+  resize: vertical;
+  font-size: 13px;
+  line-height: 1.4;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(9, 38, 88, 0.18);
+  box-shadow: inset 0 1px 2px rgba(6, 24, 64, 0.08);
+  background: #fff;
+}
+.job-detail-note textarea:focus {
+  outline: 2px solid rgba(33, 150, 243, 0.35);
+  border-color: rgba(33, 150, 243, 0.55);
+}
+.job-detail-label {
+  display: block;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #5a6b85;
+  margin-bottom: 6px;
+}
+.job-detail-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.job-detail-files {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.job-file-pill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.job-file-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #fff;
+  border: 1px solid #cdd6ea;
+  color: #0a63c2;
+  font-size: 12px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.job-file-pill:hover { background: #edf3fe; }
+.job-edit-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px;
+  background: #f8faff;
+  border: 1px solid #dae2f3;
+  border-radius: 12px;
+}
+.job-edit-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+.job-edit-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #5a6b85;
+}
+.job-edit-grid input {
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(15, 52, 104, 0.2);
+  font-size: 14px;
+  background: #fff;
+}
+.job-edit-grid input:focus {
+  outline: 2px solid rgba(33, 150, 243, 0.35);
+  border-color: rgba(33, 150, 243, 0.55);
+}
+.job-edit-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+.job-edit-note {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #5a6b85;
+}
+.job-edit-note textarea {
+  min-height: 80px;
+  resize: vertical;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(15, 52, 104, 0.2);
+  font-size: 14px;
+  background: #fff;
+}
+.job-edit-note textarea:focus {
+  outline: 2px solid rgba(33, 150, 243, 0.35);
+  border-color: rgba(33, 150, 243, 0.55);
+}
+.job-edit-files button {
+  align-self: flex-start;
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid #c9d3e6;
+  background: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.job-edit-files button:hover { background: #f3f6fb; }
+.job-edit-actions {
+  display: flex;
+  gap: 10px;
+}
+.job-edit-actions button {
+  padding: 8px 16px;
+  border-radius: 10px;
+  border: 1px solid #c9d3e6;
+  background: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.job-edit-actions button:hover { background: #f1f4fb; }
+.job-edit-actions .danger {
+  border-color: rgba(196, 61, 61, 0.28);
+  color: #b53939;
+}
+.job-edit-actions .danger:hover { background: rgba(244, 224, 224, 0.6); }
+
+@media (max-width: 960px) {
+  .job-table thead { display: none; }
+  .job-table, .job-table tbody, .job-table tr, .job-table td { display: block; width: 100%; }
+  .job-table tr { margin-bottom: 16px; }
+  .job-cell-actions { flex-direction: row; flex-wrap: wrap; }
+  .job-detail-card { grid-template-columns: 1fr; }
+  .job-cell-materials { grid-template-columns: 1fr 1fr; }
+}
+
+.past-jobs-block { grid-column: 1 / -1; }
+.past-jobs-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.past-jobs-summary div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid #dbe2f2;
+  background: #f6f8fd;
+  color: #10294f;
+}
+.past-jobs-summary .label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #5a6b85;
+}
+.past-jobs-summary span:last-child {
+  font-size: 15px;
+  font-weight: 600;
+}
+.past-jobs-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+  background: #fff;
+}
+.past-jobs-table th,
+.past-jobs-table td {
+  padding: 10px;
+  border: 1px solid #e0e6f2;
+  text-align: left;
+}
+.past-jobs-table th {
+  background: #f4f6fb;
+  color: #354157;
+  font-weight: 600;
+}
+.past-jobs-table td:last-child {
+  min-width: 160px;
+  color: #1f3252;
+  font-size: 13px;
+  line-height: 1.4;
+}
+.past-jobs-table td:last-child .muted { color: rgba(31, 50, 82, 0.55); }
 
 @media (max-width: 720px) {
   .dashboard-top { flex-direction: column; }


### PR DESCRIPTION
## Summary
- reorganize the active cutting jobs table into concise summary columns with a dedicated detail row for notes and attachments
- refresh job editing, status chips, and file styling to reduce visual noise while preserving inline updates
- soften the past jobs summary/table presentation to align with the streamlined layout

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d4559e817083258e0668002e69c3fa