### PR TITLE
Fix pump chart expansion overlay and enlarge canvas text

### DIFF
--- a/js/pump.js
+++ b/js/pump.js
@@ -4,6 +4,7 @@ window.pumpChartRange = window.pumpChartRange || "3m";
 window.pumpChartExpanded = window.pumpChartExpanded || false;
 
 const PUMP_BASE_FONT_SCALE = 3;
+const PUMP_FONT_ADJUST = 1.1;
 const pumpViewportState = { bound:false, lastResponsiveScale:1 };
 
 function pumpGetViewportScale(){
@@ -363,7 +364,7 @@ function drawPumpChart(canvas, rangeValue){
   ctx.fillRect(0,0,W,H);
   const fontScale = pumpComputeFontScale();
   const scaled = (value)=> Math.max(1, Math.round(value * fontScale));
-  const fontPx = (size)=> `${Math.max(1, Math.round(size * fontScale))}px sans-serif`;
+  const fontPx = (size)=> `${Math.max(1, Math.round(size * fontScale * PUMP_FONT_ADJUST))}px sans-serif`;
   ctx.font = fontPx(12);
   ctx.textAlign = "left";
   ctx.textBaseline = "alphabetic";

--- a/style.css
+++ b/style.css
@@ -7,6 +7,7 @@
 .pump-stats { margin-top:6px; display:grid; gap:4px; }
 .pump-stats .lbl { color:#666; display:inline-block; width:80px; }
 .pump-chart-block { display:flex; flex-direction:column; gap:12px; }
+.dashboard-window > .pump-chart-block { overflow:visible; }
 .pump-chart-card { display:flex; flex-direction:column; gap:12px; height:100%; }
 .pump-chart-header { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; }
 .pump-chart-toolbar { display:flex; justify-content:flex-end; align-items:center; gap:6px; flex-wrap:wrap; }


### PR DESCRIPTION
## Summary
- allow the pump chart expansion overlay to extend beyond the dashboard window by ensuring the pump chart block does not clip fixed elements
- slightly increase pump chart canvas typography for better readability

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d54c62d6fc8325ba002c952cfb99d7