### PR TITLE
Enhance cost analysis chart readability

### DIFF
--- a/style.css
+++ b/style.css
@@ -112,6 +112,51 @@ body.pump-chart-expanded { overflow:hidden; }
 .cost-chart-toggle .dot{ display:inline-block; width:12px; height:12px; border-radius:999px; }
 .cost-chart-canvas { position: relative; }
 .cost-chart-canvas canvas { width: 100%; height: auto; display: block; }
+.cost-chart-tooltip{
+  position:absolute;
+  pointer-events:none;
+  background:#111827;
+  color:#f9fafb;
+  padding:8px 10px;
+  border-radius:6px;
+  font-size:12px;
+  line-height:1.4;
+  max-width:240px;
+  box-shadow:0 12px 28px rgba(15,23,42,0.3);
+  transform:translate(-50%, -110%);
+  opacity:0;
+  transition:opacity 120ms ease, transform 120ms ease;
+  z-index:5;
+  white-space:normal;
+}
+.cost-chart-tooltip[data-visible="true"]{
+  opacity:1;
+  transform:translate(-50%, -120%);
+}
+.cost-chart-tooltip[hidden]{
+  display:none;
+  opacity:0;
+}
+.cost-chart-tooltip strong{
+  display:block;
+  font-weight:600;
+  color:#bfdbfe;
+  margin-bottom:4px;
+}
+.cost-chart-tooltip span{
+  display:block;
+  color:#e5e7eb;
+}
+.cost-chart-tooltip::after{
+  content:"";
+  position:absolute;
+  left:50%;
+  bottom:-6px;
+  transform:translateX(-50%);
+  border-width:6px 6px 0 6px;
+  border-style:solid;
+  border-color:#111827 transparent transparent transparent;
+}
 
 .cost-table{ width:100%; border-collapse:collapse; font-variant-numeric:tabular-nums; }
 .cost-table th, .cost-table td{ padding:8px; border:1px solid #e1e5ee; text-align:left; }

--- a/style.css
+++ b/style.css
@@ -123,15 +123,24 @@ body.pump-chart-expanded { overflow:hidden; }
   line-height:1.4;
   max-width:240px;
   box-shadow:0 12px 28px rgba(15,23,42,0.3);
-  transform:translate(-50%, -110%);
   opacity:0;
   transition:opacity 120ms ease, transform 120ms ease;
   z-index:5;
   white-space:normal;
 }
-.cost-chart-tooltip[data-visible="true"]{
+.cost-chart-tooltip[data-placement="above"]{
+  transform:translate(-50%, -110%);
+}
+.cost-chart-tooltip[data-placement="above"][data-visible="true"]{
   opacity:1;
   transform:translate(-50%, -120%);
+}
+.cost-chart-tooltip[data-placement="below"]{
+  transform:translate(-50%, 10%);
+}
+.cost-chart-tooltip[data-placement="below"][data-visible="true"]{
+  opacity:1;
+  transform:translate(-50%, 0%);
 }
 .cost-chart-tooltip[hidden]{
   display:none;
@@ -151,11 +160,18 @@ body.pump-chart-expanded { overflow:hidden; }
   content:"";
   position:absolute;
   left:50%;
-  bottom:-6px;
   transform:translateX(-50%);
-  border-width:6px 6px 0 6px;
   border-style:solid;
+}
+.cost-chart-tooltip[data-placement="above"]::after{
+  bottom:-6px;
+  border-width:6px 6px 0 6px;
   border-color:#111827 transparent transparent transparent;
+}
+.cost-chart-tooltip[data-placement="below"]::after{
+  top:-6px;
+  border-width:0 6px 6px 6px;
+  border-color:transparent transparent #111827 transparent;
 }
 
 .cost-table{ width:100%; border-collapse:collapse; font-variant-numeric:tabular-nums; }


### PR DESCRIPTION
## Summary
- add formatted gridlines and tick labels to the cost analysis chart for clearer scale context
- show evenly spaced time markers and highlight the most recent value for each dataset with labeled callouts

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d56ef011988325a9f2a58e20c53093