### PR TITLE
Allow editing and deleting completed cutting jobs

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -323,10 +323,12 @@ let inventorySearchTerm = window.inventorySearchTerm;
 
 /* ================ Jobs editing & render flags ================ */
 if (!(window.editingJobs instanceof Set)) window.editingJobs = new Set();
+if (!(window.editingCompletedJobs instanceof Set)) window.editingCompletedJobs = new Set();
 if (typeof window.RENDER_TOTAL !== "number") window.RENDER_TOTAL = null;
 if (typeof window.RENDER_DELTA !== "number") window.RENDER_DELTA = 0;
 
 const editingJobs  = window.editingJobs;
+const editingCompletedJobs = window.editingCompletedJobs;
 let   RENDER_TOTAL = window.RENDER_TOTAL;
 let   RENDER_DELTA = window.RENDER_DELTA;
 

--- a/js/core.js
+++ b/js/core.js
@@ -328,9 +328,17 @@ if (typeof window.RENDER_TOTAL !== "number") window.RENDER_TOTAL = null;
 if (typeof window.RENDER_DELTA !== "number") window.RENDER_DELTA = 0;
 
 const editingJobs  = window.editingJobs;
-const editingCompletedJobs = window.editingCompletedJobs;
 let   RENDER_TOTAL = window.RENDER_TOTAL;
 let   RENDER_DELTA = window.RENDER_DELTA;
+
+function getEditingCompletedJobsSet(){
+  if (!(window.editingCompletedJobs instanceof Set)){
+    window.editingCompletedJobs = new Set();
+  }
+  return window.editingCompletedJobs;
+}
+
+window.getEditingCompletedJobsSet = getEditingCompletedJobsSet;
 
 window.defaultIntervalTasks = defaultIntervalTasks;
 window.defaultAsReqTasks = defaultAsReqTasks;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -4,6 +4,16 @@ const pendingNewJobFiles = window.pendingNewJobFiles;
 if (!(window.orderPartialSelection instanceof Set)) window.orderPartialSelection = new Set();
 const orderPartialSelection = window.orderPartialSelection;
 
+function editingCompletedJobsSet(){
+  if (typeof getEditingCompletedJobsSet === "function"){
+    return getEditingCompletedJobsSet();
+  }
+  if (!(window.editingCompletedJobs instanceof Set)){
+    window.editingCompletedJobs = new Set();
+  }
+  return window.editingCompletedJobs;
+}
+
 function readFileAsDataUrl(file){
   return new Promise((resolve, reject)=>{
     const reader = new FileReader();
@@ -4891,13 +4901,13 @@ function renderJobs(){
 
     if (histEdit){
       const id = histEdit.getAttribute("data-history-edit");
-      if (id != null){ editingCompletedJobs.add(String(id)); renderJobs(); }
+      if (id != null){ editingCompletedJobsSet().add(String(id)); renderJobs(); }
       return;
     }
 
     if (histCancel){
       const id = histCancel.getAttribute("data-history-cancel");
-      if (id != null){ editingCompletedJobs.delete(String(id)); renderJobs(); }
+      if (id != null){ editingCompletedJobsSet().delete(String(id)); renderJobs(); }
       return;
     }
 
@@ -4911,7 +4921,7 @@ function renderJobs(){
       const idStr = String(id);
       completedCuttingJobs = completedCuttingJobs.filter(job => String(job?.id) !== idStr);
       window.completedCuttingJobs = completedCuttingJobs;
-      editingCompletedJobs.delete(idStr);
+      editingCompletedJobsSet().delete(idStr);
       saveCloudDebounced();
       toast("History entry deleted");
       renderJobs();
@@ -4984,7 +4994,7 @@ function renderJobs(){
         gainLoss
       };
 
-      editingCompletedJobs.delete(String(id));
+      editingCompletedJobsSet().delete(String(id));
       saveCloudDebounced();
       toast("History updated");
       renderJobs();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -4882,6 +4882,115 @@ function renderJobs(){
     }
   });
 
+  const historyBody = content.querySelector(".past-jobs-table tbody");
+  historyBody?.addEventListener("click", (e)=>{
+    const histEdit = e.target.closest("[data-history-edit]");
+    const histCancel = e.target.closest("[data-history-cancel]");
+    const histSave = e.target.closest("[data-history-save]");
+    const histDelete = e.target.closest("[data-history-delete]");
+
+    if (histEdit){
+      const id = histEdit.getAttribute("data-history-edit");
+      if (id != null){ editingCompletedJobs.add(String(id)); renderJobs(); }
+      return;
+    }
+
+    if (histCancel){
+      const id = histCancel.getAttribute("data-history-cancel");
+      if (id != null){ editingCompletedJobs.delete(String(id)); renderJobs(); }
+      return;
+    }
+
+    if (histDelete){
+      const id = histDelete.getAttribute("data-history-delete");
+      if (!id) return;
+      const proceed = typeof window.confirm === "function"
+        ? window.confirm("Delete this completed job entry?")
+        : true;
+      if (!proceed) return;
+      const idStr = String(id);
+      completedCuttingJobs = completedCuttingJobs.filter(job => String(job?.id) !== idStr);
+      window.completedCuttingJobs = completedCuttingJobs;
+      editingCompletedJobs.delete(idStr);
+      saveCloudDebounced();
+      toast("History entry deleted");
+      renderJobs();
+      return;
+    }
+
+    if (histSave){
+      const id = histSave.getAttribute("data-history-save");
+      if (!id) return;
+      const entry = completedCuttingJobs.find(job => String(job?.id) === String(id));
+      if (!entry) return;
+      const field = (key)=> content.querySelector(`[data-history-field="${key}"][data-history-id="${id}"]`);
+      const nameInput = field("name");
+      const estimateInput = field("estimateHours");
+      const actualInput = field("actualHours");
+      const materialInput = field("material");
+      const materialCostInput = field("materialCost");
+      const materialQtyInput = field("materialQty");
+      const notesInput = field("notes");
+      const completedInput = field("completedAtISO");
+
+      const name = (nameInput?.value || entry.name || "").trim();
+      if (!name){ toast("Enter a job name."); return; }
+
+      const estVal = estimateInput?.value;
+      const estNum = estVal === "" || estVal == null ? null : Number(estVal);
+      const estimateHours = Number.isFinite(estNum) && estNum >= 0 ? estNum : Number(entry.estimateHours) || 0;
+
+      const actVal = actualInput?.value;
+      const actualNum = actVal === "" || actVal == null ? null : Number(actVal);
+      const actualHours = Number.isFinite(actualNum) && actualNum >= 0 ? actualNum : null;
+
+      const material = materialInput?.value ?? entry.material ?? "";
+      const materialCostVal = materialCostInput?.value;
+      const materialCostNum = materialCostVal === "" || materialCostVal == null ? null : Number(materialCostVal);
+      const materialCost = Number.isFinite(materialCostNum) && materialCostNum >= 0 ? materialCostNum : Number(entry.materialCost) || 0;
+
+      const materialQtyVal = materialQtyInput?.value;
+      const materialQtyNum = materialQtyVal === "" || materialQtyVal == null ? null : Number(materialQtyVal);
+      const materialQty = Number.isFinite(materialQtyNum) && materialQtyNum >= 0 ? materialQtyNum : Number(entry.materialQty) || 0;
+
+      const notes = notesInput?.value ?? entry.notes ?? "";
+
+      const completedRaw = completedInput?.value;
+      if (completedRaw){
+        const dt = new Date(completedRaw);
+        if (!Number.isNaN(dt.getTime())) entry.completedAtISO = dt.toISOString();
+      }
+
+      entry.name = name;
+      entry.estimateHours = estimateHours;
+      entry.material = material;
+      entry.materialCost = materialCost;
+      entry.materialQty = materialQty;
+      entry.notes = notes;
+      entry.actualHours = actualHours != null ? actualHours : null;
+
+      const rate = Number(entry.efficiency?.rate) || JOB_RATE_PER_HOUR;
+      const deltaHours = actualHours != null ? (estimateHours - actualHours) : (entry.efficiency?.deltaHours ?? null);
+      const gainLoss = deltaHours != null ? deltaHours * rate : (entry.efficiency?.gainLoss ?? null);
+
+      entry.efficiency = {
+        ...entry.efficiency,
+        rate,
+        expectedHours: estimateHours,
+        actualHours: entry.actualHours,
+        expectedRemaining: 0,
+        actualRemaining: 0,
+        deltaHours,
+        gainLoss
+      };
+
+      editingCompletedJobs.delete(String(id));
+      saveCloudDebounced();
+      toast("History updated");
+      renderJobs();
+    }
+  });
+
   // 6) Edit/Remove/Save/Cancel + Log panel + Apply spent/remaining
   content.querySelector("tbody")?.addEventListener("click",(e)=>{
     const locked = e.target.closest("[data-requires-edit]");

--- a/js/views.js
+++ b/js/views.js
@@ -1095,9 +1095,8 @@ function viewJobs(){
       ? ` (${delta > 0 ? "+" : "−"}${Math.abs(delta).toFixed(1)} hr)`
       : "";
     const noteDisplay = job?.notes
-      ? esc(String(job.notes)).replace(/
-/g, "<br>")
-      : "<span class="muted">—</span>";
+      ? esc(String(job.notes)).replace(/\n/g, "<br>")
+      : "<span class=\"muted\">—</span>";
     const materialLine = job?.material ? `<div class="small muted">${esc(job.material)}</div>` : "";
 
     if (!editingHistory){

--- a/js/views.js
+++ b/js/views.js
@@ -1058,12 +1058,27 @@ function viewJobs(){
     return acc;
   }, { total: 0 });
   const completedAverage = completedSorted.length ? (completedStats.total / completedSorted.length) : 0;
+  const numberInputValue = (value)=>{
+    const num = Number(value);
+    return Number.isFinite(num) ? String(num) : "";
+  };
+  const formatDateTimeLocal = (iso)=>{
+    if (!iso) return "";
+    const dt = new Date(iso);
+    if (!(dt instanceof Date) || Number.isNaN(dt.getTime())) return "";
+    const offset = dt.getTimezoneOffset();
+    const local = new Date(dt.getTime() - offset * 60000);
+    return local.toISOString().slice(0,16);
+  };
+
+  const historyColumnCount = 7;
   const completedRows = completedSorted.map(job => {
     const eff = job && job.efficiency ? job.efficiency : {};
     const delta = Number(eff.deltaHours);
     const gainLoss = Number(eff.gainLoss);
     const actualHours = Number(job.actualHours ?? eff.actualHours);
     const estHours = Number(job.estimateHours);
+    const editingHistory = editingCompletedJobs.has(String(job.id));
     let statusLabel = "Finished on estimate";
     if (Number.isFinite(delta) && Math.abs(delta) > 0.1){
       statusLabel = delta > 0 ? "Finished ahead" : "Finished behind";
@@ -1072,20 +1087,57 @@ function viewJobs(){
       ? ` (${delta > 0 ? "+" : "−"}${Math.abs(delta).toFixed(1)} hr)`
       : "";
     const noteDisplay = job?.notes
-      ? esc(String(job.notes)).replace(/\n/g, "<br>")
-      : "<span class=\"muted\">—</span>";
+      ? esc(String(job.notes)).replace(/
+/g, "<br>")
+      : "<span class="muted">—</span>";
     const materialLine = job?.material ? `<div class="small muted">${esc(job.material)}</div>` : "";
+
+    if (!editingHistory){
+      return `
+        <tr data-history-row="${job.id || ""}">
+          <td>
+            <div><strong>${esc(job?.name || "Job")}</strong></div>
+            ${materialLine}
+          </td>
+          <td>${formatDate(job?.completedAtISO)}</td>
+          <td>${formatHours(actualHours)} / ${formatHours(estHours)}</td>
+          <td>${esc(statusLabel)}${statusDetail}</td>
+          <td>${formatCurrency(gainLoss)}</td>
+          <td>${noteDisplay}</td>
+          <td class="past-job-actions">
+            <button type="button" data-history-edit="${job.id}">Edit</button>
+            <button type="button" class="danger" data-history-delete="${job.id}">Delete</button>
+          </td>
+        </tr>
+      `;
+    }
+
+    const completedVal = formatDateTimeLocal(job?.completedAtISO);
+    const actualVal = numberInputValue(actualHours);
+    const estimateVal = numberInputValue(estHours);
+    const materialCostVal = numberInputValue(job?.materialCost);
+    const materialQtyVal = numberInputValue(job?.materialQty);
+
     return `
-      <tr>
-        <td>
-          <div><strong>${esc(job?.name || "Job")}</strong></div>
-          ${materialLine}
+      <tr data-history-row="${job.id || ""}" class="editing">
+        <td colspan="${historyColumnCount}">
+          <div class="past-job-edit">
+            <div class="past-job-edit-grid">
+              <label>Job name<input type="text" data-history-field="name" data-history-id="${job.id}" value="${esc(job?.name || "")}"></label>
+              <label>Completed at<input type="datetime-local" data-history-field="completedAtISO" data-history-id="${job.id}" value="${completedVal}"></label>
+              <label>Estimate (hrs)<input type="number" min="0" step="0.1" data-history-field="estimateHours" data-history-id="${job.id}" value="${estimateVal}"></label>
+              <label>Actual (hrs)<input type="number" min="0" step="0.1" data-history-field="actualHours" data-history-id="${job.id}" value="${actualVal}"></label>
+              <label>Material<input type="text" data-history-field="material" data-history-id="${job.id}" value="${esc(job?.material || "")}"></label>
+              <label>Material cost<input type="number" min="0" step="0.01" data-history-field="materialCost" data-history-id="${job.id}" value="${materialCostVal}"></label>
+              <label>Material quantity<input type="number" min="0" step="0.01" data-history-field="materialQty" data-history-id="${job.id}" value="${materialQtyVal}"></label>
+            </div>
+            <label class="past-job-edit-notes">Notes<textarea data-history-field="notes" data-history-id="${job.id}" rows="3">${textEsc(job?.notes || "")}</textarea></label>
+            <div class="past-job-edit-actions">
+              <button type="button" data-history-save="${job.id}">Save</button>
+              <button type="button" class="danger" data-history-cancel="${job.id}">Cancel</button>
+            </div>
+          </div>
         </td>
-        <td>${formatDate(job?.completedAtISO)}</td>
-        <td>${formatHours(actualHours)} / ${formatHours(estHours)}</td>
-        <td>${esc(statusLabel)}${statusDetail}</td>
-        <td>${formatCurrency(gainLoss)}</td>
-        <td>${noteDisplay}</td>
       </tr>
     `;
   }).join("");
@@ -1098,7 +1150,7 @@ function viewJobs(){
       </div>
       <table class="past-jobs-table">
         <thead>
-          <tr><th>Job</th><th>Completed</th><th>Actual vs estimate</th><th>Status</th><th>Cost impact</th><th>Note</th></tr>
+          <tr><th>Job</th><th>Completed</th><th>Actual vs estimate</th><th>Status</th><th>Cost impact</th><th>Note</th><th>Actions</th></tr>
         </thead>
         <tbody>${completedRows}</tbody>
       </table>

--- a/js/views.js
+++ b/js/views.js
@@ -1072,13 +1072,21 @@ function viewJobs(){
   };
 
   const historyColumnCount = 7;
+  const editingCompletedJobsSet = typeof getEditingCompletedJobsSet === "function"
+    ? getEditingCompletedJobsSet()
+    : (()=>{
+        if (!(window.editingCompletedJobs instanceof Set)){
+          window.editingCompletedJobs = new Set();
+        }
+        return window.editingCompletedJobs;
+      })();
   const completedRows = completedSorted.map(job => {
     const eff = job && job.efficiency ? job.efficiency : {};
     const delta = Number(eff.deltaHours);
     const gainLoss = Number(eff.gainLoss);
     const actualHours = Number(job.actualHours ?? eff.actualHours);
     const estHours = Number(job.estimateHours);
-    const editingHistory = editingCompletedJobs.has(String(job.id));
+    const editingHistory = editingCompletedJobsSet.has(String(job.id));
     let statusLabel = "Finished on estimate";
     if (Number.isFinite(delta) && Math.abs(delta) > 0.1){
       statusLabel = delta > 0 ? "Finished ahead" : "Finished behind";

--- a/style.css
+++ b/style.css
@@ -1676,6 +1676,127 @@ h1 { margin: 0 0 10px; font-size: 22px; }
   line-height: 1.4;
 }
 .past-jobs-table td:last-child .muted { color: rgba(31, 50, 82, 0.55); }
+.past-job-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.past-job-actions button {
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: 1px solid #1a3159;
+  background: #1f3b67;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+.past-job-actions button:hover,
+.past-job-actions button:focus {
+  background: #264b84;
+  border-color: #223d6a;
+}
+.past-job-actions button:focus-visible {
+  outline: 2px solid #91b7ff;
+  outline-offset: 1px;
+}
+.past-job-actions .danger {
+  border-color: #7f1f1f;
+  background: #b53939;
+}
+.past-job-actions .danger:hover,
+.past-job-actions .danger:focus {
+  background: #a62a2a;
+  border-color: #821f1f;
+}
+.past-job-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  background: #f8faff;
+  border: 1px solid #dae2f3;
+  border-radius: 12px;
+}
+.past-job-edit-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+.past-job-edit-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #5a6b85;
+}
+.past-job-edit-grid input {
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(15, 52, 104, 0.2);
+  font-size: 14px;
+  background: #fff;
+}
+.past-job-edit-grid input:focus {
+  outline: 2px solid rgba(33, 150, 243, 0.35);
+  border-color: rgba(33, 150, 243, 0.55);
+}
+.past-job-edit-notes {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #5a6b85;
+}
+.past-job-edit-notes textarea {
+  min-height: 80px;
+  resize: vertical;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(15, 52, 104, 0.2);
+  font-size: 14px;
+  background: #fff;
+}
+.past-job-edit-notes textarea:focus {
+  outline: 2px solid rgba(33, 150, 243, 0.35);
+  border-color: rgba(33, 150, 243, 0.55);
+}
+.past-job-edit-actions {
+  display: flex;
+  gap: 10px;
+}
+.past-job-edit-actions button {
+  padding: 8px 18px;
+  border-radius: 10px;
+  border: 1px solid #1a3159;
+  background: #1f3b67;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+.past-job-edit-actions button:hover,
+.past-job-edit-actions button:focus {
+  background: #264b84;
+  border-color: #223d6a;
+}
+.past-job-edit-actions button:focus-visible {
+  outline: 2px solid #91b7ff;
+  outline-offset: 1px;
+}
+.past-job-edit-actions .danger {
+  border-color: #7f1f1f;
+  background: #b53939;
+}
+.past-job-edit-actions .danger:hover,
+.past-job-edit-actions .danger:focus {
+  background: #a62a2a;
+  border-color: #821f1f;
+}
 
 @media (max-width: 720px) {
   .dashboard-top { flex-direction: column; }


### PR DESCRIPTION
## Summary
- add global state for editing completed job history entries and expose controls on the jobs page
- render edit/delete actions for completed cutting jobs and wire up handlers plus styling for the editor

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d56f2a93648325a66e918a48404a85