### PR TITLE
Normalize folder state before saving

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -3098,6 +3098,11 @@ function renderSettings(){
   }
 
   const persist = ()=>{
+    if (typeof setSettingsFolders === "function") {
+      try { setSettingsFolders(window.settingsFolders); } catch (err) {
+        console.warn("Failed to sync folders before save", err);
+      }
+    }
     if (typeof saveTasks === "function") { try{ saveTasks(); }catch(_){} }
     if (typeof saveCloudDebounced === "function") { try{ saveCloudDebounced(); }catch(_){} }
   };

--- a/js/views.js
+++ b/js/views.js
@@ -465,6 +465,11 @@ function renderSettingsCategoriesPane(){
 
   // Save helpers (support local + cloud)
   function persist(){
+    if (typeof setSettingsFolders === "function") {
+      try { setSettingsFolders(window.settingsFolders); } catch (err) {
+        console.warn("Failed to sync folders before save", err);
+      }
+    }
     if (typeof saveTasks === "function") { try { saveTasks(); } catch(_){} }
     if (typeof saveCloudDebounced === "function") { try { saveCloudDebounced(); } catch(_){} }
   }


### PR DESCRIPTION
## Summary
- normalize folder snapshots directly from the current settings list and guard cloud saves by reapplying `setSettingsFolders`
- sync the settings UI persist helpers with `setSettingsFolders` so folder changes are normalized before local or cloud writes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d54e0f98b4832594da9a337c064fab