### PR TITLE
Ensure maintenance folders sync with settings state

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -331,11 +331,114 @@ let   RENDER_TOTAL = window.RENDER_TOTAL;
 let   RENDER_DELTA = window.RENDER_DELTA;
 
 window.defaultIntervalTasks = defaultIntervalTasks;
+const DEFAULT_SETTINGS_FOLDERS = [
+  { id: "root",     name: "All Tasks",    parent: null,   order: 3 },
+  { id: "interval", name: "Per Interval", parent: "root", order: 2 },
+  { id: "asreq",    name: "As Required",  parent: "root", order: 1 }
+];
+
+function defaultSettingsFolders(){
+  return DEFAULT_SETTINGS_FOLDERS.map(f => ({ ...f }));
+}
+
+function normalizeSettingsFolders(raw){
+  const seen = new Set();
+  const normalized = [];
+  if (Array.isArray(raw)){
+    for (const entry of raw){
+      if (!entry || entry.id == null) continue;
+      const key = String(entry.id);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      normalized.push({
+        id: entry.id,
+        name: typeof entry.name === "string" ? entry.name : "",
+        parent: entry.parent != null ? entry.parent : null,
+        order: Number.isFinite(entry.order) ? Number(entry.order) : 0
+      });
+    }
+  }
+  for (const template of DEFAULT_SETTINGS_FOLDERS){
+    const key = String(template.id);
+    if (seen.has(key)){
+      const existing = normalized.find(f => String(f.id) === key);
+      if (existing){
+        if (!existing.name) existing.name = template.name;
+        if (existing.parent == null && template.parent != null) existing.parent = template.parent;
+        if (!Number.isFinite(existing.order) && Number.isFinite(template.order)){
+          existing.order = Number(template.order);
+        }
+      }
+      continue;
+    }
+    seen.add(key);
+    normalized.push({ ...template });
+  }
+  return normalized;
+}
+
+function setSettingsFolders(raw){
+  const normalized = normalizeSettingsFolders(raw);
+  window.settingsFolders = normalized;
+  window.folders = window.settingsFolders;
+  return normalized;
+}
+
+function cloneFolders(list){
+  if (!Array.isArray(list)) return [];
+  return list.map(folder => ({ ...folder }));
+}
+
+function foldersEqual(a, b){
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+  if (a.length !== b.length) return false;
+
+  const normalizeEntry = (folder)=>(
+    {
+      id: folder && folder.id != null ? String(folder.id) : "",
+      name: typeof folder?.name === "string" ? folder.name : "",
+      parent: folder && folder.parent != null ? String(folder.parent) : null,
+      order: Number.isFinite(Number(folder?.order)) ? Number(folder.order) : 0
+    }
+  );
+
+  const map = new Map();
+  for (const entry of a){
+    const norm = normalizeEntry(entry);
+    if (!norm.id) continue;
+    map.set(norm.id, norm);
+  }
+
+  for (const entry of b){
+    const norm = normalizeEntry(entry);
+    if (!norm.id) return false;
+    const match = map.get(norm.id);
+    if (!match) return false;
+    if (match.name !== norm.name) return false;
+    if ((match.parent ?? null) !== (norm.parent ?? null)) return false;
+    if (match.order !== norm.order) return false;
+    map.delete(norm.id);
+  }
+
+  return map.size === 0;
+}
+
+function snapshotSettingsFolders(){
+  const source = Array.isArray(window.settingsFolders)
+    ? window.settingsFolders
+    : (Array.isArray(window.folders) ? window.folders : defaultSettingsFolders());
+  const normalized = normalizeSettingsFolders(source);
+  window.settingsFolders = normalized;
+  window.folders = window.settingsFolders;
+  return cloneFolders(normalized);
+}
+
 window.defaultAsReqTasks = defaultAsReqTasks;
 
 /* ==================== Cloud load / save ===================== */
 function snapshotState(){
   const safePumpEff = (typeof window.pumpEff !== "undefined") ? window.pumpEff : null;
+  const foldersSnapshot = snapshotSettingsFolders();
   return {
     schema: window.APP_SCHEMA || APP_SCHEMA,
     totalHistory,
@@ -347,7 +450,9 @@ function snapshotState(){
     orderRequests,
     orderRequestTab,
     garnetCleanings,
-    pumpEff: safePumpEff
+    pumpEff: safePumpEff,
+    settingsFolders: foldersSnapshot,
+    folders: cloneFolders(window.settingsFolders)
   };
 }
 
@@ -477,18 +582,12 @@ function redoLastUndo(){
 resetHistoryToCurrent();
 
 /* ======= Minimal folder model used by the explorer UI ======= */
-if (!Array.isArray(window.folders) || !window.folders.length) {
-  window.folders = [
-    { id: "root",     name: "All Tasks",    parent: null },
-    { id: "interval", name: "Per Interval", parent: "root" },
-    { id: "asreq",    name: "As Required",  parent: "root" },
-  ];
-}
-const folders = window.folders;
+setSettingsFolders(window.settingsFolders || window.folders);
 
 /* ================ Explorer helper functions ================= */
 function childrenFolders(parentId){
-  return folders.filter(f => f.parent === parentId);
+  const key = String(parentId ?? "");
+  return window.settingsFolders.filter(f => String((f?.parent ?? "")) === key);
 }
 
 function topTasksInCat(folderId){
@@ -544,6 +643,28 @@ function adoptState(doc){
   }
   orderRequestTab = window.orderRequestTab;
 
+  const rawFolders = Array.isArray(data.settingsFolders)
+    ? data.settingsFolders
+    : (Array.isArray(data.folders) ? data.folders : null);
+  setSettingsFolders(rawFolders);
+
+  if (typeof window._maintOrderCounter !== "number" || !Number.isFinite(window._maintOrderCounter)){
+    window._maintOrderCounter = 0;
+  }
+  let maxOrder = window._maintOrderCounter;
+  for (const list of [tasksInterval, tasksAsReq]){
+    if (!Array.isArray(list)) continue;
+    for (const task of list){
+      const val = Number(task && task.order);
+      if (Number.isFinite(val) && val > maxOrder) maxOrder = val;
+    }
+  }
+  for (const folder of window.settingsFolders){
+    const val = Number(folder && folder.order);
+    if (Number.isFinite(val) && val > maxOrder) maxOrder = val;
+  }
+  window._maintOrderCounter = maxOrder;
+
   // Pump efficiency (guard against reading an undefined identifier)
   const pe = (typeof window.pumpEff === "object" && window.pumpEff)
     ? window.pumpEff
@@ -565,6 +686,11 @@ const saveCloudInternal = debounce(async ()=>{
   try{ await FB.docRef.set(snapshotState(), { merge:true }); }catch(e){ console.error("Cloud save failed:", e); }
 }, 300);
 function saveCloudDebounced(){
+  try {
+    setSettingsFolders(window.settingsFolders);
+  } catch (err) {
+    console.warn("Failed to normalize folders before save:", err);
+  }
   captureHistorySnapshot();
   saveCloudInternal();
 }
@@ -579,6 +705,8 @@ async function loadFromCloud(){
         const pe = (typeof window.pumpEff === "object" && window.pumpEff)
           ? window.pumpEff
           : (window.pumpEff = { baselineRPM:null, baselineDateISO:null, entries:[] });
+        const seededFolders = normalizeSettingsFolders(data.settingsFolders || data.folders);
+        const seededFoldersPayload = cloneFolders(seededFolders);
         const seeded = {
           schema:APP_SCHEMA,
           totalHistory: Array.isArray(data.totalHistory) ? data.totalHistory : [],
@@ -590,21 +718,62 @@ async function loadFromCloud(){
           garnetCleanings: Array.isArray(data.garnetCleanings) ? data.garnetCleanings : [],
           orderRequests: Array.isArray(data.orderRequests) ? normalizeOrderRequests(data.orderRequests) : [createOrderRequest()],
           orderRequestTab: typeof data.orderRequestTab === "string" ? data.orderRequestTab : "active",
+          settingsFolders: seededFoldersPayload,
+          folders: cloneFolders(seededFoldersPayload),
           pumpEff: pe
         };
         adoptState(seeded);
         resetHistoryToCurrent();
         await FB.docRef.set(seeded, { merge:true });
       }else{
+        const docHasSettingsFolders = Array.isArray(data.settingsFolders);
+        const docHasLegacyFolders = Array.isArray(data.folders);
+        const docFoldersRaw = docHasSettingsFolders
+          ? data.settingsFolders
+          : (docHasLegacyFolders ? data.folders : null);
+        const normalizedDocFolders = normalizeSettingsFolders(docFoldersRaw);
+
         adoptState(data);
         resetHistoryToCurrent();
+
+        const localFoldersSnapshot = cloneFolders(window.settingsFolders);
+        let shouldSyncFolders = !docHasSettingsFolders || !docHasLegacyFolders;
+        if (!shouldSyncFolders){
+          shouldSyncFolders = !foldersEqual(normalizedDocFolders, localFoldersSnapshot);
+        }
+
+        if (shouldSyncFolders){
+          try {
+            const payloadFolders = cloneFolders(localFoldersSnapshot);
+            await FB.docRef.set({
+              settingsFolders: payloadFolders,
+              folders: cloneFolders(payloadFolders)
+            }, { merge:true });
+          } catch (err) {
+            console.warn("Failed to sync folders to cloud:", err);
+          }
+        }
       }
     }else{
       const pe = (typeof window.pumpEff === "object" && window.pumpEff)
         ? window.pumpEff
         : (window.pumpEff = { baselineRPM:null, baselineDateISO:null, entries:[] });
-      const seeded = { schema:APP_SCHEMA, totalHistory:[], tasksInterval:defaultIntervalTasks.slice(), tasksAsReq:defaultAsReqTasks.slice(), inventory:seedInventoryFromTasks(), cuttingJobs:[], completedCuttingJobs:[], orderRequests:[createOrderRequest()], orderRequestTab:"active", pumpEff: pe };
-      seeded.garnetCleanings = [];
+      const defaultFolders = defaultSettingsFolders();
+      const seeded = {
+        schema: APP_SCHEMA,
+        totalHistory: [],
+        tasksInterval: defaultIntervalTasks.slice(),
+        tasksAsReq: defaultAsReqTasks.slice(),
+        inventory: seedInventoryFromTasks(),
+        cuttingJobs: [],
+        completedCuttingJobs: [],
+        orderRequests: [createOrderRequest()],
+        orderRequestTab: "active",
+        pumpEff: pe,
+        settingsFolders: defaultFolders,
+        folders: cloneFolders(defaultFolders),
+        garnetCleanings: []
+      };
       adoptState(seeded);
       resetHistoryToCurrent();
       await FB.docRef.set(seeded);
@@ -614,7 +783,8 @@ async function loadFromCloud(){
     const pe = (typeof window.pumpEff === "object" && window.pumpEff)
       ? window.pumpEff
       : (window.pumpEff = { baselineRPM:null, baselineDateISO:null, entries:[] });
-    adoptState({ schema:APP_SCHEMA, totalHistory:[], tasksInterval:defaultIntervalTasks.slice(), tasksAsReq:defaultAsReqTasks.slice(), inventory:seedInventoryFromTasks(), cuttingJobs:[], completedCuttingJobs:[], orderRequests:[createOrderRequest()], orderRequestTab:"active", pumpEff: pe, garnetCleanings: [] });
+    const fallbackFolders = defaultSettingsFolders();
+    adoptState({ schema:APP_SCHEMA, totalHistory:[], tasksInterval:defaultIntervalTasks.slice(), tasksAsReq:defaultAsReqTasks.slice(), inventory:seedInventoryFromTasks(), cuttingJobs:[], completedCuttingJobs:[], orderRequests:[createOrderRequest()], orderRequestTab:"active", pumpEff: pe, settingsFolders: fallbackFolders, folders: cloneFolders(fallbackFolders), garnetCleanings: [] });
     resetHistoryToCurrent();
   }
 }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -3285,6 +3285,11 @@ function renderSettings(){
   }
 
   const persist = ()=>{
+    if (typeof setSettingsFolders === "function") {
+      try { setSettingsFolders(window.settingsFolders); } catch (err) {
+        console.warn("Failed to sync folders before save", err);
+      }
+    }
     if (typeof saveTasks === "function") { try{ saveTasks(); }catch(_){} }
     if (typeof saveCloudDebounced === "function") { try{ saveCloudDebounced(); }catch(_){} }
   };

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -2087,6 +2087,16 @@ function repairMaintenanceGraph(){
     if (!Array.isArray(window.tasksInterval))   window.tasksInterval   = [];
     if (!Array.isArray(window.tasksAsReq))      window.tasksAsReq      = [];
 
+    const ROOT_ID = (typeof window !== "undefined" && window.ROOT_FOLDER_ID)
+      ? String(window.ROOT_FOLDER_ID)
+      : "root";
+
+    if (!window.settingsFolders.some(f => f && String(f.id) === ROOT_ID)){
+      const fallbackOrder = Number(window._maintOrderCounter) || 0;
+      window.settingsFolders.push({ id: ROOT_ID, name: "All Tasks", parent: null, order: fallbackOrder + 1 });
+      window._maintOrderCounter = Math.max(Number(window._maintOrderCounter) || 0, fallbackOrder + 1);
+    }
+
     // Flatten any legacy nested `.sub` arrays so every task lives in the
     // top-level list with a parentTask pointer (Explorer-style tree).
     const seenIds = new Set();
@@ -2135,22 +2145,38 @@ function repairMaintenanceGraph(){
 
     // --- Fix bad folder parents & cycles ---
     for (const f of window.settingsFolders){
-      if (f.parent == null) continue;
-      if (!fMap[String(f.parent)] || String(f.parent) === String(f.id)){
-        f.parent = null; // orphan or self-parent → root
+      if (!f || f.id == null) continue;
+      const fid = String(f.id);
+      if (fid === ROOT_ID){
+        f.parent = null;
         continue;
       }
-      // break cycles: walk up until root; if we re-meet self, detach
-      const seen = new Set([String(f.id)]);
-      let cur = f;
-      let p = fMap[String(cur.parent)];
-      while (p){
-        const pid = String(p.id);
-        if (seen.has(pid)){ f.parent = null; break; }
-        seen.add(pid);
-        if (p.parent == null) break;
-        p = fMap[String(p.parent)] || null;
+
+      const parentRaw = f.parent != null ? String(f.parent) : null;
+      if (!parentRaw || parentRaw === fid || !fMap[parentRaw]){
+        f.parent = ROOT_ID;
       }
+
+      // break cycles: walk up until root; if we re-meet self, reset to ROOT
+      const seen = new Set([fid]);
+      let guard = 0;
+      let current = f;
+      let parent = current.parent != null ? String(current.parent) : null;
+      while (parent && guard++ < 1000){
+        if (seen.has(parent)){
+          f.parent = ROOT_ID;
+          break;
+        }
+        seen.add(parent);
+        const next = fMap[parent];
+        if (!next){
+          f.parent = ROOT_ID;
+          break;
+        }
+        parent = next.parent != null ? String(next.parent) : null;
+      }
+
+      f.parent = f.parent == null ? null : String(f.parent);
     }
 
     // --- Fix bad task parentTask and cat (folder) pointers + cycles ---
@@ -2161,7 +2187,8 @@ function repairMaintenanceGraph(){
         if (pid === String(t.id) || !tMap[pid]) t.parentTask = null;
       }
       // folder ref to nowhere → clear
-      if (t.cat != null && !fMap[String(t.cat)]) t.cat = null;
+      if (t.cat != null && !fMap[String(t.cat)]) t.cat = ROOT_ID;
+      if (t.cat == null) t.cat = ROOT_ID;
 
       // break cycles: follow parentTask chain and cut if we loop
       if (t.parentTask != null){
@@ -2185,11 +2212,17 @@ function repairMaintenanceGraph(){
         }
       }
 
+      if (t.parentTask == null && (t.cat == null || !fMap[String(t.cat)])){
+        t.cat = ROOT_ID;
+      }
+
       // numeric 'order' normalization (optional but stabilizes rendering)
       if (!isFinite(t.order)) t.order = 0;
+      if (t.cat != null) t.cat = String(t.cat);
     }
     for (const f of window.settingsFolders){
       if (!isFinite(f.order)) f.order = 0;
+      if (f.parent != null) f.parent = String(f.parent);
     }
   }catch(err){
     console.warn("repairMaintenanceGraph failed:", err);
@@ -2216,6 +2249,10 @@ function moveNodeSafely(kind, nodeId, target){
   window.maintenanceSearchTerm = typeof window.maintenanceSearchTerm === "string"
     ? window.maintenanceSearchTerm
     : "";
+
+  const ROOT_ID = (typeof window !== "undefined" && window.ROOT_FOLDER_ID)
+    ? String(window.ROOT_FOLDER_ID)
+    : "root";
 
   // ---------- Helpers: tasks ----------
   function findTaskMeta(id){
@@ -2345,7 +2382,7 @@ function moveNodeSafely(kind, nodeId, target){
   }
 
   function ensureFolder(catId){
-    if (catId == null) return true;
+    if (catId == null) return window.settingsFolders.some(f => String(f.id) === ROOT_ID);
     return window.settingsFolders.some(f => String(f.id) === String(catId));
   }
 
@@ -2414,13 +2451,14 @@ function moveNodeSafely(kind, nodeId, target){
     }
 
     if (Object.prototype.hasOwnProperty.call(target || {}, "intoCat")){
-      const catId = target.intoCat;
+      const rawCat = target.intoCat;
+      const catId = rawCat == null ? ROOT_ID : rawCat;
       if (!ensureFolder(catId)) return false;
 
       const place = target && target.position === "end" ? "end" : "start";
       const nextOrder = nextTaskOrder(catId ?? null, null, src.task.id, place);
 
-      src.task.cat = catId ?? null;
+      src.task.cat = catId;
       src.task.parentTask = null;
       src.task.order = nextOrder;
       if (isFinite(Number(nextOrder))) {
@@ -2440,21 +2478,31 @@ function moveNodeSafely(kind, nodeId, target){
     const cat = findCat(nodeId);
     if (!cat) return false;
     const originalParent = cat.parent || null;
+    const catId = String(cat.id);
+
+    if (catId === ROOT_ID && target && Object.prototype.hasOwnProperty.call(target || {}, "intoCat") && target.intoCat != null){
+      return false;
+    }
 
     if (Object.prototype.hasOwnProperty.call(target || {}, "intoCat")){
-      const parent = target.intoCat; // may be null → root
+      const rawParent = target.intoCat; // may be null → root
       // prevent cycles: cannot move into own descendant
-      let p = parent, hops = 0;
+      let p = rawParent, hops = 0;
       while (p != null && hops++ < 1000){
         if (String(p) === String(cat.id)) return false;
         p = findCat(p)?.parent ?? null;
       }
-      if (parent != null && !findCat(parent)) return false;
+      const parent = rawParent == null ? ROOT_ID : rawParent;
+      if (parent != null && String(parent) !== ROOT_ID && !findCat(parent)) return false;
 
       const place = target && target.position === "end" ? "end" : "start";
       const nextOrder = nextMixedOrder(parent ?? null, null, cat.id, place);
 
-      cat.parent = parent || null;
+      if (catId === ROOT_ID){
+        cat.parent = null;
+      }else{
+        cat.parent = parent == null ? ROOT_ID : parent;
+      }
       cat.order  = nextOrder;
       if (isFinite(Number(nextOrder))) {
         window._maintOrderCounter = Math.max(window._maintOrderCounter, Number(nextOrder));
@@ -2470,7 +2518,8 @@ function moveNodeSafely(kind, nodeId, target){
       const sib = findCat(target.beforeCat.id);
       if (!sib) return false;
 
-      cat.parent = sib.parent || null;
+      if (catId === ROOT_ID) return false;
+      cat.parent = sib.parent == null ? ROOT_ID : sib.parent;
       // Place "just before" by giving a slightly higher order, then normalize
       cat.order = (Number(sib.order)||0) + 0.5;
       normalizeFolderOrder(cat.parent);
@@ -2484,7 +2533,8 @@ function moveNodeSafely(kind, nodeId, target){
       const dest = findTaskMeta(target.beforeTask.id);
       if (!dest || dest.task.parentTask != null) return false;
 
-      cat.parent = dest.task.cat ?? null;
+      if (catId === ROOT_ID) return false;
+      cat.parent = dest.task.cat == null ? ROOT_ID : dest.task.cat;
       cat.order = (Number(dest.task.order)||0) + 0.5;
       normalizeFolderOrder(cat.parent);
       normalizeFolderOrder(originalParent);
@@ -3356,7 +3406,8 @@ function renderSettings(){
   document.getElementById("btnAddCategory")?.addEventListener("click", ()=>{
     const name = prompt("Category name?");
     if (!name) return;
-    const cat = { id: name.toLowerCase().replace(/[^a-z0-9]+/g,"_")+"_"+Math.random().toString(36).slice(2,7), name, parent:null, order: ++window._maintOrderCounter };
+    const rootId = (typeof window !== "undefined" && typeof window.ROOT_FOLDER_ID === "string") ? window.ROOT_FOLDER_ID : "root";
+    const cat = { id: name.toLowerCase().replace(/[^a-z0-9]+/g,"_")+"_"+Math.random().toString(36).slice(2,7), name, parent: rootId, order: ++window._maintOrderCounter };
     window.settingsFolders.push(cat);
     persist();
     renderSettings();
@@ -3412,7 +3463,9 @@ function renderSettings(){
     const name = (data.get("taskName")||"").toString().trim();
     const mode = (data.get("taskType")||"interval").toString();
     if (!name){ alert("Task name is required."); return; }
-    const catId = (data.get("taskCategory")||"").toString().trim() || null;
+    const rootId = (typeof window !== "undefined" && typeof window.ROOT_FOLDER_ID === "string") ? window.ROOT_FOLDER_ID : "root";
+    const catRaw = (data.get("taskCategory")||"").toString().trim();
+    const catId = catRaw ? catRaw : rootId;
     const manual = (data.get("taskManual")||"").toString().trim();
     const store = (data.get("taskStore")||"").toString().trim();
     const pn = (data.get("taskPN")||"").toString().trim();

--- a/js/views.js
+++ b/js/views.js
@@ -465,6 +465,11 @@ function renderSettingsCategoriesPane(){
 
   // Save helpers (support local + cloud)
   function persist(){
+    if (typeof setSettingsFolders === "function") {
+      try { setSettingsFolders(window.settingsFolders); } catch (err) {
+        console.warn("Failed to sync folders before save", err);
+      }
+    }
     if (typeof saveTasks === "function") { try { saveTasks(); } catch(_){} }
     if (typeof saveCloudDebounced === "function") { try { saveCloudDebounced(); } catch(_){} }
   }


### PR DESCRIPTION
## Summary
- add normalization helpers for maintenance folders and include them in saved snapshots
- keep folder order counters and persisted state in sync when adopting or loading cloud data
- update settings UI persistence to normalize folders before saving

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d57512aad88325bca7f894dd0767f3