### PR TITLE
Improve cost analysis chart auto-resizing

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -103,6 +103,10 @@ function route(){
   }
 
   function renderByHash(norm){
+    if (typeof teardownCostChartAutoResize === "function"){
+      try { teardownCostChartAutoResize(); }
+      catch (err){ console.warn(err); }
+    }
     if (norm === "#/settings")      { renderSettings();   return; }
     if (norm === "#/jobs")          { renderJobs();       return; }
     if (norm === "#/costs")         { renderCosts();      return; }


### PR DESCRIPTION
## Summary
- add a reusable auto-resize helper for the cost analysis chart using ResizeObserver and layout events
- update the cost renderer to use the helper and refresh size snapshots after draws
- clear chart resize listeners when routes change to avoid leaks and ensure clean re-inits

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d58b3bae608325b18de02a6983b0f1