### PR TITLE
Fix maintenance modal overlapping footer

### DIFF
--- a/style.css
+++ b/style.css
@@ -676,6 +676,13 @@ h1 { margin: 0 0 10px; font-size: 22px; }
   position: sticky;
   bottom: 0;
   z-index: 900;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+body.modal-open .auth-bar {
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(110%);
 }
 
 .auth-bar #authStatus {

--- a/style.css
+++ b/style.css
@@ -635,12 +635,16 @@ main::after {
 
 footer {
   position: relative;
-  z-index: 1;
+  z-index: 0;
   padding: 20px 16px;
   text-align: center;
   color: rgba(241, 245, 255, 0.78);
   background: linear-gradient(135deg, rgba(4, 28, 74, 0.92), rgba(13, 63, 145, 0.85));
   box-shadow: 0 -12px 30px rgba(0, 17, 46, 0.4);
+}
+
+body.modal-open footer {
+  pointer-events: none;
 }
 
 .folder-dropzone {


### PR DESCRIPTION
## Summary
- lower the footer stacking context so maintenance modals can overlay the page
- disable footer pointer events while modals are open to prevent it from blocking dialogs

## Testing
- not run (not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d58f20917c8325a8fdb353c6180fd0