### PR TITLE
Update calendar day add button to open picker

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -387,7 +387,7 @@ function renderCalendar(){
       addBtn.setAttribute("aria-label", `Add item on ${date.toDateString()}`);
       addBtn.addEventListener("click", (ev)=>{
         ev.stopPropagation();
-        triggerDashboardAddPicker({ dateISO: key, step: "task" });
+        triggerDashboardAddPicker({ dateISO: key });
       });
       addBtn.addEventListener("focus", ()=> addBtn.classList.add("is-visible"));
       addBtn.addEventListener("blur", ()=> addBtn.classList.remove("is-visible"));


### PR DESCRIPTION
## Summary
- update the calendar day add button to open the add picker instead of defaulting to task creation
- preserve the selected calendar date so downtime selections autofill the chosen day

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5956d31e08325af2326d4bf9ddf2f