### PR TITLE
Hide All Tasks label in maintenance settings

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -349,7 +349,7 @@ window.defaultIntervalTasks = defaultIntervalTasks;
 const ROOT_FOLDER_ID = "root";
 window.ROOT_FOLDER_ID = ROOT_FOLDER_ID;
 const DEFAULT_SETTINGS_FOLDERS = [
-  { id: ROOT_FOLDER_ID, name: "All Tasks",    parent: null,           order: 3 },
+  { id: ROOT_FOLDER_ID, name: "",             parent: null,           order: 3 },
   { id: "interval",    name: "Per Interval", parent: ROOT_FOLDER_ID, order: 2 },
   { id: "asreq",       name: "As Required",  parent: ROOT_FOLDER_ID, order: 1 }
 ];

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -2205,7 +2205,7 @@ function repairMaintenanceGraph(){
 
     if (!window.settingsFolders.some(f => f && String(f.id) === ROOT_ID)){
       const fallbackOrder = Number(window._maintOrderCounter) || 0;
-      window.settingsFolders.push({ id: ROOT_ID, name: "All Tasks", parent: null, order: fallbackOrder + 1 });
+      window.settingsFolders.push({ id: ROOT_ID, name: "", parent: null, order: fallbackOrder + 1 });
       window._maintOrderCounter = Math.max(Number(window._maintOrderCounter) || 0, fallbackOrder + 1);
     }
 


### PR DESCRIPTION
## Summary
- remove the default "All Tasks" label from the maintenance settings root folder so it no longer renders in the UI
- ensure any fallback initialization also uses a blank name to keep functionality unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d59603927083259a60d1bcf41b14f7