### PR TITLE
Adjust combined impact calculation

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -5227,8 +5227,8 @@ function computeCostModel(){
     {
       icon: "📊",
       title: "Combined estimated impact",
-      value: formatterCurrency(predictedAnnual + totalGainLoss, { decimals: 0, showPlus: true }),
-      hint: "Maintenance forecast plus cutting job efficiency impact."
+      value: formatterCurrency(totalGainLoss - predictedAnnual, { decimals: 0, showPlus: true }),
+      hint: "Cutting job efficiency impact minus the maintenance forecast (cost treated as negative)."
     }
   ];
 


### PR DESCRIPTION
## Summary
- treat the maintenance forecast as a negative cost when computing the combined estimated impact card
- update the card hint to clarify that the maintenance forecast is subtracted from cutting job efficiency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d6ce00c483259b64591e5f4d5e0e