### PR TITLE
Add shortcut from cost analysis to cutting job history

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -4573,6 +4573,30 @@ function renderCosts(){
   const canvasWrap = content.querySelector(".cost-chart-canvas");
   let tooltipEl = canvasWrap ? canvasWrap.querySelector(".cost-chart-tooltip") : null;
 
+  const jobsHistoryLink = content.querySelector("[data-cost-jobs-history]");
+  if (jobsHistoryLink){
+    const goToJobsHistory = ()=>{
+      window.pendingJobHistoryFocus = true;
+      const targetHash = "#/jobs";
+      if (location.hash !== targetHash){
+        location.hash = targetHash;
+      }else{
+        renderJobs();
+      }
+    };
+    const activateHistoryLink = (event)=>{
+      event.preventDefault();
+      event.stopPropagation();
+      goToJobsHistory();
+    };
+    jobsHistoryLink.addEventListener("click", activateHistoryLink);
+    jobsHistoryLink.addEventListener("keydown", (event)=>{
+      if (event.key === "Enter" || event.key === " "){
+        activateHistoryLink(event);
+      }
+    });
+  }
+
   const escapeTooltip = (value)=> String(value ?? "").replace(/[&<>"']/g, c => ({
     "&": "&amp;",
     "<": "&lt;",
@@ -5560,32 +5584,44 @@ function renderJobs(){
   // 1) Render the jobs view (includes the table with the Actions column)
   content.innerHTML = viewJobs();
 
+  const focusPastJobs = ()=>{
+    const target = document.getElementById("pastJobs");
+    if (!target) return;
+    const restoreTabindex = !target.hasAttribute("tabindex");
+    if (restoreTabindex){
+      target.setAttribute("tabindex", "-1");
+      target.dataset.tempTabindex = "1";
+    }
+    target.scrollIntoView({ behavior: "smooth", block: "start" });
+    try {
+      target.focus({ preventScroll: true });
+    } catch (_) {
+      // Fallback focus handling for browsers without focus options
+      target.focus();
+    }
+    if (restoreTabindex){
+      const cleanup = ()=>{
+        if (!target.dataset.tempTabindex) return;
+        delete target.dataset.tempTabindex;
+        target.removeAttribute("tabindex");
+      };
+      target.addEventListener("blur", ()=> cleanup(), { once: true });
+      setTimeout(()=> cleanup(), 1500);
+    }
+  };
+
   const historyBtn = content.querySelector("[data-job-history-trigger]");
   if (historyBtn){
-    historyBtn.addEventListener("click", ()=>{
-      const target = document.getElementById("pastJobs");
-      if (!target) return;
-      const restoreTabindex = !target.hasAttribute("tabindex");
-      if (restoreTabindex){
-        target.setAttribute("tabindex", "-1");
-        target.dataset.tempTabindex = "1";
-      }
-      target.scrollIntoView({ behavior: "smooth", block: "start" });
-      try {
-        target.focus({ preventScroll: true });
-      } catch (_) {
-        // Fallback focus handling for browsers without focus options
-        target.focus();
-      }
-      if (restoreTabindex){
-        const cleanup = ()=>{
-          if (!target.dataset.tempTabindex) return;
-          delete target.dataset.tempTabindex;
-          target.removeAttribute("tabindex");
-        };
-        target.addEventListener("blur", ()=> cleanup(), { once: true });
-        setTimeout(()=> cleanup(), 1500);
-      }
+    historyBtn.addEventListener("click", (event)=>{
+      event.preventDefault();
+      focusPastJobs();
+    });
+  }
+
+  if (window.pendingJobHistoryFocus){
+    delete window.pendingJobHistoryFocus;
+    requestAnimationFrame(()=>{
+      focusPastJobs();
     });
   }
 

--- a/js/views.js
+++ b/js/views.js
@@ -907,7 +907,7 @@ function viewCosts(model){
             <h3>Estimated Cost Trends</h3>
             <div class="cost-chart-toggle">
               <label><input type="checkbox" id="toggleCostMaintenance" checked> <span class="dot" style="background:${esc(chartColors.maintenance)}"></span> Maintenance</label>
-              <label><input type="checkbox" id="toggleCostJobs" checked> <span class="dot" style="background:${esc(chartColors.jobs)}"></span> Cutting jobs</label>
+              <label class="cost-chart-toggle-jobs"><input type="checkbox" id="toggleCostJobs" checked> <span class="dot" style="background:${esc(chartColors.jobs)}"></span> <span class="cost-chart-toggle-link" data-cost-jobs-history role="link" tabindex="0">Cutting jobs</span></label>
             </div>
           </div>
           <div class="cost-chart-canvas">

--- a/style.css
+++ b/style.css
@@ -132,6 +132,9 @@ body.pump-chart-expanded { overflow:hidden; }
 .cost-chart-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:8px; }
 .cost-chart-toggle{ display:flex; gap:12px; flex-wrap:wrap; font-size:13px; color:#333; }
 .cost-chart-toggle label{ display:flex; align-items:center; gap:6px; cursor:pointer; }
+.cost-chart-toggle-jobs{ gap:6px; }
+.cost-chart-toggle-link{ cursor:pointer; text-decoration:underline; color:inherit; }
+.cost-chart-toggle-link:focus-visible{ outline:2px solid #0a63c2; outline-offset:2px; border-radius:2px; }
 .cost-chart-toggle .dot{ display:inline-block; width:12px; height:12px; border-radius:999px; }
 .cost-chart-canvas { position: relative; }
 .cost-chart-canvas canvas { width: 100%; height: auto; display: block; }


### PR DESCRIPTION
## Summary
- add a dedicated link on the cost analysis page to jump to cutting job history
- focus the past jobs section automatically when the shortcut is used
- style the new shortcut to look and behave like an accessible link

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6d734ff6c832596354e3328cc38a3