### PR TITLE
Link maintenance history events to maintenance tasks

### DIFF
--- a/js/views.js
+++ b/js/views.js
@@ -970,13 +970,23 @@ function viewCosts(model){
           <h3>Recent Maintenance Events</h3>
           ${historyRows.length ? `
             <ul class="cost-history">
-              ${historyRows.map(item => `
-                <li>
-                  <span>${esc(item.dateLabel || "")}</span>
-                  <span>${esc(item.hoursLabel || "")}</span>
-                  <span>${esc(item.costLabel || "")}</span>
-                </li>
-              `).join("")}
+              ${historyRows.map(item => {
+                const hasTask = item.taskId && String(item.taskId).trim().length;
+                const jobLabel = item.jobLabel || "—";
+                const attrs = hasTask
+                  ? `type="button" class="cost-history-entry" data-maintenance-task-id="${esc(item.taskId)}"`
+                  : `type="button" class="cost-history-entry" disabled`;
+                return `
+                  <li>
+                    <button ${attrs}>
+                      <span class="cost-history-date">${esc(item.dateLabel || "")}</span>
+                      <span class="cost-history-job">${esc(jobLabel)}</span>
+                      <span class="cost-history-hours">${esc(item.hoursLabel || "")}</span>
+                      <span class="cost-history-cost">${esc(item.costLabel || "")}</span>
+                    </button>
+                  </li>
+                `;
+              }).join("")}
             </ul>
           ` : `<p class="small muted">${esc(data.historyEmpty || "No usage history yet. Log machine hours to estimate maintenance spend.")}</p>`}
         </div>

--- a/style.css
+++ b/style.css
@@ -202,9 +202,11 @@ body.pump-chart-expanded { overflow:hidden; }
 .cost-table th{ background:#f4f7fb; font-weight:600; color:#3b475f; }
 
 .cost-history{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:8px; }
-.cost-history li{
+.cost-history li{ margin:0; padding:0; }
+.cost-history-entry{
+  width:100%;
   display:grid;
-  grid-template-columns:repeat(3,minmax(0,1fr));
+  grid-template-columns:minmax(0,1fr) minmax(0,1.2fr) minmax(0,0.8fr) minmax(0,0.8fr);
   gap:8px;
   padding:10px 12px;
   background:rgba(255, 255, 255, 0.75);
@@ -212,8 +214,22 @@ body.pump-chart-expanded { overflow:hidden; }
   border-radius:12px;
   font-variant-numeric:tabular-nums;
   box-shadow:0 12px 24px rgba(6, 24, 64, 0.18);
+  text-align:left;
+  color:inherit;
+  font:inherit;
+  cursor:pointer;
+  transition:box-shadow .15s ease, transform .15s ease;
 }
-.cost-history span:last-child{ text-align:right; font-weight:600; color:var(--brand-blue-400); }
+.cost-history-entry:hover:not(:disabled){
+  box-shadow:0 16px 28px rgba(6, 24, 64, 0.22);
+  transform:translateY(-1px);
+}
+.cost-history-entry:disabled{
+  cursor:default;
+  opacity:0.7;
+}
+.cost-history-entry span:last-child{ text-align:right; font-weight:600; color:var(--brand-blue-400); }
+.cost-history-job{ font-weight:600; color:#1e2b45; }
 
 .cost-jobs-summary{ display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:8px; margin-bottom:10px; font-variant-numeric:tabular-nums; }
 .cost-jobs-summary .label{ display:block; font-size:12px; text-transform:uppercase; letter-spacing:.04em; color:#5a6478; margin-bottom:2px; }


### PR DESCRIPTION
## Summary
- show maintenance job names in the Recent Maintenance Events list on the Costs page
- make cost history entries clickable so they open the related maintenance task in Settings
- refresh styling so the new job column looks and feels interactive

## Testing
- No automated tests (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6d7f126c083259aa68810cd28a3f1