### PR TITLE
Add info bubble to cost trend chart

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -5260,6 +5260,7 @@ function computeCostModel(){
   const jobEmpty = "Add cutting jobs with estimates to build the efficiency tracker.";
 
   const chartNote = `Maintenance line allocates interval pricing plus as-required spend per logged hour (${asReqAnnualActual > 0 ? "derived from approved orders" : "using task estimates when orders are unavailable"}); cutting jobs line shows the rolling average gain/loss at ${formatterCurrency(JOB_RATE_PER_HOUR, { decimals: 0 })}/hr.`;
+  const chartInfo = "Maintenance trend distributes interval task pricing and approved as-required spend across each logged machine hour so you can monitor burn rate, while the cutting jobs trend plots rolling average gain or loss to highlight profitability swings.";
 
   const orderSorted = orderHistory.slice().sort((a,b)=>{
     const aTime = new Date(a.resolvedAt || a.createdAt || 0).getTime();
@@ -5312,6 +5313,7 @@ function computeCostModel(){
     maintenanceJobsNote,
     maintenanceJobsEmpty,
     chartNote,
+    chartInfo,
     orderRequestSummary,
     chartColors: COST_CHART_COLORS,
     maintenanceSeries,

--- a/js/views.js
+++ b/js/views.js
@@ -825,6 +825,7 @@ function viewCosts(model){
   const maintenanceJobsNote = data.maintenanceJobsNote || "";
   const maintenanceJobsEmpty = data.maintenanceJobsEmpty || "";
   const chartColors = data.chartColors || { maintenance:"#0a63c2", jobs:"#2e7d32" };
+  const chartInfo = data.chartInfo || "Maintenance cost line spreads interval pricing and approved as-required spend across logged machine hours; cutting jobs line tracks the rolling average gain or loss per completed job to spotlight margin drift.";
   const orderSummary = data.orderRequestSummary || {};
   const orderRows = Array.isArray(orderSummary.rows) ? orderSummary.rows : [];
 
@@ -904,7 +905,18 @@ function viewCosts(model){
       <div class="dashboard-window" data-cost-window="chart">
         <div class="block cost-chart-block">
           <div class="cost-chart-header">
-            <h3>Estimated Cost Trends</h3>
+            <div class="cost-chart-title">
+              <h3>Estimated Cost Trends</h3>
+              <div class="chart-info">
+                <button type="button" class="chart-info-button" aria-describedby="costChartInfo" aria-label="Explain Estimated Cost Trends">
+                  <span aria-hidden="true">?</span>
+                  <span class="sr-only">Show how the Estimated Cost Trends chart is calculated</span>
+                </button>
+                <div class="chart-info-bubble" id="costChartInfo" role="tooltip">
+                  <p>${esc(chartInfo)}</p>
+                </div>
+              </div>
+            </div>
             <div class="cost-chart-toggle">
               <label><input type="checkbox" id="toggleCostMaintenance" checked> <span class="dot" style="background:${esc(chartColors.maintenance)}"></span> Maintenance</label>
               <label><input type="checkbox" id="toggleCostJobs" checked> <span class="dot" style="background:${esc(chartColors.jobs)}"></span> Cutting jobs</label>

--- a/style.css
+++ b/style.css
@@ -130,11 +130,22 @@ body.pump-chart-expanded { overflow:hidden; }
 .cost-card-hint{ color:#1e3352; font-size:12px; opacity:0.7; }
 
 .cost-chart-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:8px; }
+.cost-chart-title{ display:flex; align-items:center; gap:8px; }
 .cost-chart-toggle{ display:flex; gap:12px; flex-wrap:wrap; font-size:13px; color:#333; }
 .cost-chart-toggle label{ display:flex; align-items:center; gap:6px; cursor:pointer; }
 .cost-chart-toggle .dot{ display:inline-block; width:12px; height:12px; border-radius:999px; }
 .cost-chart-canvas { position: relative; }
 .cost-chart-canvas canvas { width: 100%; height: auto; display: block; }
+.chart-info{ position:relative; display:inline-flex; align-items:center; }
+.chart-info-button{ display:inline-flex; align-items:center; justify-content:center; width:24px; height:24px; border-radius:999px; border:1px solid rgba(19, 41, 74, 0.2); background:#f4f7fb; color:#0b2e6b; font-size:14px; line-height:1; cursor:pointer; transition:background 0.2s ease, color 0.2s ease, border-color 0.2s ease; }
+.chart-info-button:hover{ background:#e7efff; color:#08204a; border-color:rgba(19, 41, 74, 0.35); }
+.chart-info-button:focus-visible{ outline:2px solid rgba(11, 46, 107, 0.5); outline-offset:2px; }
+.chart-info-bubble{ position:absolute; top:calc(100% + 10px); left:0; min-width:220px; max-width:320px; padding:10px 12px; background:#fff; border:1px solid rgba(19, 41, 74, 0.2); border-radius:8px; box-shadow:0 8px 24px rgba(15, 51, 110, 0.18); color:#1e3352; font-size:13px; line-height:1.5; z-index:20; opacity:0; transform:translateY(6px); pointer-events:none; transition:opacity 0.16s ease, transform 0.16s ease; }
+.chart-info-bubble::before{ content:""; position:absolute; top:-6px; left:16px; width:12px; height:12px; background:#fff; border-left:1px solid rgba(19, 41, 74, 0.2); border-top:1px solid rgba(19, 41, 74, 0.2); transform:rotate(45deg); }
+.chart-info:hover .chart-info-bubble,
+.chart-info:focus-within .chart-info-bubble{ opacity:1; transform:translateY(0); pointer-events:auto; }
+.chart-info-bubble p{ margin:0; }
+.sr-only{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
 .cost-chart-tooltip{
   position:absolute;
   pointer-events:none;


### PR DESCRIPTION
## Summary
- add an accessible info bubble to the Estimated Cost Trends chart so viewers can understand the calculation
- provide renderer data and styling to support the new tooltip across the cost analysis layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6d826ebc483258abe345fccacf5bc