### PR TITLE
Add contextual insights to cost dashboard

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -5548,6 +5548,7 @@ function computeCostModel(){
   const jobEmpty = "Add cutting jobs with estimates to build the efficiency tracker.";
 
   const chartNote = `Maintenance line allocates interval pricing plus as-required spend per logged hour (${asReqAnnualActual > 0 ? "derived from approved orders" : "using task estimates when orders are unavailable"}); cutting jobs line shows the rolling average gain/loss at ${formatterCurrency(JOB_RATE_PER_HOUR, { decimals: 0 })}/hr.`;
+  const chartInfo = "Maintenance trend distributes interval task pricing and approved as-required spend across each logged machine hour so you can monitor burn rate, while the cutting jobs trend plots rolling average gain or loss to highlight profitability swings.";
 
   const orderSorted = orderHistory.slice().sort((a,b)=>{
     const aTime = new Date(a.resolvedAt || a.createdAt || 0).getTime();
@@ -5601,6 +5602,7 @@ function computeCostModel(){
     maintenanceJobsNote,
     maintenanceJobsEmpty,
     chartNote,
+    chartInfo,
     orderRequestSummary,
     chartColors: COST_CHART_COLORS,
     maintenanceSeries,

--- a/js/views.js
+++ b/js/views.js
@@ -825,8 +825,15 @@ function viewCosts(model){
   const maintenanceJobsNote = data.maintenanceJobsNote || "";
   const maintenanceJobsEmpty = data.maintenanceJobsEmpty || "";
   const chartColors = data.chartColors || { maintenance:"#0a63c2", jobs:"#2e7d32" };
+  const chartInfo = data.chartInfo || "Maintenance cost line spreads interval pricing and approved as-required spend across logged machine hours; cutting jobs line tracks the rolling average gain or loss per completed job to spotlight margin drift.";
   const orderSummary = data.orderRequestSummary || {};
   const orderRows = Array.isArray(orderSummary.rows) ? orderSummary.rows : [];
+  const overviewInsight = data.overviewInsight || "Totals blend the latest maintenance allocations, consumable burn rates, downtime burdens, and job margin data so you always see current cost exposure.";
+  const ordersInsight = data.ordersInsight || "Tracks every waterjet part request from submission through approval so finance can confirm spend and spot stalled orders.";
+  const timeframeInsight = data.timeframeInsight || "Usage windows combine logged machine hours with interval pricing to estimate what each upcoming maintenance window will cost.";
+  const historyInsight = data.historyInsight || "Shows the latest completed maintenance, combining hours logged and reconciled spend to highlight cost spikes.";
+  const maintenanceJobsInsight = data.maintenanceJobsInsight || "Lists maintenance jobs that need attention, including follow-up actions and any cost exceptions that still require confirmation.";
+  const efficiencyInsight = data.efficiencyInsight || "Summarizes cutting job profitability by tying revenue to labor, material, consumable, and overhead allocations so you can act on true margins.";
   const breakdown = data.forecastBreakdown || {};
   const breakdownSections = Array.isArray(breakdown.sections) ? breakdown.sections : [];
   const breakdownTotals = breakdown.totals || {};
@@ -1001,13 +1008,26 @@ function viewCosts(model){
           <div class="cost-summary-grid">
             ${summaryCardsHTML}
           </div>
+          <div class="cost-window-insight">
+            <div class="chart-info">
+              <button type="button" class="chart-info-button" aria-describedby="costOverviewInsight" aria-label="Explain Cost Overview metrics">
+                <span aria-hidden="true">?</span>
+                <span class="sr-only">Show how Cost Overview metrics are calculated</span>
+              </button>
+              <div class="chart-info-bubble" id="costOverviewInsight" role="tooltip">
+                <p>${esc(overviewInsight)}</p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
       <div class="dashboard-window" data-cost-window="chart">
         <div class="block cost-chart-block">
           <div class="cost-chart-header">
-            <h3>Estimated Cost Trends</h3>
+            <div class="cost-chart-title">
+              <h3>Estimated Cost Trends</h3>
+            </div>
             <div class="cost-chart-toggle">
               <label><input type="checkbox" id="toggleCostMaintenance" checked> <span class="dot" style="background:${esc(chartColors.maintenance)}"></span> Maintenance</label>
               <label><input type="checkbox" id="toggleCostJobs" checked> <span class="dot" style="background:${esc(chartColors.jobs)}"></span> Cutting jobs</label>
@@ -1017,6 +1037,17 @@ function viewCosts(model){
             <canvas id="costChart" width="780" height="240"></canvas>
           </div>
           ${data.chartNote ? `<p class="small muted">${esc(data.chartNote)}</p>` : `<p class="small muted">Toggle a line to explore how maintenance and job efficiency costs evolve over time.</p>`}
+          <div class="cost-window-insight">
+            <div class="chart-info">
+              <button type="button" class="chart-info-button" aria-describedby="costChartInfo" aria-label="Explain Estimated Cost Trends">
+                <span aria-hidden="true">?</span>
+                <span class="sr-only">Show how the Estimated Cost Trends chart is calculated</span>
+              </button>
+              <div class="chart-info-bubble" id="costChartInfo" role="tooltip">
+                <p>${esc(chartInfo)}</p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -1043,6 +1074,17 @@ function viewCosts(model){
               </tbody>
             </table>
           ` : `<p class="small muted">${esc(orderSummary.emptyMessage || "Approve or deny order requests to build the spend log.")}</p>`}
+          <div class="cost-window-insight">
+            <div class="chart-info">
+              <button type="button" class="chart-info-button" aria-describedby="costOrdersInsight" aria-label="Explain Waterjet Part Summary tracking">
+                <span aria-hidden="true">?</span>
+                <span class="sr-only">Show how the Waterjet Part Summary data is compiled</span>
+              </button>
+              <div class="chart-info-bubble" id="costOrdersInsight" role="tooltip">
+                <p>${esc(ordersInsight)}</p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -1065,6 +1107,17 @@ function viewCosts(model){
             </table>
           ` : `<p class="small muted">No usage windows yet. Log machine hours to calculate maintenance spending.</p>`}
           ${data.timeframeNote ? `<p class="small muted">${esc(data.timeframeNote)}</p>` : ""}
+          <div class="cost-window-insight">
+            <div class="chart-info">
+              <button type="button" class="chart-info-button" aria-describedby="costTimeframesInsight" aria-label="Explain Maintenance Cost Windows table">
+                <span aria-hidden="true">?</span>
+                <span class="sr-only">Show how Maintenance Cost Windows are generated</span>
+              </button>
+              <div class="chart-info-bubble" id="costTimeframesInsight" role="tooltip">
+                <p>${esc(timeframeInsight)}</p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -1082,6 +1135,17 @@ function viewCosts(model){
               `).join("")}
             </ul>
           ` : `<p class="small muted">${esc(data.historyEmpty || "No usage history yet. Log machine hours to estimate maintenance spend.")}</p>`}
+          <div class="cost-window-insight">
+            <div class="chart-info">
+              <button type="button" class="chart-info-button" aria-describedby="costHistoryInsight" aria-label="Explain Recent Maintenance Events list">
+                <span aria-hidden="true">?</span>
+                <span class="sr-only">Show how Recent Maintenance Events are curated</span>
+              </button>
+              <div class="chart-info-bubble" id="costHistoryInsight" role="tooltip">
+                <p>${esc(historyInsight)}</p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -1090,6 +1154,17 @@ function viewCosts(model){
           <h3>Maintenance Job Tracker</h3>
           ${maintenanceJobsNote ? `<p class="small muted">${esc(maintenanceJobsNote)}</p>` : ""}
           ${maintenanceJobsEmpty ? `<p class="small muted">${esc(maintenanceJobsEmpty)}</p>` : ""}
+          <div class="cost-window-insight">
+            <div class="chart-info">
+              <button type="button" class="chart-info-button" aria-describedby="costJobsInsight" aria-label="Explain Maintenance Job Tracker">
+                <span aria-hidden="true">?</span>
+                <span class="sr-only">Show how the Maintenance Job Tracker should be used</span>
+              </button>
+              <div class="chart-info-bubble" id="costJobsInsight" role="tooltip">
+                <p>${esc(maintenanceJobsInsight)}</p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -1117,6 +1192,17 @@ function viewCosts(model){
               </tbody>
             </table>
           ` : `<p class="small muted">${esc(data.jobEmpty || "Add cutting jobs with estimates to build the efficiency tracker.")}</p>`}
+          <div class="cost-window-insight">
+            <div class="chart-info">
+              <button type="button" class="chart-info-button" aria-describedby="costEfficiencyInsight" aria-label="Explain Cutting Job Efficiency Snapshot">
+                <span aria-hidden="true">?</span>
+                <span class="sr-only">Show how the Cutting Job Efficiency Snapshot reveals margin trends</span>
+              </button>
+              <div class="chart-info-bubble" id="costEfficiencyInsight" role="tooltip">
+                <p>${esc(efficiencyInsight)}</p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -144,11 +144,26 @@ body.pump-chart-expanded { overflow:hidden; }
 .cost-card-hint{ color:#1e3352; font-size:12px; opacity:0.7; }
 
 .cost-chart-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:8px; }
+.cost-chart-title{ display:flex; align-items:center; gap:8px; }
 .cost-chart-toggle{ display:flex; gap:12px; flex-wrap:wrap; font-size:13px; color:#333; }
 .cost-chart-toggle label{ display:flex; align-items:center; gap:6px; cursor:pointer; }
 .cost-chart-toggle .dot{ display:inline-block; width:12px; height:12px; border-radius:999px; }
 .cost-chart-canvas { position: relative; }
 .cost-chart-canvas canvas { width: 100%; height: auto; display: block; }
+.chart-info{ position:relative; display:inline-flex; align-items:center; }
+.chart-info-button{ display:inline-flex; align-items:center; justify-content:center; width:24px; height:24px; border-radius:999px; border:1px solid rgba(19, 41, 74, 0.2); background:#f4f7fb; color:#0b2e6b; font-size:14px; line-height:1; cursor:pointer; transition:background 0.2s ease, color 0.2s ease, border-color 0.2s ease; }
+.chart-info-button:hover{ background:#e7efff; color:#08204a; border-color:rgba(19, 41, 74, 0.35); }
+.chart-info-button:focus-visible{ outline:2px solid rgba(11, 46, 107, 0.5); outline-offset:2px; }
+.chart-info-bubble{ position:absolute; top:calc(100% + 10px); left:0; min-width:220px; max-width:320px; padding:10px 12px; background:#fff; border:1px solid rgba(19, 41, 74, 0.2); border-radius:8px; box-shadow:0 8px 24px rgba(15, 51, 110, 0.18); color:#1e3352; font-size:13px; line-height:1.5; z-index:20; opacity:0; transform:translateY(6px); pointer-events:none; transition:opacity 0.16s ease, transform 0.16s ease; }
+.chart-info-bubble::before{ content:""; position:absolute; top:-6px; left:16px; width:12px; height:12px; background:#fff; border-left:1px solid rgba(19, 41, 74, 0.2); border-top:1px solid rgba(19, 41, 74, 0.2); transform:rotate(45deg); }
+.chart-info:hover .chart-info-bubble,
+.chart-info:focus-within .chart-info-bubble{ opacity:1; transform:translateY(0); pointer-events:auto; }
+.chart-info-bubble p{ margin:0; }
+.cost-window-insight{ margin-top:16px; display:flex; justify-content:flex-end; }
+.cost-window-insight .chart-info{ margin-left:auto; }
+.cost-window-insight .chart-info-bubble{ top:auto; bottom:calc(100% + 10px); left:auto; right:0; transform:translateY(-6px); }
+.cost-window-insight .chart-info-bubble::before{ top:auto; bottom:-6px; left:auto; right:16px; border-left:1px solid rgba(19, 41, 74, 0.2); border-top:0; border-right:0; border-bottom:1px solid rgba(19, 41, 74, 0.2); }
+.sr-only{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
 .cost-chart-tooltip{
   position:absolute;
   pointer-events:none;


### PR DESCRIPTION
## Summary
- add reusable tooltip styling for chart info buttons and accessibility helpers
- surface descriptive insight bubbles across cost overview sections to explain metrics and tables
- feed chart tooltip copy from cost model so UI messaging stays in sync with underlying data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f87795388325b716a4060264dc54