### PR TITLE
Remove recent maintenance events section from cost analysis view

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -5546,12 +5546,6 @@ function computeCostModel(){
     }
   };
 
-  const historyRows = maintenanceHistory.slice(-6).reverse().map(entry => ({
-    dateLabel: entry.date.toLocaleDateString(),
-    hoursLabel: formatHours(entry.hours),
-    costLabel: formatterCurrency(entry.cost, { decimals: entry.cost < 1000 ? 2 : 0 })
-  }));
-
   const jobBreakdown = jobsInfo
     .slice()
     .sort((a,b)=> b.date - a.date)
@@ -5634,9 +5628,6 @@ function computeCostModel(){
   if (forecastBreakdown){
     forecastBreakdown.note = timeframeNote || "Add pricing to maintenance tasks and approve order requests to enrich the forecast.";
   }
-  const historyEmpty = parsedHistory.length
-    ? "Log additional machine hours to expand the maintenance cost timeline."
-    : "No usage history yet. Log machine hours to estimate maintenance spend.";
   const jobEmpty = "Add cutting jobs with estimates to build the efficiency tracker.";
 
   const chartNote = `Maintenance line allocates interval pricing plus as-required spend per logged hour (${asReqAnnualActual > 0 ? "derived from approved orders" : "using task estimates when orders are unavailable"}); cutting jobs line shows the rolling average gain/loss at ${formatterCurrency(JOB_RATE_PER_HOUR, { decimals: 0 })}/hr.`;
@@ -5685,8 +5676,6 @@ function computeCostModel(){
     timeframeRows,
     forecastBreakdown,
     timeframeNote,
-    historyRows,
-    historyEmpty,
     jobSummary,
     jobBreakdown,
     jobEmpty,

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -5546,6 +5546,12 @@ function computeCostModel(){
     }
   };
 
+  const historyRows = maintenanceHistory.slice(-6).reverse().map(entry => ({
+    dateLabel: entry.date.toLocaleDateString(),
+    hoursLabel: formatHours(entry.hours),
+    costLabel: formatterCurrency(entry.cost, { decimals: entry.cost < 1000 ? 2 : 0 })
+  }));
+
   const jobBreakdown = jobsInfo
     .slice()
     .sort((a,b)=> b.date - a.date)
@@ -5612,11 +5618,6 @@ function computeCostModel(){
       : formatterCurrency(0, { decimals: 0 })
   };
 
-  const maintenanceJobs = [];
-
-  const maintenanceJobsNote = "Maintenance job tracker will consolidate every job once the Jobs integration is complete.";
-  const maintenanceJobsEmpty = "Tracker setup is in progress. This space will list all maintenance jobs when the data wiring is finished.";
-
   let timeframeNote;
   if (maintenanceOrderItems.length){
     timeframeNote = "Actual spend combines interval allocations with approved maintenance orders matched to your task part numbers.";
@@ -5628,6 +5629,9 @@ function computeCostModel(){
   if (forecastBreakdown){
     forecastBreakdown.note = timeframeNote || "Add pricing to maintenance tasks and approve order requests to enrich the forecast.";
   }
+  const historyEmpty = parsedHistory.length
+    ? "Log additional machine hours to expand the maintenance cost timeline."
+    : "No usage history yet. Log machine hours to estimate maintenance spend.";
   const jobEmpty = "Add cutting jobs with estimates to build the efficiency tracker.";
 
   const chartNote = `Maintenance line allocates interval pricing plus as-required spend per logged hour (${asReqAnnualActual > 0 ? "derived from approved orders" : "using task estimates when orders are unavailable"}); cutting jobs line shows the rolling average gain/loss at ${formatterCurrency(JOB_RATE_PER_HOUR, { decimals: 0 })}/hr.`;
@@ -5676,12 +5680,11 @@ function computeCostModel(){
     timeframeRows,
     forecastBreakdown,
     timeframeNote,
+    historyRows,
+    historyEmpty,
     jobSummary,
     jobBreakdown,
     jobEmpty,
-    maintenanceJobs,
-    maintenanceJobsNote,
-    maintenanceJobsEmpty,
     chartNote,
     chartInfo,
     orderRequestSummary,

--- a/js/views.js
+++ b/js/views.js
@@ -819,10 +819,9 @@ function viewCosts(model){
 
   const cards = Array.isArray(data.summaryCards) ? data.summaryCards : [];
   const timeframeRows = Array.isArray(data.timeframeRows) ? data.timeframeRows : [];
+  const historyRows = Array.isArray(data.historyRows) ? data.historyRows : [];
   const jobBreakdown = Array.isArray(data.jobBreakdown) ? data.jobBreakdown : [];
   const jobSummary = data.jobSummary || { countLabel:"0", totalLabel:"$0", averageLabel:"$0", rollingLabel:"$0" };
-  const maintenanceJobsNote = data.maintenanceJobsNote || "";
-  const maintenanceJobsEmpty = data.maintenanceJobsEmpty || "";
   const chartColors = data.chartColors || { maintenance:"#0a63c2", jobs:"#2e7d32" };
   const chartInfo = data.chartInfo || "Maintenance cost line spreads interval pricing and approved as-required spend across logged machine hours; cutting jobs line tracks the rolling average gain or loss per completed job to spotlight margin drift.";
   const orderSummary = data.orderRequestSummary || {};
@@ -830,7 +829,7 @@ function viewCosts(model){
   const overviewInsight = data.overviewInsight || "Totals blend the latest maintenance allocations, consumable burn rates, downtime burdens, and job margin data so you always see current cost exposure.";
   const ordersInsight = data.ordersInsight || "Tracks every waterjet part request from submission through approval so finance can confirm spend and spot stalled orders.";
   const timeframeInsight = data.timeframeInsight || "Usage windows combine logged machine hours with interval pricing to estimate what each upcoming maintenance window will cost.";
-  const maintenanceJobsInsight = data.maintenanceJobsInsight || "Lists maintenance jobs that need attention, including follow-up actions and any cost exceptions that still require confirmation.";
+  const historyInsight = data.historyInsight || "Shows the latest completed maintenance, combining hours logged and reconciled spend to highlight cost spikes.";
   const efficiencyInsight = data.efficiencyInsight || "Summarizes cutting job profitability by tying revenue to labor, material, consumable, and overhead allocations so you can act on true margins.";
   const breakdown = data.forecastBreakdown || {};
   const breakdownSections = Array.isArray(breakdown.sections) ? breakdown.sections : [];
@@ -1128,19 +1127,28 @@ function viewCosts(model){
         </div>
       </div>
 
-      <div class="dashboard-window" data-cost-window="jobs">
+      <div class="dashboard-window" data-cost-window="history">
         <div class="block">
-          <h3>Maintenance Job Tracker</h3>
-          ${maintenanceJobsNote ? `<p class="small muted">${esc(maintenanceJobsNote)}</p>` : ""}
-          ${maintenanceJobsEmpty ? `<p class="small muted">${esc(maintenanceJobsEmpty)}</p>` : ""}
+          <h3>Recent Maintenance Events</h3>
+          ${historyRows.length ? `
+            <ul class="cost-history">
+              ${historyRows.map(item => `
+                <li>
+                  <span>${esc(item.dateLabel || "")}</span>
+                  <span>${esc(item.hoursLabel || "")}</span>
+                  <span>${esc(item.costLabel || "")}</span>
+                </li>
+              `).join("")}
+            </ul>
+          ` : `<p class="small muted">${esc(data.historyEmpty || "No usage history yet. Log machine hours to estimate maintenance spend.")}</p>`}
           <div class="cost-window-insight">
             <div class="chart-info">
-              <button type="button" class="chart-info-button" aria-describedby="costJobsInsight" aria-label="Explain Maintenance Job Tracker">
+              <button type="button" class="chart-info-button" aria-describedby="costHistoryInsight" aria-label="Explain Recent Maintenance Events list">
                 <span aria-hidden="true">?</span>
-                <span class="sr-only">Show how the Maintenance Job Tracker should be used</span>
+                <span class="sr-only">Show how Recent Maintenance Events are curated</span>
               </button>
-              <div class="chart-info-bubble" id="costJobsInsight" role="tooltip">
-                <p>${esc(maintenanceJobsInsight)}</p>
+              <div class="chart-info-bubble" id="costHistoryInsight" role="tooltip">
+                <p>${esc(historyInsight)}</p>
               </div>
             </div>
           </div>

--- a/js/views.js
+++ b/js/views.js
@@ -819,7 +819,6 @@ function viewCosts(model){
 
   const cards = Array.isArray(data.summaryCards) ? data.summaryCards : [];
   const timeframeRows = Array.isArray(data.timeframeRows) ? data.timeframeRows : [];
-  const historyRows = Array.isArray(data.historyRows) ? data.historyRows : [];
   const jobBreakdown = Array.isArray(data.jobBreakdown) ? data.jobBreakdown : [];
   const jobSummary = data.jobSummary || { countLabel:"0", totalLabel:"$0", averageLabel:"$0", rollingLabel:"$0" };
   const maintenanceJobsNote = data.maintenanceJobsNote || "";
@@ -831,7 +830,6 @@ function viewCosts(model){
   const overviewInsight = data.overviewInsight || "Totals blend the latest maintenance allocations, consumable burn rates, downtime burdens, and job margin data so you always see current cost exposure.";
   const ordersInsight = data.ordersInsight || "Tracks every waterjet part request from submission through approval so finance can confirm spend and spot stalled orders.";
   const timeframeInsight = data.timeframeInsight || "Usage windows combine logged machine hours with interval pricing to estimate what each upcoming maintenance window will cost.";
-  const historyInsight = data.historyInsight || "Shows the latest completed maintenance, combining hours logged and reconciled spend to highlight cost spikes.";
   const maintenanceJobsInsight = data.maintenanceJobsInsight || "Lists maintenance jobs that need attention, including follow-up actions and any cost exceptions that still require confirmation.";
   const efficiencyInsight = data.efficiencyInsight || "Summarizes cutting job profitability by tying revenue to labor, material, consumable, and overhead allocations so you can act on true margins.";
   const breakdown = data.forecastBreakdown || {};
@@ -1124,34 +1122,6 @@ function viewCosts(model){
               </button>
               <div class="chart-info-bubble" id="costTimeframesInsight" role="tooltip">
                 <p>${esc(timeframeInsight)}</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="dashboard-window" data-cost-window="history">
-        <div class="block">
-          <h3>Recent Maintenance Events</h3>
-          ${historyRows.length ? `
-            <ul class="cost-history">
-              ${historyRows.map(item => `
-                <li>
-                  <span>${esc(item.dateLabel || "")}</span>
-                  <span>${esc(item.hoursLabel || "")}</span>
-                  <span>${esc(item.costLabel || "")}</span>
-                </li>
-              `).join("")}
-            </ul>
-          ` : `<p class="small muted">${esc(data.historyEmpty || "No usage history yet. Log machine hours to estimate maintenance spend.")}</p>`}
-          <div class="cost-window-insight">
-            <div class="chart-info">
-              <button type="button" class="chart-info-button" aria-describedby="costHistoryInsight" aria-label="Explain Recent Maintenance Events list">
-                <span aria-hidden="true">?</span>
-                <span class="sr-only">Show how Recent Maintenance Events are curated</span>
-              </button>
-              <div class="chart-info-bubble" id="costHistoryInsight" role="tooltip">
-                <p>${esc(historyInsight)}</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove the Recent Maintenance Events dashboard window from the cost analysis page
- stop computing and returning history list data that is no longer rendered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7013b19a483258157d1137c15cf28