### PR TITLE
Fix cutting job required hours/day when no progress is logged

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -157,7 +157,7 @@ function showJobBubble(jobId, anchor){
     const money = Math.abs(showMoney).toFixed(2);
     const reqCell = (req.requiredPerDay === Infinity)
       ? `<span class="danger">Past due / no days remaining</span>`
-      : `${req.requiredPerDay.toFixed(2)} hr/day <span class="muted">(rem ${req.remainingHours.toFixed(1)} hr over ${req.remainingDays} day${req.remainingDays===1?"":"s"})</span>`;
+      : `${req.requiredPerDay.toFixed(2)} hr/day needed to meet goal <span class="muted">(rem ${req.remainingHours.toFixed(1)} hr over ${req.remainingDays} day${req.remainingDays===1?"":"s"})</span>`;
     const noteAuto = eff.usedAutoFromManual
       ? `<div class="small"><strong>Auto from last manual</strong>: continuing at ${DAILY_HOURS} hr/day.</div>`
       : (eff.usedFromStartAuto ? `<div class="small"><strong>Auto</strong>: assuming ${DAILY_HOURS} hr/day from start.</div>` : ``);

--- a/js/computations.js
+++ b/js/computations.js
@@ -137,9 +137,8 @@ function computeRequiredDaily(job){
   if (!job || !job.startISO || !job.dueISO) return { remainingHours:0, remainingDays:0, requiredPerDay:0 };
   const eff = computeJobEfficiency(job);
   const planned = Number(job.estimateHours) || 0;
-  const remainingHours = eff.actualRemaining != null
-    ? eff.actualRemaining
-    : Math.max(0, planned - eff.actualHours);
+  const actualForRequirement = eff.usedFromStartAuto ? 0 : eff.actualHours;
+  const remainingHours = Math.max(0, planned - actualForRequirement);
 
   const today = new Date(); today.setHours(0,0,0,0);
   const due   = parseDateLocal(job.dueISO);

--- a/js/views.js
+++ b/js/views.js
@@ -1408,7 +1408,7 @@ function viewJobs(){
     const remainingDisplay = formatHours(remainHrs);
     const needDisplay = req.requiredPerDay === Infinity
       ? '<span class="job-badge job-badge-overdue">Past due</span>'
-      : `${needPerDay} hr/day`;
+      : `${needPerDay} hr/day needed to meet goal`;
     const statusDisplay = [
       `<div class="job-status ${ahead ? 'job-status-ahead' : (behind ? 'job-status-behind' : 'job-status-onpace')}">${statusLabel}</div>`,
       statusDetail ? `<div class="job-status-detail">${statusDetail.trim()}</div>` : ''


### PR DESCRIPTION
## Summary
- prevent the required hours/day calculation from using the automatic 8 hr/day fallback when no cutting job progress has been logged
- base the daily requirement on the job estimate unless manual logs or machine totals provide actual hours

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68da95b53ef08325b851f562ebbbd281