### PR TITLE
Focus maintenance task when following dashboard shortcut

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -2370,11 +2370,19 @@ function openJobsEditor(jobId){
 
 
 function openSettingsAndReveal(taskId){
-  location.hash = "#/settings";
-  setTimeout(()=>{
-    const el = document.querySelector(`[data-task-id="${taskId}"]`);
-    if (el){ el.open = true; el.scrollIntoView({behavior:"smooth", block:"center"}); }
-  }, 60);
+  if (taskId == null) return;
+  const id = String(taskId);
+  if (!id) return;
+  if (typeof window !== "undefined"){
+    window.maintenanceSearchTerm = "";
+    window.pendingMaintenanceFocus = { taskIds: [id] };
+  }
+  const hash = (location.hash || "#").toLowerCase();
+  if (hash === "#/settings" || hash === "#settings"){
+    if (typeof renderSettings === "function") renderSettings();
+  }else{
+    location.hash = "#/settings";
+  }
 }
 
 // --- SAFETY: repair tasks/folders graph so Settings never crashes ---


### PR DESCRIPTION
## Summary
- reset the maintenance search and queue a pending focus when jumping from the dashboard
- rerender settings immediately when already on the settings view to reveal the requested task

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbda2ba7fc8325a77029e9bdffb2f5