### PR TITLE
Improve calendar month header contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -2139,12 +2139,13 @@ th { background: linear-gradient(135deg, rgba(9, 68, 165, 0.85), rgba(33, 182, 2
   backdrop-filter: blur(6px);
 }
 .month-header {
-  background: linear-gradient(135deg, rgba(9, 68, 165, 0.82), rgba(33, 182, 255, 0.65));
+  background: linear-gradient(135deg, #0a3d90, #1468c9);
   padding: 10px 16px;
   font-weight: bold;
   border-bottom: 1px solid rgba(255, 255, 255, 0.35);
-  color: #fff;
+  color: #f7fbff;
   letter-spacing: 0.04em;
+  text-shadow: 0 1px 3px rgba(7, 18, 42, 0.45);
 }
 .weekdays, .week { display: grid; grid-template-columns: repeat(7, 1fr); }
 .weekdays div {


### PR DESCRIPTION
## Summary
- darken the calendar month header gradient and add a subtle text shadow to boost readability

## Testing
- Manual QA via local browser

------
https://chatgpt.com/codex/tasks/task_e_68dbdb5d1c5c8325bf0aff4f7edbbc3a