### PR TITLE
Add material fields to new cutting job form

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -6414,11 +6414,18 @@ function renderJobs(){
     e.preventDefault();
     const name  = document.getElementById("jobName").value.trim();
     const est   = Number(document.getElementById("jobEst").value);
+    const material = document.getElementById("jobMaterial")?.value.trim() || "";
+    const materialCostRaw = document.getElementById("jobMaterialCost")?.value ?? "";
+    const materialQtyRaw = document.getElementById("jobMaterialQty")?.value ?? "";
     const start = document.getElementById("jobStart").value;
     const due   = document.getElementById("jobDue").value;
+    const materialCost = materialCostRaw === "" ? 0 : Number(materialCostRaw);
+    const materialQty = materialQtyRaw === "" ? 0 : Number(materialQtyRaw);
     if (!name || !isFinite(est) || est<=0 || !start || !due){ toast("Fill job fields."); return; }
+    if (!Number.isFinite(materialCost) || materialCost < 0){ toast("Enter a valid material cost."); return; }
+    if (!Number.isFinite(materialQty) || materialQty < 0){ toast("Enter a valid material quantity."); return; }
     const attachments = pendingNewJobFiles.map(f=>({ ...f }));
-    cuttingJobs.push({ id: genId(name), name, estimateHours:est, startISO:start, dueISO:due, material:"", notes:"", manualLogs:[], files:attachments });
+    cuttingJobs.push({ id: genId(name), name, estimateHours:est, startISO:start, dueISO:due, material, materialCost, materialQty, notes:"", manualLogs:[], files:attachments });
     pendingNewJobFiles.length = 0;
     saveCloudDebounced(); renderJobs();
   });

--- a/js/views.js
+++ b/js/views.js
@@ -1531,6 +1531,9 @@ function viewJobs(){
       <form id="addJobForm" class="mini-form">
         <input type="text" id="jobName" placeholder="Job name" required>
         <input type="number" id="jobEst" placeholder="Estimate (hrs)" required min="1">
+        <input type="text" id="jobMaterial" placeholder="Material">
+        <input type="number" id="jobMaterialCost" placeholder="Material cost ($)" min="0" step="0.01">
+        <input type="number" id="jobMaterialQty" placeholder="Material quantity" min="0" step="0.01">
         <input type="date" id="jobStart" required>
         <input type="date" id="jobDue" required>
         <button type="button" id="jobFilesBtn">Attach Files</button>


### PR DESCRIPTION
## Summary
- add material name, cost, and quantity inputs to the cutting jobs form
- persist the captured material details when creating a new cutting job

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68dbdbfede648325bae40f099c2d0892