### PR TITLE
Improve garnet bubble text contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -2285,14 +2285,15 @@ th { background: linear-gradient(135deg, rgba(9, 68, 165, 0.85), rgba(33, 182, 2
 .month, .week, .day { pointer-events: auto; }
 
 /* Bubble (hover popover) */
-.bubble {  
+.bubble {
   position: absolute; z-index: 9999; background: #fff; border: 1px solid #d8deea; border-radius: 10px;
   padding: 10px; min-width: 260px; box-shadow: 0 8px 16px rgba(0,0,0,.12);
+  color: #142544;
 }
-.bubble-title { font-weight: 700; margin-bottom: 6px; }
+.bubble-title { font-weight: 700; margin-bottom: 6px; color: #0b1f3d; }
 .bubble-kv { display: grid; grid-template-columns: 120px 1fr; gap: 6px; font-size: 13px; margin: 3px 0; }
-.bubble-kv span:first-child { color: #5a6478; font-weight: 600; }
-.bubble-kv span:last-child { color: #0a63c2; font-weight: 600; }
+.bubble-kv span:first-child { color: #3d4a63; font-weight: 600; }
+.bubble-kv span:last-child { color: #0b4c99; font-weight: 600; }
 .bubble-actions { margin-top: 8px; display:flex; gap:8px; flex-wrap: wrap; }
 
 /* Toast */


### PR DESCRIPTION
## Summary
- darkened the text styles used in calendar popover bubbles to improve garnet cleaning readability against the white background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdd2f59c0832589735eaddd4a8b7c