### PR TITLE
Add note to cutting jobs cost efficiency column

### DIFF
--- a/js/views.js
+++ b/js/views.js
@@ -1554,7 +1554,7 @@ function viewJobs(){
             <th>Hours remaining</th>
             <th>Needed / day</th>
             <th>Status</th>
-            <th>Projected impact</th>
+            <th>Projected impact<div class="small muted">log cutting hours to get accurate prediction</div></th>
             <th>Actions</th>
           </tr>
         </thead>

--- a/js/views.js
+++ b/js/views.js
@@ -1445,7 +1445,10 @@ function viewJobs(){
           <td class="job-col job-col-hours">${remainingDisplay}</td>
           <td class="job-col job-col-need">${needDisplay}</td>
           <td class="job-col job-col-status">${statusDisplay}</td>
-          <td class="job-col job-col-impact"><span class="job-impact ${impactClass}">${impactDisplay}</span></td>
+          <td class="job-col job-col-impact">
+            <span class="job-impact ${impactClass}">${impactDisplay}</span>
+            <div class="job-impact-note small muted">Log cutting hours to get accurate prediction</div>
+          </td>
           <td class="job-col job-col-actions">
             <div class="job-actions">
               <button data-log-job="${j.id}">Log time</button>
@@ -1554,7 +1557,7 @@ function viewJobs(){
             <th>Hours remaining</th>
             <th>Needed / day</th>
             <th>Status</th>
-            <th>Projected impact<div class="small muted">log cutting hours to get accurate prediction</div></th>
+            <th>Projected impact</th>
             <th>Actions</th>
           </tr>
         </thead>


### PR DESCRIPTION
## Summary
- add a reminder beneath the Projected impact column header on the Cutting Jobs page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbde1d70ac8325ab6438345a98e0da