### PR TITLE
Add material inputs to dashboard cutting job modal

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1693,6 +1693,9 @@ function renderDashboard(){
   const existingTaskSearchEmpty = taskExistingForm?.querySelector('[data-task-existing-search-empty]');
   const jobNameInput     = document.getElementById("dashJobName");
   const jobEstimateInput = document.getElementById("dashJobEstimate");
+  const jobMaterialInput = document.getElementById("dashJobMaterial");
+  const jobMaterialCostInput = document.getElementById("dashJobMaterialCost");
+  const jobMaterialQtyInput = document.getElementById("dashJobMaterialQty");
   const jobStartInput    = document.getElementById("dashJobStart");
   const jobDueInput      = document.getElementById("dashJobDue");
   const garnetForm       = document.getElementById("dashGarnetForm");
@@ -2652,10 +2655,17 @@ function renderDashboard(){
     e.preventDefault();
     const name = (jobNameInput?.value || "").trim();
     const est  = Number(jobEstimateInput?.value);
+    const material = (jobMaterialInput?.value || "").trim();
+    const materialCostRaw = jobMaterialCostInput?.value ?? "";
+    const materialQtyRaw  = jobMaterialQtyInput?.value ?? "";
     const start = jobStartInput?.value;
     const due   = jobDueInput?.value;
+    const materialCost = materialCostRaw === "" ? 0 : Number(materialCostRaw);
+    const materialQty  = materialQtyRaw === "" ? 0 : Number(materialQtyRaw);
     if (!name || !isFinite(est) || est <= 0 || !start || !due){ toast("Fill job fields."); return; }
-    cuttingJobs.push({ id: genId(name), name, estimateHours: est, startISO: start, dueISO: due, material:"", materialCost:0, materialQty:0, notes:"", manualLogs:[] });
+    if (!Number.isFinite(materialCost) || materialCost < 0){ toast("Enter a valid material cost."); return; }
+    if (!Number.isFinite(materialQty) || materialQty < 0){ toast("Enter a valid material quantity."); return; }
+    cuttingJobs.push({ id: genId(name), name, estimateHours: est, startISO: start, dueISO: due, material, materialCost, materialQty, notes:"", manualLogs:[] });
     saveCloudDebounced();
     toast("Cutting job added");
     closeModal();

--- a/js/views.js
+++ b/js/views.js
@@ -179,6 +179,9 @@ function viewDashboard(){
           <div class="modal-grid">
             <label>Job name<input id="dashJobName" required placeholder="Job"></label>
             <label>Estimate (hrs)<input type="number" min="1" step="0.1" id="dashJobEstimate" required placeholder="e.g. 12"></label>
+            <label>Material<input id="dashJobMaterial" placeholder="Material"></label>
+            <label>Material cost ($)<input type="number" min="0" step="0.01" id="dashJobMaterialCost" placeholder="optional"></label>
+            <label>Material quantity<input type="number" min="0" step="0.01" id="dashJobMaterialQty" placeholder="optional"></label>
             <label>Start date<input type="date" id="dashJobStart" required></label>
             <label>Due date<input type="date" id="dashJobDue" required></label>
           </div>


### PR DESCRIPTION
## Summary
- add material, material cost, and material quantity inputs to the dashboard cutting job modal
- persist the new fields when creating a cutting job from the dashboard with validation to prevent negative values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc084620c0832588416ccc938d84ad