### PR TITLE
Ensure task and job deletions persist to cloud state

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -119,6 +119,7 @@ function showTaskBubble(taskId, anchor){
       console.warn("Failed to record deleted task from calendar", err);
     }
     tasksInterval = tasksInterval.filter(x => x.id !== taskId);
+    window.tasksInterval = tasksInterval;
     saveCloudDebounced(); toast("Removed"); hideBubble(); route();
   });
   b.querySelector("[data-bbl-edit]")?.addEventListener("click", ()=>{
@@ -231,7 +232,7 @@ function showJobBubble(jobId, anchor){
       } catch (err) {
         console.warn("Failed to record deleted job from calendar", err);
       }
-      cuttingJobs = cuttingJobs.filter(x=>String(x.id)!==String(j.id)); saveCloudDebounced(); toast("Removed"); hideBubble(); route();
+      cuttingJobs = cuttingJobs.filter(x=>String(x.id)!==String(j.id)); window.cuttingJobs = cuttingJobs; saveCloudDebounced(); toast("Removed"); hideBubble(); route();
     });
     b.querySelector("[data-bbl-edit-job]")?.addEventListener("click", ()=>{ hideBubble(); openJobsEditor(j.id); });
   }catch(err){

--- a/js/core.js
+++ b/js/core.js
@@ -360,6 +360,9 @@ let garnetCleanings = window.garnetCleanings;
 function refreshGlobalCollections(){
   if (typeof window === "undefined") return;
 
+  if (!Array.isArray(window.totalHistory)) window.totalHistory = [];
+  totalHistory = window.totalHistory;
+
   if (!Array.isArray(window.tasksInterval)) window.tasksInterval = [];
   tasksInterval = window.tasksInterval;
 
@@ -1004,6 +1007,7 @@ window.defaultAsReqTasks = defaultAsReqTasks;
 
 /* ==================== Cloud load / save ===================== */
 function snapshotState(){
+  refreshGlobalCollections();
   const safePumpEff = (typeof window.pumpEff !== "undefined") ? window.pumpEff : null;
   const foldersSnapshot = snapshotSettingsFolders();
   const trashSnapshot = deletedItems.map(entry => ({

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -7072,6 +7072,7 @@ function renderJobs(){
         }
       }
       cuttingJobs = cuttingJobs.filter(x=>x.id!==id);
+      window.cuttingJobs = cuttingJobs;
       saveCloudDebounced(); toast("Removed"); renderJobs();
       return;
     }


### PR DESCRIPTION
## Summary
- refresh global collections before capturing cloud snapshots so the latest task and job lists are saved
- synchronize task deletions from the calendar UI back to the shared window state
- update job deletions to keep window state in sync before saving

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc310368a8832588f3c8fe88e1ee6e