### PR TITLE
Enhance calendar scheduling and history handling

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -63,6 +63,63 @@ function baselineInputValue(task){
   return "";
 }
 
+const DASHBOARD_DAY_MS = 24 * 60 * 60 * 1000;
+
+function hoursSnapshotOnOrBefore(dateISO){
+  if (!dateISO || !Array.isArray(totalHistory) || !totalHistory.length) return null;
+  let best = null;
+  let bestTime = -Infinity;
+  const target = new Date(`${dateISO}T00:00:00`);
+  if (Number.isNaN(target.getTime())) return null;
+  for (const entry of totalHistory){
+    if (!entry || typeof entry.dateISO !== "string") continue;
+    const entryDate = new Date(`${entry.dateISO}T00:00:00`);
+    if (Number.isNaN(entryDate.getTime())) continue;
+    if (entryDate > target) continue;
+    const hoursVal = Number(entry.hours);
+    if (!Number.isFinite(hoursVal)) continue;
+    const timeVal = entryDate.getTime();
+    if (timeVal > bestTime){
+      bestTime = timeVal;
+      best = hoursVal;
+    }
+  }
+  return best;
+}
+
+function ensureTaskManualHistory(task){
+  if (!task) return [];
+  const normalized = [];
+  const existing = Array.isArray(task.manualHistory) ? task.manualHistory : [];
+  existing.forEach(entry => {
+    if (!entry || typeof entry.dateISO !== "string") return;
+    const clone = { ...entry };
+    if (clone.hoursAtEntry != null){
+      const h = Number(clone.hoursAtEntry);
+      clone.hoursAtEntry = Number.isFinite(h) && h >= 0 ? h : null;
+    } else {
+      clone.hoursAtEntry = null;
+    }
+    if (typeof clone.recordedAtISO !== "string") clone.recordedAtISO = null;
+    if (clone.status !== "completed" && clone.status !== "scheduled" && clone.status !== "logged"){
+      clone.status = "logged";
+    }
+    if (clone.source !== "machine" && clone.source !== "estimate"){
+      clone.source = clone.hoursAtEntry != null ? "machine" : "estimate";
+    }
+    if (clone.estimatedDailyHours != null){
+      const est = Number(clone.estimatedDailyHours);
+      clone.estimatedDailyHours = Number.isFinite(est) && est > 0 ? est : null;
+    } else {
+      clone.estimatedDailyHours = null;
+    }
+    normalized.push(clone);
+  });
+  normalized.sort((a,b)=> String(a.dateISO).localeCompare(String(b.dateISO)));
+  task.manualHistory = normalized;
+  return task.manualHistory;
+}
+
 function editingCompletedJobsSet(){
   if (typeof getEditingCompletedJobsSet === "function"){
     return getEditingCompletedJobsSet();
@@ -1900,34 +1957,93 @@ function renderDashboard(){
     if (!task || task.mode !== "interval") return false;
     const interval = Number(task.interval);
     if (!Number.isFinite(interval) || interval <= 0) return false;
+    ensureTaskManualHistory(task);
+
+    const hoursPerDay = (typeof DAILY_HOURS === "number" && Number.isFinite(DAILY_HOURS) && DAILY_HOURS > 0)
+      ? Number(DAILY_HOURS)
+      : 8;
+
+    let targetISO = dateISO || ymd(new Date());
+    const today = new Date(); today.setHours(0,0,0,0);
+    const todayISO = ymd(today);
+
+    const liveHoursRaw = getCurrentMachineHours();
+    const liveHours = (liveHoursRaw != null && Number.isFinite(Number(liveHoursRaw)))
+      ? Number(liveHoursRaw)
+      : null;
+    const historyToday = hoursSnapshotOnOrBefore(todayISO);
+    const effectiveNowHours = liveHours != null
+      ? liveHours
+      : (historyToday != null && Number.isFinite(Number(historyToday)) ? Number(historyToday) : null);
+
     let baselineHours = Number(task.sinceBase);
     if (!Number.isFinite(baselineHours) || baselineHours < 0){
       baselineHours = null;
     }
-    let targetISO = dateISO;
-    if (!targetISO){
-      targetISO = ymd(new Date());
-    }
-    if (targetISO){
-      const targetDate = parseDateLocal(targetISO);
-      if (targetDate instanceof Date && !Number.isNaN(targetDate.getTime())){
-        const today = new Date();
-        today.setHours(0,0,0,0);
-        targetDate.setHours(0,0,0,0);
-        const diffMs = targetDate.getTime() - today.getTime();
-        const days = Math.max(0, Math.round(diffMs / (24*60*60*1000)));
-        const hoursPerDay = (typeof DAILY_HOURS === "number" && Number.isFinite(DAILY_HOURS) && DAILY_HOURS > 0)
-          ? Number(DAILY_HOURS)
-          : 8;
-        let remainHours = days * hoursPerDay;
-        if (!Number.isFinite(remainHours) || remainHours < 0) remainHours = 0;
-        if (remainHours > interval) remainHours = interval;
-        baselineHours = interval - remainHours;
-        if (!Number.isFinite(baselineHours) || baselineHours < 0) baselineHours = 0;
+
+    const targetDate = targetISO ? parseDateLocal(targetISO) : null;
+    if (targetDate instanceof Date && !Number.isNaN(targetDate.getTime())){
+      targetDate.setHours(0,0,0,0);
+      targetISO = ymd(targetDate);
+      const isPastOrToday = targetDate.getTime() <= today.getTime();
+      const hoursAtTarget = hoursSnapshotOnOrBefore(targetISO);
+      let consumedHours;
+      let source = "estimate";
+
+      if (isPastOrToday){
+        if (effectiveNowHours != null && hoursAtTarget != null){
+          consumedHours = Math.max(0, effectiveNowHours - hoursAtTarget);
+          source = "machine";
+        }else{
+          const diffDays = Math.max(0, Math.round((today.getTime() - targetDate.getTime()) / DASHBOARD_DAY_MS));
+          consumedHours = diffDays * hoursPerDay;
+        }
+      }else{
+        const diffDays = Math.max(0, Math.round((targetDate.getTime() - today.getTime()) / DASHBOARD_DAY_MS));
+        const remainHours = Math.min(interval, diffDays * hoursPerDay);
+        consumedHours = Math.max(0, interval - remainHours);
       }
+
+      if (!Number.isFinite(consumedHours) || consumedHours < 0) consumedHours = 0;
+      baselineHours = consumedHours;
+      applyIntervalBaseline(task, { baselineHours, currentHours: effectiveNowHours });
+
+      if (isPastOrToday){
+        const completionKey = ymd(targetDate);
+        if (completionKey){
+          if (!Array.isArray(task.completedDates)) task.completedDates = [];
+          if (!task.completedDates.includes(completionKey)){
+            task.completedDates.push(completionKey);
+            task.completedDates.sort();
+          }
+        }
+      }
+
+      const manualHistory = ensureTaskManualHistory(task);
+      const entryHours = hoursAtTarget != null
+        ? hoursAtTarget
+        : (effectiveNowHours != null ? Math.max(0, effectiveNowHours - baselineHours) : null);
+      const entry = {
+        dateISO: targetISO,
+        hoursAtEntry: (entryHours != null && Number.isFinite(entryHours) && entryHours >= 0) ? entryHours : null,
+        recordedAtISO: new Date().toISOString(),
+        status: isPastOrToday ? "completed" : "scheduled",
+        source,
+        estimatedDailyHours: hoursPerDay
+      };
+      const existingIdx = manualHistory.findIndex(item => item && item.dateISO === targetISO);
+      if (existingIdx >= 0){
+        manualHistory[existingIdx] = { ...manualHistory[existingIdx], ...entry };
+      }else{
+        manualHistory.push(entry);
+      }
+      manualHistory.sort((a,b)=> String(a.dateISO).localeCompare(String(b.dateISO)));
+      task.manualHistory = manualHistory;
+    }else{
+      applyIntervalBaseline(task, { baselineHours, currentHours: effectiveNowHours });
     }
+
     task.calendarDateISO = targetISO || null;
-    applyIntervalBaseline(task, { baselineHours, currentHours: getCurrentMachineHours() });
     return true;
   }
 
@@ -2534,17 +2650,33 @@ function renderDashboard(){
     if (mode === "interval"){
       let interval = Number(taskIntervalInput?.value);
       if (!isFinite(interval) || interval <= 0) interval = 8;
-      const task = Object.assign({}, base, { mode:"interval", interval, sinceBase:0, anchorTotal:null, completedDates: [] });
+      const task = Object.assign({}, base, {
+        mode:"interval",
+        interval,
+        sinceBase:0,
+        anchorTotal:null,
+        completedDates: [],
+        manualHistory: []
+      });
       const curHours = getCurrentMachineHours();
       const baselineHours = parseBaselineHours(taskLastInput?.value);
       applyIntervalBaseline(task, { baselineHours, currentHours: curHours });
       tasksInterval.unshift(task);
       scheduleExistingIntervalTask(task, { dateISO: targetISO });
       const parsed = parseDateLocal(targetISO);
-      const dateLabel = (parsed instanceof Date && !Number.isNaN(parsed.getTime()))
-        ? parsed.toLocaleDateString()
-        : targetISO;
-      message = `Scheduled "${task.name || "Task"}" for ${dateLabel}`;
+      const todayMidnight = new Date(); todayMidnight.setHours(0,0,0,0);
+      let dateLabel = targetISO;
+      let completed = false;
+      if (parsed instanceof Date && !Number.isNaN(parsed.getTime())){
+        const display = new Date(parsed.getTime());
+        dateLabel = display.toLocaleDateString();
+        const compare = new Date(parsed.getTime());
+        compare.setHours(0,0,0,0);
+        completed = compare.getTime() <= todayMidnight.getTime();
+      }
+      message = completed
+        ? `Logged "${task.name || "Task"}" as completed on ${dateLabel}`
+        : `Scheduled "${task.name || "Task"}" for ${dateLabel}`;
     }else{
       const condition = (taskConditionInput?.value || "").trim() || "As required";
       const task = Object.assign({}, base, { mode:"asreq", condition });
@@ -2577,7 +2709,14 @@ function renderDashboard(){
         if (!isFinite(subInterval) || subInterval <= 0){
           subInterval = isFinite(parentInterval) && parentInterval > 0 ? parentInterval : 8;
         }
-        const subTask = Object.assign({}, subBase, { mode:"interval", interval: subInterval, sinceBase:0, anchorTotal:null, completedDates: [] });
+        const subTask = Object.assign({}, subBase, {
+          mode:"interval",
+          interval: subInterval,
+          sinceBase:0,
+          anchorTotal:null,
+          completedDates: [],
+          manualHistory: []
+        });
         const curHours = getCurrentMachineHours();
         const lastField = row.querySelector("[data-subtask-last]");
         const baselineHours = parseBaselineHours(lastField?.value);
@@ -2617,10 +2756,19 @@ function renderDashboard(){
     if (task.mode === "interval"){
       scheduleExistingIntervalTask(task, { dateISO: targetISO });
       const parsed = parseDateLocal(targetISO);
-      const dateLabel = (parsed instanceof Date && !Number.isNaN(parsed.getTime()))
-        ? parsed.toLocaleDateString()
-        : targetISO;
-      message = `Scheduled "${task.name || "Task"}" for ${dateLabel}`;
+      const todayMidnight = new Date(); todayMidnight.setHours(0,0,0,0);
+      let dateLabel = targetISO;
+      let completed = false;
+      if (parsed instanceof Date && !Number.isNaN(parsed.getTime())){
+        const display = new Date(parsed.getTime());
+        dateLabel = display.toLocaleDateString();
+        const compare = new Date(parsed.getTime());
+        compare.setHours(0,0,0,0);
+        completed = compare.getTime() <= todayMidnight.getTime();
+      }
+      message = completed
+        ? `Logged "${task.name || "Task"}" as completed on ${dateLabel}`
+        : `Scheduled "${task.name || "Task"}" for ${dateLabel}`;
     }else{
       task.calendarDateISO = targetISO || null;
       message = "As-required task linked from Maintenance Settings";
@@ -4529,7 +4677,14 @@ function renderSettings(){
     if (mode === "interval"){
       const intervalVal = data.get("taskInterval");
       const interval = intervalVal === null || intervalVal === "" ? 8 : Number(intervalVal);
-      const task = Object.assign(base, { mode:"interval", interval: isFinite(interval) && interval>0 ? interval : 8, sinceBase:0, anchorTotal:null, completedDates: [] });
+      const task = Object.assign(base, {
+        mode:"interval",
+        interval: isFinite(interval) && interval>0 ? interval : 8,
+        sinceBase:0,
+        anchorTotal:null,
+        completedDates: [],
+        manualHistory: []
+      });
       const curHours = getCurrentMachineHours();
       const baselineHours = parseBaselineHours(data.get("taskLastServiced"));
       applyIntervalBaseline(task, { baselineHours, currentHours: curHours });


### PR DESCRIPTION
## Summary
- Normalize maintenance task manual history, capture machine hour snapshots, and enrich interval scheduling workflows.
- Expand calendar task bubbles to support marking, unmarking, or removing occurrences while keeping histories in sync.
- Project upcoming interval tasks onto the calendar with status metadata and improved event rendering.

## Testing
- Not run (not requested).

------
https://chatgpt.com/codex/tasks/task_e_68dc4484c650832592774fadb1970930