### PR TITLE
Improve order request remove button contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -528,6 +528,20 @@ body.cost-info-visible{
 .order-actions button:disabled{ opacity:0.55; cursor:not-allowed; }
 .order-card .link{ background:none; border:0; padding:0; color:#c62828; cursor:pointer; text-decoration:underline; }
 .order-card .link:hover{ color:#a31818; }
+.order-card .link.danger{
+  background:#c62828;
+  border-radius:999px;
+  color:#fff;
+  font-weight:600;
+  padding:4px 10px;
+  text-decoration:none;
+}
+.order-card .link.danger:hover,
+.order-card .link.danger:focus{ background:#a31818; color:#fff; }
+.order-card .link.danger:focus-visible{
+  outline:2px solid rgba(198, 40, 40, 0.55);
+  outline-offset:2px;
+}
 
 #explorer .task.task--focus{ outline:2px solid #0a63c2; box-shadow:0 0 0 3px rgba(10,99,194,.18); animation:explorerTaskFocusPulse 1.6s ease-in-out 0s 2; }
 @keyframes explorerTaskFocusPulse{


### PR DESCRIPTION
## Summary
- improve the order request remove button styling so the text has sufficient contrast against its background
- add hover and focus-visible states to keep the button legible and accessible when interacting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc4692fac08325a3d1878fee0da642