### PR TITLE
Add search bar to deleted items page

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -895,6 +895,7 @@ if (typeof window !== "undefined"){
   window.purgeExpiredDeletedItems = purgeExpiredDeletedItems;
 }
 
+if (typeof window.deletedItemsSearchTerm !== "string") window.deletedItemsSearchTerm = "";
 if (typeof window.inventorySearchTerm !== "string") window.inventorySearchTerm = "";
 let inventorySearchTerm = window.inventorySearchTerm;
 

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -8691,7 +8691,8 @@ function computeDeletedItemsModel(){
   };
 }
 
-function renderDeletedItems(){
+function renderDeletedItems(options){
+  const opts = options && typeof options === "object" ? options : {};
   const content = document.getElementById("content"); if (!content) return;
   setAppSettingsContext("default");
   wireDashboardSettingsMenu();
@@ -8741,18 +8742,40 @@ function renderDeletedItems(){
     searchInput.addEventListener("input", ()=>{
       const value = searchInput.value || "";
       if (typeof window.deletedItemsSearchTerm === "string" && window.deletedItemsSearchTerm === value) return;
+      const shouldRestoreFocus = document.activeElement === searchInput;
+      const selectionStart = shouldRestoreFocus && typeof searchInput.selectionStart === "number"
+        ? searchInput.selectionStart
+        : undefined;
+      const selectionEnd = shouldRestoreFocus && typeof searchInput.selectionEnd === "number"
+        ? searchInput.selectionEnd
+        : undefined;
       window.deletedItemsSearchTerm = value;
-      renderDeletedItems();
+      renderDeletedItems({
+        focusSearch: shouldRestoreFocus,
+        selectionStart,
+        selectionEnd
+      });
     });
   }
   if (clearButton){
     clearButton.addEventListener("click", ()=>{
       if (!window.deletedItemsSearchTerm) return;
       window.deletedItemsSearchTerm = "";
-      renderDeletedItems();
+      renderDeletedItems({ focusSearch: true, selectionStart: 0, selectionEnd: 0 });
       const nextInput = document.getElementById("deletedItemsSearch");
       if (nextInput) nextInput.focus();
     });
+  }
+
+  if (opts.focusSearch && searchInput){
+    searchInput.focus();
+    const selStart = typeof opts.selectionStart === "number" ? opts.selectionStart : searchInput.value.length;
+    const selEnd = typeof opts.selectionEnd === "number" ? opts.selectionEnd : selStart;
+    try {
+      searchInput.setSelectionRange(selStart, selEnd);
+    } catch (_){
+      /* ignore selection failures (e.g. unsupported input types) */
+    }
   }
 }
 

--- a/js/views.js
+++ b/js/views.js
@@ -1864,6 +1864,9 @@ function viewOrderRequest(model){
 function viewDeletedItems(model){
   const data = model || {};
   const items = Array.isArray(data.items) ? data.items : [];
+  const totalCount = typeof data.totalCount === "number" ? data.totalCount : items.length;
+  const searchValue = String(data.searchTerm || "");
+  const searchDisabled = totalCount === 0 && !searchValue;
   const esc = (str)=> String(str ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
   const rows = items.map(item => `
     <tr>
@@ -1895,13 +1898,20 @@ function viewDeletedItems(model){
         </thead>
         <tbody>${rows}</tbody>
       </table>`
-    : `<p class="small muted">Nothing has been deleted in the last 30 days.</p>`;
+    : totalCount > 0
+      ? `<p class="small muted">No deleted items match your search.</p>`
+      : `<p class="small muted">Nothing has been deleted in the last 30 days.</p>`;
 
   return `
     <div class="container deleted-container">
       <div class="block" style="grid-column:1 / -1">
         <h3>Deleted items</h3>
         <p class="small muted">Items remain here for 30 days after deletion. Restore them or delete forever.</p>
+        <div class="deleted-search">
+          <label class="sr-only" for="deletedItemsSearch">Search deleted items</label>
+          <input type="search" id="deletedItemsSearch" placeholder="Search deleted items" value="${esc(searchValue)}" ${searchDisabled ? "disabled" : ""} autocomplete="off">
+          <button type="button" id="deletedItemsSearchClear" ${searchValue ? "" : "disabled"}>Clear</button>
+        </div>
         ${body}
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -517,6 +517,9 @@ body.cost-info-visible{
 .deleted-container .deleted-label{font-weight:600}
 .deleted-container .deleted-actions{display:flex;gap:8px;justify-content:flex-end;flex-wrap:wrap}
 .deleted-container .deleted-when{min-width:180px}
+.deleted-container .deleted-search{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-top:12px}
+.deleted-container .deleted-search input[type="search"]{flex:1 1 220px;min-width:200px}
+.deleted-container .deleted-search button{flex:0 0 auto}
 .order-card-footer{ display:flex; gap:12px; justify-content:space-between; flex-wrap:wrap; align-items:flex-start; }
 .order-total{ color:#1e2b45; }
 .order-total strong{ color:#0a63c2; font-size:20px; }


### PR DESCRIPTION
## Summary
- add a search input to the deleted items page and filter results client-side
- persist the deleted items search term between renders and update empty states
- style the new search controls to match the existing deleted items table

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68deaeb6b83483258e45880101ac290e