### PR TITLE
Add search bar to cutting job history

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -897,6 +897,8 @@ if (typeof window !== "undefined"){
 
 if (typeof window.inventorySearchTerm !== "string") window.inventorySearchTerm = "";
 let inventorySearchTerm = window.inventorySearchTerm;
+if (typeof window.jobHistorySearchTerm !== "string") window.jobHistorySearchTerm = "";
+let jobHistorySearchTerm = window.jobHistorySearchTerm;
 
 /* ================ Jobs editing & render flags ================ */
 if (!(window.editingJobs instanceof Set)) window.editingJobs = new Set();
@@ -1680,6 +1682,9 @@ async function clearAllAppData(){
   } catch(_){ }
   try { if (Array.isArray(window.pendingNewJobFiles)) window.pendingNewJobFiles.length = 0; } catch(_){ }
   if (typeof window.inventorySearchTerm === "string") window.inventorySearchTerm = "";
+  inventorySearchTerm = "";
+  if (typeof window.jobHistorySearchTerm === "string") window.jobHistorySearchTerm = "";
+  jobHistorySearchTerm = "";
   if (window.orderPartialSelection instanceof Set) window.orderPartialSelection.clear();
 
   try { captureHistorySnapshot(); } catch(_){ }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -7169,6 +7169,15 @@ function renderJobs(){
   const historySearchInput = document.getElementById("jobHistorySearch");
   const historySearchClear = document.getElementById("jobHistorySearchClear");
 
+  const captureScrollPosition = ()=> ({
+    x: window.scrollX || document.documentElement.scrollLeft || document.body.scrollLeft || 0,
+    y: window.scrollY || document.documentElement.scrollTop || document.body.scrollTop || 0
+  });
+  const restoreScrollPosition = (pos)=>{
+    if (!pos || typeof pos.x !== "number" || typeof pos.y !== "number") return;
+    window.scrollTo(pos.x, pos.y);
+  };
+
   if (historySearchInput){
     historySearchInput.addEventListener("input", (event)=>{
       jobHistorySearchTerm = event.target.value;
@@ -7176,8 +7185,10 @@ function renderJobs(){
       const selectionStart = event.target.selectionStart ?? jobHistorySearchTerm.length;
       const selectionEnd = event.target.selectionEnd ?? selectionStart;
       const selectionDirection = event.target.selectionDirection || "none";
+      const scrollPosition = captureScrollPosition();
       renderJobs();
       requestAnimationFrame(()=>{
+        restoreScrollPosition(scrollPosition);
         const nextInput = document.getElementById("jobHistorySearch");
         if (!nextInput) return;
         try {
@@ -7199,8 +7210,10 @@ function renderJobs(){
       if (!jobHistorySearchTerm) return;
       jobHistorySearchTerm = "";
       window.jobHistorySearchTerm = "";
+      const scrollPosition = captureScrollPosition();
       renderJobs();
       requestAnimationFrame(()=>{
+        restoreScrollPosition(scrollPosition);
         const nextInput = document.getElementById("jobHistorySearch");
         if (!nextInput) return;
         try {

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -7166,6 +7166,55 @@ function renderJobs(){
     });
   }
 
+  const historySearchInput = document.getElementById("jobHistorySearch");
+  const historySearchClear = document.getElementById("jobHistorySearchClear");
+
+  if (historySearchInput){
+    historySearchInput.addEventListener("input", (event)=>{
+      jobHistorySearchTerm = event.target.value;
+      window.jobHistorySearchTerm = jobHistorySearchTerm;
+      const selectionStart = event.target.selectionStart ?? jobHistorySearchTerm.length;
+      const selectionEnd = event.target.selectionEnd ?? selectionStart;
+      const selectionDirection = event.target.selectionDirection || "none";
+      renderJobs();
+      requestAnimationFrame(()=>{
+        const nextInput = document.getElementById("jobHistorySearch");
+        if (!nextInput) return;
+        try {
+          nextInput.focus({ preventScroll: true });
+        } catch (_){
+          nextInput.focus();
+        }
+        try {
+          const start = Math.min(selectionStart, nextInput.value.length);
+          const end = Math.min(selectionEnd, nextInput.value.length);
+          nextInput.setSelectionRange(start, end, selectionDirection);
+        } catch (_){ }
+      });
+    });
+  }
+
+  if (historySearchClear){
+    historySearchClear.addEventListener("click", ()=>{
+      if (!jobHistorySearchTerm) return;
+      jobHistorySearchTerm = "";
+      window.jobHistorySearchTerm = "";
+      renderJobs();
+      requestAnimationFrame(()=>{
+        const nextInput = document.getElementById("jobHistorySearch");
+        if (!nextInput) return;
+        try {
+          nextInput.focus({ preventScroll: true });
+        } catch (_){
+          nextInput.focus();
+        }
+        try {
+          nextInput.setSelectionRange(0, 0);
+        } catch (_){ }
+      });
+    });
+  }
+
   const newFilesBtn = document.getElementById("jobFilesBtn");
   const newFilesInput = document.getElementById("jobFiles");
   newFilesBtn?.addEventListener("click", ()=>{ newFilesInput?.click(); });

--- a/style.css
+++ b/style.css
@@ -1954,6 +1954,37 @@ body.modal-open .auth-bar {
 }
 
 .past-jobs-block { grid-column: 1 / -1; }
+.past-jobs-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+.past-jobs-search {
+  flex: 1 1 auto;
+}
+.past-jobs-search input[type="search"] {
+  flex: 1 1 240px;
+  min-width: 200px;
+  max-width: 420px;
+}
+.past-jobs-hint {
+  margin: 0 0 12px;
+}
+.past-jobs-filter-status {
+  margin: -6px 0 12px;
+}
+@media (max-width: 720px) {
+  .past-jobs-search {
+    width: 100%;
+  }
+  .past-jobs-search input[type="search"] {
+    max-width: 100%;
+    min-width: 0;
+  }
+}
 .past-jobs-summary {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add a persistent search bar and filter logic for past cutting jobs
- show filtered counts, retain edit rows, and reset search state when clearing data
- style the new toolbar for desktop and mobile layouts and preserve focus while typing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deac18c6fc8325b348c65fe86262d5