### PR TITLE
Add recurrence model and Google-style repeat controls; fix interval completion duplicate

### DIFF
--- a/docs/calendar-recurrence-google-style-plan.md
+++ b/docs/calendar-recurrence-google-style-plan.md
@@ -1,0 +1,142 @@
+# Dashboard Calendar Recurrence & Completion Behavior Plan (Google-Style)
+
+## Scope of request
+- Fix bug: marking an interval task complete on the dashboard calendar (e.g., **Mixing tube rotation**) is causing a new copy to appear on the next day.
+- Move calendar behavior toward a Google Calendar-like recurrence model:
+  - When adding/scheduling events/tasks, explicitly choose whether it repeats.
+  - If repeating, choose the recurrence frequency.
+- Update Maintenance Settings so recurrence controls are aligned with calendar behavior.
+- Preserve existing interval/per-hour maintenance logic and avoid breaking forecasting/cost logic.
+
+---
+
+## Code reading summary (pass 1)
+
+### 1) Where the duplicate-next-day behavior comes from
+The current completion path for interval template tasks creates a new **instance** and then completes it immediately:
+1. `completeTask(taskId)` in `js/calendar.js` checks if the selected item is an interval template.
+2. If it is, it calls `scheduleExistingIntervalTask(template, { dateISO: today })`, which can create a new instance and assign today as `calendarDateISO`.
+3. Then `markCalendarTaskComplete(...)` marks completion and records `completedDates`/`manualHistory`.
+
+This instance/template split, plus projection logic and manual-history merge logic, can produce “extra copy” behavior depending on what dates are already in manual/completed/projection sets. The symptom aligns with this flow.
+
+### 2) Recurrence/event scheduling touchpoints
+- Calendar rendering and event composition:
+  - `renderCalendar()`, `projectIntervalDueDates()`, `pushTaskEvent(...)` in `js/calendar.js`.
+- Completion/uncompletion/removal behavior:
+  - `markCalendarTaskComplete`, `unmarkCalendarTaskComplete`, `removeCalendarTaskOccurrences` in `js/calendar.js`.
+- Task scheduling/instancing:
+  - `scheduleExistingIntervalTask`, `scheduleExistingAsReqTask`, `createIntervalTaskInstance` in `js/renderers.js`.
+- Add-task modal UI and submit handlers:
+  - Dashboard picker/forms in `js/views.js` + handler wiring in `js/renderers.js`.
+- Baseline/per-interval math:
+  - `nextDue`, `liveSince` in `js/computations.js`.
+  - `applyIntervalBaseline`, `ensureTaskManualHistory` in `js/renderers.js`.
+
+### 3) Current model mismatch with requested UX
+Current model is maintenance-centric (interval + as-required + optional scheduling) and stores recurrence implicitly through interval math and projections. Requested behavior requires explicit scheduling recurrence settings per added calendar event (none/daily/weekly/monthly/custom) similar to Google Calendar.
+
+---
+
+## Initial implementation plan (draft)
+
+1. **Define recurrence schema (non-breaking).**
+   - Add optional recurrence fields to scheduled task instances (and one-time tasks where needed):
+     - `scheduleMode`: `"none" | "recurring"`
+     - `recurrenceType`: `"daily" | "weekly" | "monthly" | "hours_interval"`
+     - `recurrenceInterval`: number (e.g., every 2 days/weeks/months)
+     - `recurrenceDaysOfWeek`: optional array for weekly rules
+     - `recurrenceEnd`: `"never" | "on_date" | "after_count"`
+     - `recurrenceEndDate` / `recurrenceCount`
+   - Keep legacy fields (`interval`, `manualHistory`, `completedDates`, etc.) untouched for compatibility.
+
+2. **Add recurrence controls to Add Task flow (dashboard modal).**
+   - In “existing task” and “new task” forms, add UI:
+     - Repeat: No / Yes
+     - Frequency selector (daily/weekly/monthly/hour-interval)
+     - Frequency value input
+     - End condition (never/end date/after count)
+   - Ensure defaults preserve old behavior (for interval templates default to recurring by interval-hours when appropriate).
+
+3. **Add recurrence controls to Maintenance Settings cards.**
+   - Add editable recurrence fields alongside existing interval/condition fields.
+   - Hook into `data-k` input persistence path in `renderers.js` without breaking current edit-mode gating.
+
+4. **Introduce a unified occurrence generator layer.**
+   - New helper(s) that produce occurrences from either:
+     - explicit recurrence schema, or
+     - legacy interval projection fallback.
+   - Calendar renderer should consume this unified occurrence list so both old and new tasks behave consistently.
+
+5. **Fix completion behavior for interval templates.**
+   - Refactor `completeTask(...)` so “mark complete” updates the right task occurrence without creating an accidental additional near-term occurrence.
+   - Ensure the next due/recurrence computation excludes the completed occurrence in a deterministic way.
+
+6. **Preserve cost and analytics compatibility.**
+   - Ensure `computeCostModel()` and history extraction still rely on completed/manual history dates.
+   - If recurrence fields are added, they should be optional metadata and not replace existing completion records used by cost calculations.
+
+7. **Migration + normalization.**
+   - Add normalization so older saved tasks without recurrence fields behave exactly as before.
+   - Add guardrails for invalid recurrence values.
+
+8. **Validation matrix.**
+   - Interval template completion (today/past/future).
+   - As-required scheduled once vs repeated.
+   - One-time tasks remain one-time by default.
+   - Remove single/future/all occurrence behavior still works.
+   - Forecast/cost widgets still render and derive values correctly.
+
+---
+
+## Code reading summary (pass 2 review + adjustments)
+
+After re-reading the scheduling/completion/render paths, I am adjusting the plan to reduce risk in this complex codebase:
+
+### Key findings from second pass
+1. **Instances are heavily integrated** in settings organization, cost history, and calendar rendering. Fully replacing instance behavior now is risky.
+2. `renderCalendar()` currently expects interval *instances* for projected/due rendering (`isInstanceTask` filters). Any immediate model replacement could break visibility.
+3. Cost model and history logic pull from `manualHistory`, `completedDates`, and task activity checks; these must remain the source of truth.
+4. The bug is likely solvable quickly by tightening completion flow and projection exclusion, independent of full recurrence redesign.
+
+### Revised plan (safer phased rollout)
+
+#### Phase 1 — Stabilization + bug fix
+1. **Patch completion logic first** (minimal invasive):
+   - Update `completeTask(...)` path so marking an interval task complete does not create an unintended extra calendar occurrence.
+   - Add explicit de-duplication guard around “today + next projected date” collision.
+2. **Add deterministic event dedupe in calendar assembly**:
+   - Normalize composite keys (`templateId/taskId + date + status precedence`) before pushing chips.
+   - Keep completed > manual > due priority, but prevent duplicate semantic occurrences.
+3. **Regression pass for removal/uncomplete operations** using existing scope logic (`single/future/all`).
+
+#### Phase 2 — Google-style recurrence controls (additive)
+4. **Add recurrence metadata fields** (optional, backward-compatible) for newly scheduled tasks/events.
+5. **Extend Add Task / Existing Task scheduling UI** with repeat controls.
+6. **Extend Maintenance Settings UI** with same repeat controls so users can edit recurrence after creation.
+
+#### Phase 3 — Unified recurrence engine behind feature-compat facade
+7. Build a unified occurrence generator that first checks explicit recurrence metadata; if absent, falls back to current interval projection logic.
+8. Keep existing `manualHistory` + `completedDates` writes intact so cost/forecast code stays stable.
+
+#### Phase 4 — Hardening + migration
+9. Add normalization migration for recurrence defaults on load.
+10. Add test checklist + manual validation scripts for all recurrence/completion modes and cost widgets.
+
+---
+
+## Implementation notes / guardrails
+- **Do not break existing task schema consumers** (`computeCostModel`, history cards, next-due widget).
+- **Completion semantics remain event-based**: completing an occurrence writes completion history for that date.
+- **Recurrence semantics are generation-only**: they generate candidate dates but do not auto-mark completion.
+- **As-required defaults to non-repeating** unless user enables recurrence explicitly.
+- **Interval maintenance can default to repeating** but user must be able to set “does not repeat” when adding from calendar.
+
+---
+
+## Deliverables for implementation phase
+1. Completion bug fix in calendar logic.
+2. New recurrence UI controls in dashboard add modal and maintenance settings cards.
+3. Recurrence metadata persistence + normalization.
+4. Unified occurrence generation with legacy fallback.
+5. Validation checklist run and documented.

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1134,11 +1134,13 @@ function showTaskBubble(taskId, anchor, options = {}){
   }
 
   const targetKey = dateKey || normalizeDateKey(new Date());
+  const recurrence = getTaskRecurrence(task);
+  const isRepeating = Boolean(recurrence && recurrence.enabled);
 
   const actions = [];
   if (dateKey){
-    const noteLabel = occurrenceNote ? "Edit occurrence note" : "Add occurrence note";
-    const hoursLabel = occurrenceHours != null ? "Edit occurrence time" : "Add occurrence time";
+    const noteLabel = occurrenceNote ? "Edit note" : "Add note";
+    const hoursLabel = occurrenceHours != null ? "Edit time" : "Add time";
     actions.push(`<button data-bbl-occurrence-hours>${escapeHtml(hoursLabel)}</button>`);
     actions.push(`<button data-bbl-occurrence-note>${escapeHtml(noteLabel)}</button>`);
   }
@@ -1149,20 +1151,10 @@ function showTaskBubble(taskId, anchor, options = {}){
     actions.push(`<button data-bbl-uncomplete>Unmark complete</button>`);
   }
   if (canRemoveOccurrence){
-    const removeSelectId = `bubbleRemoveScope-${taskId}-${targetKey || "na"}`;
-    actions.push(`
-      <div class="bubble-remove-group">
-        <label for="${removeSelectId}">Remove:</label>
-        <div class="bubble-remove-row">
-          <select id="${removeSelectId}" data-bbl-remove-scope>
-            <option value="single">This occurrence only</option>
-            <option value="future">This and future occurrences</option>
-            <option value="all">All occurrences (past & future)</option>
-          </select>
-          <button class="secondary" data-bbl-remove-occurrence>Remove</button>
-        </div>
-      </div>
-    `);
+    actions.push(`<button class="secondary" data-bbl-remove-single>Remove occurrence</button>`);
+    if (isRepeating){
+      actions.push(`<button class="secondary" data-bbl-remove-future>Remove future</button>`);
+    }
   }
   actions.push(`<button data-bbl-edit>Edit settings</button>`);
   actions.push(`<button class="danger" data-bbl-remove-task>Remove task</button>`);
@@ -1223,8 +1215,7 @@ function showTaskBubble(taskId, anchor, options = {}){
     }
   });
 
-  b.querySelector("[data-bbl-remove-occurrence]")?.addEventListener("click", ()=>{
-    const scope = b.querySelector("[data-bbl-remove-scope]")?.value || "single";
+  const runRemoveScope = (scope)=>{
     const confirmText = scope === "future"
       ? "Remove this occurrence and all future occurrences from the calendar?"
       : scope === "all"
@@ -1245,7 +1236,10 @@ function showTaskBubble(taskId, anchor, options = {}){
       hideBubble();
       route();
     }
-  });
+  };
+  b.querySelector("[data-bbl-remove-single]")?.addEventListener("click", ()=> runRemoveScope("single"));
+  b.querySelector("[data-bbl-remove-future]")?.addEventListener("click", ()=> runRemoveScope("future"));
+  b.querySelector("[data-bbl-remove-all]")?.addEventListener("click", ()=> runRemoveScope("all"));
 
   b.querySelector("[data-bbl-remove-task]")?.addEventListener("click", ()=>{
     const templateId = task.templateId != null ? String(task.templateId) : String(task.id);

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1667,11 +1667,41 @@ function projectCalendarBasedOccurrences(task, recurrence, options = {}){
   const monthsAhead = Number.isFinite(Number(options.monthsAhead)) ? Math.max(1, Number(options.monthsAhead)) : 3;
   horizon.setMonth(horizon.getMonth() + monthsAhead);
   const every = Math.max(1, Number(recurrence.every) || 1);
+  const weekDays = Array.isArray(recurrence.weekDays)
+    ? recurrence.weekDays.map(v => Number(v)).filter(v => Number.isInteger(v) && v >= 0 && v <= 6)
+    : [];
   const endDate = recurrence.endType === "on_date" ? toDayStart(recurrence.endDateISO) : null;
   const endCount = recurrence.endType === "after_count" ? Math.max(1, Number(recurrence.endCount) || 1) : null;
   const events = [];
   let producedCount = 0;
   const maxIterations = 720;
+  if (recurrence.basis === "calendar_week" && weekDays.length){
+    const startWeekAnchor = new Date(startDate);
+    startWeekAnchor.setDate(startWeekAnchor.getDate() - startWeekAnchor.getDay());
+    startWeekAnchor.setHours(0,0,0,0);
+    for (let dayOffset = 0; dayOffset < maxIterations; dayOffset++){
+      const cursor = new Date(startDate);
+      cursor.setDate(cursor.getDate() + dayOffset);
+      cursor.setHours(0,0,0,0);
+      const day = cursor.getDay();
+      if (!weekDays.includes(day)) continue;
+      const diffWeeks = Math.floor((cursor.getTime() - startWeekAnchor.getTime()) / (7 * CALENDAR_DAY_MS));
+      if (diffWeeks < 0) continue;
+      if (diffWeeks % every !== 0) continue;
+      const key = ymd(cursor);
+      if (!key) continue;
+      producedCount += 1;
+      if (endDate && cursor.getTime() > endDate.getTime()) break;
+      if (endCount != null && producedCount > endCount) break;
+      if (excludeSet.has(key)) continue;
+      if (cursor.getTime() >= today.getTime()){
+        events.push({ dateISO: key, dueDate: new Date(cursor) });
+        if (maxOccurrences != null && events.length >= maxOccurrences) break;
+      }
+      if (cursor.getTime() > horizon.getTime() && events.length >= minOccurrences) break;
+    }
+    return events;
+  }
   for (let i = 0; i < maxIterations; i++){
     const cursor = new Date(startDate);
     if (recurrence.basis === "calendar_day"){

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -617,6 +617,17 @@ function markCalendarTaskComplete(meta, dateISO){
     if (!task.calendarDateISO || normalizeDateKey(task.calendarDateISO) === key){
       task.calendarDateISO = key;
     }
+    const recurrence = getTaskRecurrence(task);
+    if (recurrence && recurrence.enabled){
+      recurrence.completionAnchorISO = key;
+      if (currentHours != null && Number.isFinite(Number(currentHours))){
+        recurrence.completionAnchorHours = Number(currentHours);
+      }
+      if (recurrence.basis === "machine_hours"){
+        recurrence.startISO = key;
+      }
+      task.recurrence = recurrence;
+    }
     changed = true;
   }else{
     if (!Array.isArray(task.completedDates)) task.completedDates = [];
@@ -627,6 +638,12 @@ function markCalendarTaskComplete(meta, dateISO){
     }
     if (normalizeDateKey(task.calendarDateISO) !== key){
       task.calendarDateISO = key;
+      changed = true;
+    }
+    const recurrence = getTaskRecurrence(task);
+    if (recurrence && recurrence.enabled){
+      recurrence.completionAnchorISO = key;
+      task.recurrence = recurrence;
       changed = true;
     }
   }
@@ -1028,14 +1045,6 @@ function makeBubble(anchor){
 function completeTask(taskId){
   let meta = findCalendarTaskMeta(taskId);
   if (!meta) return;
-  if (isTemplateTask(meta.task) && meta.task.mode === "interval"){
-    const instance = scheduleExistingIntervalTask(meta.task, { dateISO: ymd(new Date()) });
-    if (instance){
-      const nextMeta = findCalendarTaskMeta(instance.id);
-      if (nextMeta) meta = nextMeta;
-      else meta = { task: instance, mode: "interval", list: window.tasksInterval, index: window.tasksInterval.indexOf(instance) };
-    }
-  }
   const todayKey = normalizeDateKey(new Date());
   if (!todayKey) return;
   const changed = markCalendarTaskComplete(meta, todayKey);
@@ -1613,6 +1622,87 @@ function wireCalendarBubbles(){
   });
 }
 
+function getTaskRecurrence(task){
+  if (!task || typeof task !== "object") return null;
+  if (typeof normalizeTaskRecurrence === "function"){
+    try { return normalizeTaskRecurrence(task); } catch (_err){}
+  }
+  const raw = task.recurrence && typeof task.recurrence === "object" ? task.recurrence : null;
+  if (!raw) return null;
+  const basis = String(raw.basis || "").toLowerCase();
+  const everyRaw = Number(raw.every);
+  return {
+    enabled: Boolean(raw.enabled),
+    basis: ["machine_hours", "calendar_day", "calendar_week", "calendar_month"].includes(basis) ? basis : "calendar_day",
+    every: Number.isFinite(everyRaw) && everyRaw > 0 ? Math.max(1, Math.round(everyRaw)) : 1,
+    intervalHours: Number.isFinite(Number(raw.intervalHours)) ? Number(raw.intervalHours) : null,
+    startISO: normalizeDateKey(raw.startISO || task.calendarDateISO || null),
+    endType: String(raw.endType || "never").toLowerCase(),
+    endDateISO: normalizeDateKey(raw.endDateISO || null),
+    endCount: Number.isFinite(Number(raw.endCount)) ? Math.max(1, Math.floor(Number(raw.endCount))) : null,
+    completionAnchorISO: normalizeDateKey(raw.completionAnchorISO || null),
+    completionAnchorHours: Number.isFinite(Number(raw.completionAnchorHours)) ? Number(raw.completionAnchorHours) : null
+  };
+}
+
+function projectCalendarBasedOccurrences(task, recurrence, options = {}){
+  if (!task || !recurrence || !recurrence.enabled) return [];
+  if (!["calendar_day", "calendar_week", "calendar_month"].includes(recurrence.basis)) return [];
+  const toDayStart = (value)=>{
+    const key = normalizeDateKey(value);
+    if (!key) return null;
+    const parsed = parseDateLocal(key);
+    if (!(parsed instanceof Date) || Number.isNaN(parsed.getTime())) return null;
+    parsed.setHours(0,0,0,0);
+    return parsed;
+  };
+  const excludeSet = new Set();
+  const excludeRaw = options.excludeDates;
+  if (excludeRaw && typeof excludeRaw.forEach === "function"){
+    excludeRaw.forEach(v => {
+      const key = normalizeDateKey(v);
+      if (key) excludeSet.add(key);
+    });
+  }
+  const minOccurrences = Number.isFinite(Number(options.minOccurrences)) ? Math.max(1, Math.floor(Number(options.minOccurrences))) : 1;
+  const maxOccurrences = Number.isFinite(Number(options.maxOccurrences)) ? Math.max(1, Math.floor(Number(options.maxOccurrences))) : null;
+  const startDate = toDayStart(recurrence.completionAnchorISO || recurrence.startISO || task.calendarDateISO || ymd(new Date()));
+  if (!startDate) return [];
+  const today = new Date(); today.setHours(0,0,0,0);
+  const horizon = new Date(today);
+  const monthsAhead = Number.isFinite(Number(options.monthsAhead)) ? Math.max(1, Number(options.monthsAhead)) : 3;
+  horizon.setMonth(horizon.getMonth() + monthsAhead);
+  const every = Math.max(1, Number(recurrence.every) || 1);
+  const endDate = recurrence.endType === "on_date" ? toDayStart(recurrence.endDateISO) : null;
+  const endCount = recurrence.endType === "after_count" ? Math.max(1, Number(recurrence.endCount) || 1) : null;
+  const events = [];
+  let producedCount = 0;
+  const maxIterations = 720;
+  for (let i = 0; i < maxIterations; i++){
+    const cursor = new Date(startDate);
+    if (recurrence.basis === "calendar_day"){
+      cursor.setDate(cursor.getDate() + (i * every));
+    }else if (recurrence.basis === "calendar_week"){
+      cursor.setDate(cursor.getDate() + (i * every * 7));
+    }else{
+      cursor.setMonth(cursor.getMonth() + (i * every));
+    }
+    cursor.setHours(0,0,0,0);
+    const key = ymd(cursor);
+    if (!key) continue;
+    producedCount += 1;
+    if (endDate && cursor.getTime() > endDate.getTime()) break;
+    if (endCount != null && producedCount > endCount) break;
+    if (excludeSet.has(key)) continue;
+    if (cursor.getTime() >= today.getTime()){
+      events.push({ dateISO: key, dueDate: new Date(cursor) });
+      if (maxOccurrences != null && events.length >= maxOccurrences) break;
+    }
+    if (cursor.getTime() > horizon.getTime() && events.length >= minOccurrences) break;
+  }
+  return events;
+}
+
 function estimateIntervalDailyHours(task, baselineEntry, today){
   const defaultHours = configuredDailyHours();
   const history = Array.isArray(task?.manualHistory) ? task.manualHistory : [];
@@ -1666,6 +1756,16 @@ function estimateIntervalDailyHours(task, baselineEntry, today){
 
 function projectIntervalDueDates(task, options = {}){
   if (!task || task.mode !== "interval") return [];
+  const recurrence = getTaskRecurrence(task);
+  if (recurrence && recurrence.enabled === false){
+    return [];
+  }
+  if (recurrence && recurrence.enabled && recurrence.basis !== "machine_hours"){
+    return projectCalendarBasedOccurrences(task, recurrence, options);
+  }
+  if (recurrence && recurrence.enabled && recurrence.basis === "machine_hours" && Number.isFinite(Number(recurrence.intervalHours)) && Number(recurrence.intervalHours) > 0){
+    task.interval = Number(recurrence.intervalHours);
+  }
   const interval = Number(task.interval);
   if (!Number.isFinite(interval) || interval <= 0) return [];
 
@@ -1948,6 +2048,7 @@ function renderCalendar(){
       const events = dueMap[segKey] ||= [];
       const baseId = String(task.id);
       const compositeId = seg.count > 1 ? `${baseId}__seg${seg.index}` : baseId;
+      const templateKey = String(task.templateId != null ? task.templateId : task.id);
       const existing = events.find(ev => ev.type === "task" && ev.id === compositeId);
       if (existing){
         existing.name = task.name;
@@ -1965,12 +2066,33 @@ function renderCalendar(){
         existing.totalDowntimeHours = downtimeHours;
         existing.taskId = baseId;
         existing.taskStartsOn = key;
+        existing.templateKey = templateKey;
+        return;
+      }
+      const duplicateByTemplate = events.find(ev =>
+        ev.type === "task"
+        && String(ev.templateKey || ev.taskId || ev.id) === templateKey
+        && String(ev.taskStartsOn || ev.dateISO || "") === String(key)
+        && Number(ev.segmentIndex || 0) === Number(seg.index || 0)
+      );
+      if (duplicateByTemplate){
+        const statusPriority = { completed: 3, manual: 2, due: 1 };
+        const nextPriority = statusPriority[statusKey] || 1;
+        const existingPriority = statusPriority[duplicateByTemplate.status || "due"] || 1;
+        if (nextPriority >= existingPriority){
+          duplicateByTemplate.status = statusKey;
+          duplicateByTemplate.name = task.name;
+          duplicateByTemplate.mode = task && task.mode === "asreq" ? "asreq" : "interval";
+          duplicateByTemplate.durationHours = seg.hours;
+          duplicateByTemplate.totalDowntimeHours = downtimeHours;
+        }
         return;
       }
       events.push({
         type: "task",
         id: compositeId,
         taskId: baseId,
+        templateKey,
         name: task.name,
         status: statusKey,
         mode: task && task.mode === "asreq" ? "asreq" : "interval",
@@ -2083,6 +2205,23 @@ function renderCalendar(){
     const manualKey = normalizeDateKey(t.calendarDateISO);
     if (manualKey){
       pushTaskEvent(t, manualKey, completedDates.has(manualKey) ? "completed" : "manual");
+    }
+    const recurrence = getTaskRecurrence(t);
+    if (recurrence && recurrence.enabled){
+      const skipDates = new Set(completedDates);
+      if (manualKey) skipDates.add(manualKey);
+      const projections = projectCalendarBasedOccurrences(t, recurrence, {
+        monthsAhead: 3,
+        excludeDates: skipDates,
+        minOccurrences: 1,
+        maxOccurrences: 1
+      });
+      if (projections.length){
+        const dueKey = normalizeDateKey(projections[0].dateISO);
+        if (dueKey && !completedDates.has(dueKey) && (!manualKey || manualKey !== dueKey)){
+          pushTaskEvent(t, dueKey, "due");
+        }
+      }
     }
   });
 

--- a/js/computations.js
+++ b/js/computations.js
@@ -181,7 +181,30 @@ function liveSince(task){
 }
 
 function nextDue(task){
-  if (!task || task.interval == null) return null;
+  if (!task) return null;
+  const recurrence = (()=>{
+    if (typeof normalizeTaskRecurrence === "function"){
+      try { return normalizeTaskRecurrence(task); } catch (_err){}
+    }
+    return task.recurrence && typeof task.recurrence === "object" ? task.recurrence : null;
+  })();
+  if (recurrence && recurrence.enabled === false) return null;
+  if (recurrence && recurrence.enabled && recurrence.basis && recurrence.basis !== "machine_hours"){
+    const startISO = (recurrence.completionAnchorISO || recurrence.startISO || task.calendarDateISO || ymd(new Date()));
+    const startDate = parseDateLocal(startISO);
+    if (!(startDate instanceof Date) || Number.isNaN(startDate.getTime())) return null;
+    startDate.setHours(0,0,0,0);
+    const every = Math.max(1, Number(recurrence.every) || 1);
+    const due = new Date(startDate);
+    if (recurrence.basis === "calendar_month") due.setMonth(due.getMonth() + every);
+    else if (recurrence.basis === "calendar_week") due.setDate(due.getDate() + (every * 7));
+    else due.setDate(due.getDate() + every);
+    due.setHours(0,0,0,0);
+    const today = new Date(); today.setHours(0,0,0,0);
+    const days = Math.round((due.getTime() - today.getTime()) / MS_PER_DAY);
+    return { since: 0, remain: 0, days, due, lastServicedAt: null };
+  }
+  if (task.interval == null) return null;
   const sinceRaw = liveSince(task);
   if (sinceRaw == null) return null;
   const since = Math.max(0, Number(sinceRaw) || 0);

--- a/js/core.js
+++ b/js/core.js
@@ -2254,8 +2254,17 @@ function ensureTaskCategories(){
     if (!t) return;
     if (!t.cat) t.cat = "interval";
     if (!Array.isArray(t.completedDates)) t.completedDates = [];
+    if (typeof window.normalizeTaskRecurrence === "function"){
+      try { window.normalizeTaskRecurrence(t); } catch (_err){}
+    }
   });
-  tasksAsReq.forEach(t =>    { if (t && !t.cat) t.cat = "asreq"; });
+  tasksAsReq.forEach(t =>    {
+    if (!t) return;
+    if (!t.cat) t.cat = "asreq";
+    if (typeof window.normalizeTaskRecurrence === "function"){
+      try { window.normalizeTaskRecurrence(t); } catch (_err){}
+    }
+  });
 }
 
 function ensureJobCategories(){

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -5173,13 +5173,18 @@ function renderDashboard(){
     if (taskExistingBasisInput){
       const isInterval = task?.mode === "interval";
       const options = isInterval
-        ? [{ value: "machine_hours", label: "By machine cutting hours" }]
+        ? [
+            { value: "machine_hours", label: "By machine cutting hours" },
+            { value: "calendar_day", label: "By calendar day" },
+            { value: "calendar_week", label: "By calendar week" },
+            { value: "calendar_month", label: "By calendar month" }
+          ]
         : [{ value: "calendar_day", label: "By calendar day" }];
       taskExistingBasisInput.innerHTML = options.map(opt => `<option value="${opt.value}">${opt.label}</option>`).join("");
       taskExistingBasisInput.value = recurrence?.basis && options.some(opt => opt.value === recurrence.basis)
         ? recurrence.basis
         : (isInterval ? "machine_hours" : "calendar_day");
-      taskExistingBasisInput.disabled = true;
+      taskExistingBasisInput.disabled = false;
     }
     if (taskExistingRepeatInput){
       taskExistingRepeatInput.value = task?.mode === "interval" ? "yes" : "no";
@@ -5361,9 +5366,8 @@ function renderDashboard(){
       if (endDateInput?.parentElement) endDateInput.parentElement.hidden = true;
       if (endCountInput?.parentElement) endCountInput.parentElement.hidden = true;
     }
-    const isHours = enabled && String(basisSelect?.value || "") === "machine_hours";
     if (basisSelect?.closest("label")){
-      basisSelect.closest("label").hidden = !enabled || isHours;
+      basisSelect.closest("label").hidden = !enabled;
     }
     const detailsRow = repeatSelect === taskExistingRepeatInput ? taskExistingWeekdaysRow : taskWeekdaysRow;
     if (detailsRow){
@@ -5710,12 +5714,17 @@ function renderDashboard(){
     }
     if (taskRepeatBasisInput){
       const options = isInterval
-        ? [{ value: "machine_hours", label: "By machine cutting hours" }]
+        ? [
+            { value: "machine_hours", label: "By machine cutting hours" },
+            { value: "calendar_day", label: "By calendar day" },
+            { value: "calendar_week", label: "By calendar week" },
+            { value: "calendar_month", label: "By calendar month" }
+          ]
         : [{ value: "calendar_day", label: "By calendar day" }];
       const current = String(taskRepeatBasisInput.value || "");
       taskRepeatBasisInput.innerHTML = options.map(opt => `<option value="${opt.value}">${opt.label}</option>`).join("");
       taskRepeatBasisInput.value = options.some(opt => opt.value === current) ? current : (isInterval ? "machine_hours" : "calendar_day");
-      taskRepeatBasisInput.disabled = true;
+      taskRepeatBasisInput.disabled = mode !== "interval";
     }
     if (taskConditionInput){
       taskConditionInput.disabled = mode !== "asreq";
@@ -5742,7 +5751,7 @@ function renderDashboard(){
     if (taskRepeatEveryInput) taskRepeatEveryInput.value = "1";
     if (taskRepeatEndInput) taskRepeatEndInput.value = "never";
     if (taskRepeatInput) taskRepeatInput.disabled = true;
-    if (taskRepeatBasisInput) taskRepeatBasisInput.disabled = true;
+    if (taskRepeatBasisInput) taskRepeatBasisInput.disabled = false;
     if (taskWeekdaysRow) taskWeekdaysRow.hidden = true;
     toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput);
     syncTaskRepeatMode();
@@ -8321,7 +8330,12 @@ function renderSettings(){
             </select></label>
             <label data-field="recurrenceBasis">Repeat basis<select data-k="recurrenceBasis" data-id="${t.id}" data-list="${type}">
               ${type === "interval"
-                ? `<option value="machine_hours" ${recurrence.basis==="machine_hours"?"selected":""}>Machine cutting hours</option>`
+                ? `
+                  <option value="machine_hours" ${recurrence.basis==="machine_hours"?"selected":""}>Machine cutting hours</option>
+                  <option value="calendar_day" ${recurrence.basis==="calendar_day"?"selected":""}>Calendar day</option>
+                  <option value="calendar_week" ${recurrence.basis==="calendar_week"?"selected":""}>Calendar week</option>
+                  <option value="calendar_month" ${recurrence.basis==="calendar_month"?"selected":""}>Calendar month</option>
+                `
                 : `<option value="calendar_day" ${recurrence.basis==="calendar_day"?"selected":""}>Calendar day</option>`}
             </select></label>
             <label data-field="recurrenceEvery">Repeat every<input type="number" min="1" step="1" data-k="recurrenceEvery" data-id="${t.id}" data-list="${type}" value="${Math.max(1, Number(recurrence.every)||1)}"></label>
@@ -8639,8 +8653,6 @@ function renderSettings(){
         basisRow.disabled = mode !== "interval";
         if (mode !== "interval"){
           basisRow.value = "calendar_day";
-        }else{
-          basisRow.value = "machine_hours";
         }
       }
     }
@@ -9701,7 +9713,10 @@ function renderSettings(){
       if (selectKey === "recurrenceEnabled"){
         recurrence.enabled = meta.task.mode === "interval";
       }else if (selectKey === "recurrenceBasis"){
-        recurrence.basis = meta.task.mode === "interval" ? "machine_hours" : "calendar_day";
+        const requested = String(target.value || "");
+        recurrence.basis = meta.task.mode === "interval"
+          ? (["machine_hours", "calendar_day", "calendar_week", "calendar_month"].includes(requested) ? requested : "machine_hours")
+          : "calendar_day";
         if (recurrence.basis === "machine_hours"){
           recurrence.intervalHours = Number(meta.task.interval) || Number(recurrence.intervalHours) || 1;
           recurrence.every = Math.max(1, Math.round(Number(recurrence.intervalHours) || 1));
@@ -9733,9 +9748,11 @@ function renderSettings(){
         const every = Math.max(1, Number(recurrence.every) || Number(meta.task.interval) || 8);
         meta.task.interval = every;
         recurrence.enabled = true;
-        recurrence.basis = "machine_hours";
+        recurrence.basis = ["machine_hours", "calendar_day", "calendar_week", "calendar_month"].includes(String(recurrence.basis || ""))
+          ? recurrence.basis
+          : "machine_hours";
         recurrence.every = every;
-        recurrence.intervalHours = every;
+        recurrence.intervalHours = recurrence.basis === "machine_hours" ? every : null;
         recurrence.endType = recurrence.endType || "never";
         meta.task.recurrence = recurrence;
         const baseSince = Number(meta.task.sinceBase);

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -5326,7 +5326,7 @@ function renderDashboard(){
         oneTimeNameInput.focus();
       }
     }else{
-      syncTaskMode(taskTypeSelect?.value || "interval");
+      syncTaskRepeatMode();
       syncTaskDateInput();
       if (taskNameInput){
         taskNameInput.focus();
@@ -5712,6 +5712,33 @@ function renderDashboard(){
     }
   }
 
+  function deriveTaskModeFromRepeat(){
+    const repeatEnabled = String(taskRepeatInput?.value || "no") === "yes";
+    const basis = String(taskRepeatBasisInput?.value || "calendar_day");
+    if (!repeatEnabled) return "asreq";
+    return basis === "machine_hours" ? "interval" : "asreq";
+  }
+
+  function syncTaskRepeatMode(){
+    const derivedMode = deriveTaskModeFromRepeat();
+    if (taskTypeSelect){
+      taskTypeSelect.value = derivedMode;
+      taskTypeSelect.disabled = true;
+      const row = taskTypeSelect.closest("label");
+      if (row) row.hidden = true;
+    }
+    syncTaskMode(derivedMode);
+    if (taskConditionInput){
+      taskConditionInput.disabled = derivedMode !== "asreq";
+    }
+    if (taskIntervalInput){
+      taskIntervalInput.disabled = derivedMode !== "interval";
+    }
+    if (taskLastInput){
+      taskLastInput.disabled = derivedMode !== "interval";
+    }
+  }
+
   function resetTaskForm(){
     taskForm?.reset();
     if (taskDowntimeInput){
@@ -5720,12 +5747,13 @@ function renderDashboard(){
     subtaskList?.replaceChildren();
     resetExistingTaskForm();
     showTaskOptionStage();
-    syncTaskMode(taskTypeSelect?.value || "interval");
-    syncTaskDateInput();
     if (taskRepeatInput) taskRepeatInput.value = "no";
+    if (taskRepeatBasisInput) taskRepeatBasisInput.value = "machine_hours";
     if (taskRepeatEveryInput) taskRepeatEveryInput.value = "1";
     if (taskRepeatEndInput) taskRepeatEndInput.value = "never";
     toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput);
+    syncTaskRepeatMode();
+    syncTaskDateInput();
   }
 
   function showStep(step){
@@ -6018,12 +6046,15 @@ function renderDashboard(){
 
   taskTypeSelect?.addEventListener("change", ()=> syncTaskMode(taskTypeSelect.value));
   taskRepeatInput?.addEventListener("change", ()=> toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput));
+  taskRepeatInput?.addEventListener("change", ()=> syncTaskRepeatMode());
+  taskRepeatBasisInput?.addEventListener("change", ()=> syncTaskRepeatMode());
   taskRepeatEndInput?.addEventListener("change", ()=> toggleRepeatEndFields(taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput));
   taskExistingRepeatInput?.addEventListener("change", ()=> toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput));
   taskExistingEndInput?.addEventListener("change", ()=> toggleRepeatEndFields(taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput));
   syncTaskMode(taskTypeSelect?.value || "interval");
   toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput);
   toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
+  syncTaskRepeatMode();
   syncTaskDateInput();
   syncOneTimeDateInput();
   populateCategoryOptions();
@@ -6041,7 +6072,7 @@ function renderDashboard(){
     if (!taskForm) return;
     const name = (taskNameInput?.value || "").trim();
     if (!name){ alert("Task name is required."); return; }
-    const mode = (taskTypeSelect?.value === "asreq") ? "asreq" : "interval";
+    const mode = deriveTaskModeFromRepeat();
     const manual = (taskManualInput?.value || "").trim();
     const store  = (taskStoreInput?.value || "").trim();
     const pn     = (taskPNInput?.value || "").trim();
@@ -7642,10 +7673,20 @@ function renderSettings(){
   window.tasksInterval   = Array.isArray(window.tasksInterval)   ? window.tasksInterval   : [];
   window.tasksAsReq      = Array.isArray(window.tasksAsReq)      ? window.tasksAsReq      : [];
   if (!(window.settingsOpenFolders instanceof Set)) window.settingsOpenFolders = new Set();
+  if (!(window.settingsOpenTasks instanceof Set)) window.settingsOpenTasks = new Set();
   const openFolderState = window.settingsOpenFolders;
+  const openTaskState = window.settingsOpenTasks;
   const validFolderIds = new Set(window.settingsFolders.map(f => String(f.id)));
+  const validTaskIds = new Set(
+    window.tasksInterval.concat(window.tasksAsReq)
+      .filter(Boolean)
+      .map(task => String(task.id))
+  );
   for (const id of Array.from(openFolderState)){
     if (!validFolderIds.has(id)) openFolderState.delete(id);
+  }
+  for (const id of Array.from(openTaskState)){
+    if (!validTaskIds.has(id)) openTaskState.delete(id);
   }
   if (typeof window._maintOrderCounter === "undefined") window._maintOrderCounter = 0;
 
@@ -8248,8 +8289,9 @@ function renderSettings(){
       emptyAttrs: `data-empty-sub="${t.id}"`
     });
     const inventoryInfo = getInventoryLinkInfo(t);
+    const openAttr = openTaskState.has(String(t.id)) ? " open" : "";
     return `
-      <details class="task task--${type}" data-task-id="${t.id}" data-owner="${type}" data-editing="0">
+      <details class="task task--${type}" data-task-id="${t.id}" data-owner="${type}" data-editing="0"${openAttr}>
         <summary draggable="true">
           <span class="task-name">${name}</span>
           <span class="chip">${type === "interval" ? "By Interval" : "As Required"}</span>
@@ -8560,6 +8602,59 @@ function renderSettings(){
       linkBtn.disabled = !isEditing;
       linkBtn.classList.toggle("is-locked-control", !isEditing);
     }
+    updateTaskFieldRelevance(taskEl);
+  };
+
+  const updateTaskFieldRelevance = (taskEl)=>{
+    if (!(taskEl instanceof HTMLElement)) return;
+    const taskId = taskEl.getAttribute("data-task-id");
+    const meta = taskId ? findTaskMeta(taskId) : null;
+    const task = meta?.task;
+    if (!task) return;
+    const recurrence = normalizeTaskRecurrence(task);
+    const isEditing = getTaskEditingState(taskEl);
+    const repeatEnabled = Boolean(recurrence?.enabled);
+    const basis = String(recurrence?.basis || "");
+    const endType = String(recurrence?.endType || "never");
+    const mode = String(task.mode || meta.mode || "asreq");
+    const toggle = (field, visible)=>{
+      const row = taskEl.querySelector(`[data-field="${field}"]`);
+      if (!row) return;
+      row.hidden = !visible;
+      const control = row.querySelector("input,select,textarea");
+      if (control instanceof HTMLElement){
+        if (!visible){
+          control.setAttribute("data-irrelevant", "1");
+          control.setAttribute("disabled", "disabled");
+        }else{
+          control.removeAttribute("data-irrelevant");
+          if (isEditing){
+            control.removeAttribute("disabled");
+          }
+        }
+      }
+    };
+    toggle("interval", mode === "interval");
+    toggle("sinceBase", mode === "interval");
+    toggle("condition", mode !== "interval");
+    toggle("recurrenceBasis", repeatEnabled);
+    toggle("recurrenceEvery", repeatEnabled);
+    toggle("recurrenceEndType", repeatEnabled);
+    toggle("recurrenceEndDate", repeatEnabled && endType === "on_date");
+    toggle("recurrenceEndCount", repeatEnabled && endType === "after_count");
+    if (repeatEnabled){
+      const basisRow = taskEl.querySelector('[data-field="recurrenceBasis"] select[data-k="recurrenceBasis"]');
+      if (basisRow instanceof HTMLSelectElement){
+        Array.from(basisRow.options).forEach(opt => {
+          if (opt.value === "machine_hours"){
+            opt.disabled = mode !== "interval";
+          }
+        });
+        if (mode !== "interval" && basis === "machine_hours"){
+          basisRow.value = "calendar_day";
+        }
+      }
+    }
   };
 
   const closeInventoryLinkModal = ()=>{
@@ -8679,6 +8774,7 @@ function renderSettings(){
   };
 
   lockAllTasks();
+  tree?.querySelectorAll("details.task").forEach(taskEl => updateTaskFieldRelevance(taskEl));
 
   tree?.addEventListener("dblclick", (e)=>{
     const target = e.target;
@@ -8697,9 +8793,16 @@ function renderSettings(){
     const details = e.target;
     if (!(details instanceof HTMLDetailsElement)) return;
     if (!details.matches("details.task")) return;
+    const taskId = details.getAttribute("data-task-id");
+    if (taskId){
+      if (details.open) openTaskState.add(String(taskId));
+      else openTaskState.delete(String(taskId));
+    }
     if (!details.open){
       setTaskEditingState(details, false);
+      return;
     }
+    updateTaskFieldRelevance(details);
   });
 
   const promptRemoveLinkedInventory = async (task, matches)=>{
@@ -9580,6 +9683,7 @@ function renderSettings(){
       meta.task.recurrence = recurrence;
       const recurChip = holder.querySelector('[data-chip-recurrence]');
       if (recurChip) recurChip.textContent = recurrenceSummaryLabel(meta.task);
+      updateTaskFieldRelevance(holder);
       if (typeof refreshDashboardWidgets === "function") refreshDashboardWidgets({ full: true });
     }else if (key === "recurrenceEndDate"){
       const recurrence = normalizeTaskRecurrence(meta.task);
@@ -9588,6 +9692,7 @@ function renderSettings(){
       meta.task.recurrence = recurrence;
       const recurChip = holder.querySelector('[data-chip-recurrence]');
       if (recurChip) recurChip.textContent = recurrenceSummaryLabel(meta.task);
+      updateTaskFieldRelevance(holder);
     }
     persist();
   });
@@ -9629,6 +9734,7 @@ function renderSettings(){
       normalizeTaskRecurrence(meta.task);
       const recurChip = holder.querySelector('[data-chip-recurrence]');
       if (recurChip) recurChip.textContent = recurrenceSummaryLabel(meta.task);
+      updateTaskFieldRelevance(holder);
       if (typeof refreshDashboardWidgets === "function") refreshDashboardWidgets({ full: true });
       persist();
       if (typeof renderCalendar === "function") renderCalendar();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -7964,6 +7964,7 @@ function renderSettings(){
     const openTaskIds = Array.isArray(pending.openTaskIds)
       ? pending.openTaskIds.map(id => String(id)).filter(Boolean)
       : [];
+    openTaskIds.forEach(id => openTaskState.add(id));
     openTaskIds.forEach(ensureTaskOpen);
 
     const idsSource = Array.isArray(pending.taskIds)

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -5016,6 +5016,8 @@ function renderDashboard(){
   const taskRepeatEndInput = document.getElementById("dashTaskRepeatEnd");
   const taskRepeatEndDateInput = document.getElementById("dashTaskRepeatEndDate");
   const taskRepeatEndCountInput = document.getElementById("dashTaskRepeatEndCount");
+  const taskWeekdaysRow = document.getElementById("dashTaskWeekdaysRow");
+  const taskWeekdayInputs = Array.from(modal?.querySelectorAll('[data-task-weekday]') || []);
   const subtaskList      = document.getElementById("dashSubtaskList");
   const addSubtaskBtn    = document.getElementById("dashAddSubtask");
   const taskOptionStage  = modal?.querySelector('[data-task-option-stage]');
@@ -5033,6 +5035,8 @@ function renderDashboard(){
   const taskExistingEndInput = document.getElementById("dashTaskExistingRepeatEnd");
   const taskExistingEndDateInput = document.getElementById("dashTaskExistingRepeatEndDate");
   const taskExistingEndCountInput = document.getElementById("dashTaskExistingRepeatEndCount");
+  const taskExistingWeekdaysRow = document.getElementById("dashTaskExistingWeekdaysRow");
+  const taskExistingWeekdayInputs = Array.from(modal?.querySelectorAll('[data-existing-weekday]') || []);
   const taskCardBackButtons = Array.from(modal?.querySelectorAll('[data-task-card-back]') || []);
   const oneTimeForm      = document.getElementById("dashOneTimeForm");
   const oneTimeNameInput = document.getElementById("dashOneTimeName");
@@ -5203,6 +5207,16 @@ function renderDashboard(){
     if (taskExistingEndCountInput){
       taskExistingEndCountInput.value = String(Math.max(1, Number(recurrence?.endCount) || 1));
     }
+    taskExistingWeekdayInputs.forEach(input => {
+      if (!(input instanceof HTMLInputElement)) return;
+      const day = Number(input.value);
+      const selected = Array.isArray(recurrence?.weekDays) && recurrence.weekDays.includes(day);
+      input.checked = !!selected;
+    });
+    const weekly = String(taskExistingBasisInput?.value || "") === "calendar_week";
+    if (taskExistingWeekdaysRow){
+      taskExistingWeekdaysRow.hidden = !(taskExistingRepeatInput?.value === "yes" && weekly);
+    }
     toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
   }
 
@@ -5292,8 +5306,11 @@ function renderDashboard(){
     if (taskExistingSearchInput) taskExistingSearchInput.value = "";
     if (taskExistingNoteInput) taskExistingNoteInput.value = "";
     if (taskExistingRepeatInput) taskExistingRepeatInput.value = "no";
+    if (taskExistingBasisInput) taskExistingBasisInput.value = "calendar_day";
     if (taskExistingEveryInput) taskExistingEveryInput.value = "1";
     if (taskExistingEndInput) taskExistingEndInput.value = "never";
+    taskExistingWeekdayInputs.forEach(input => { if (input instanceof HTMLInputElement) input.checked = false; });
+    if (taskExistingWeekdaysRow) taskExistingWeekdaysRow.hidden = true;
     setSelectedExistingTask(null);
     refreshExistingTaskOptions("");
     toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
@@ -5347,18 +5364,18 @@ function renderDashboard(){
   }
 
   function toggleRepeatEndFields(endSelect, endDateInput, endCountInput){
-    if (endDateInput?.parentElement) endDateInput.parentElement.hidden = true;
-    if (endCountInput?.parentElement) endCountInput.parentElement.hidden = true;
+    const mode = String(endSelect?.value || "never");
+    if (endDateInput?.parentElement) endDateInput.parentElement.hidden = mode !== "on_date";
+    if (endCountInput?.parentElement) endCountInput.parentElement.hidden = mode !== "after_count";
   }
 
   function toggleRepeatFields(repeatSelect, basisSelect, everyInput, endSelect, endDateInput, endCountInput){
     const enabled = String(repeatSelect?.value || "no") === "yes";
-    [basisSelect, everyInput].forEach(el => {
+    [basisSelect, everyInput, endSelect].forEach(el => {
       if (!el) return;
       const row = el.closest("label");
       if (row) row.hidden = !enabled;
     });
-    if (endSelect?.closest("label")) endSelect.closest("label").hidden = true;
     toggleRepeatEndFields(endSelect, endDateInput, endCountInput);
     if (!enabled){
       if (endDateInput?.parentElement) endDateInput.parentElement.hidden = true;
@@ -5375,9 +5392,29 @@ function renderDashboard(){
       : (defaultBasis || "calendar_day");
     const everyRaw = Number(everyInput?.value);
     const every = Number.isFinite(everyRaw) && everyRaw > 0 ? Math.max(1, Math.round(everyRaw)) : 1;
-    const payload = { enabled: true, basis, every, endType: "never" };
+    const endTypeRaw = String(endInput?.value || "never").toLowerCase();
+    const endType = ["never", "on_date", "after_count"].includes(endTypeRaw) ? endTypeRaw : "never";
+    const payload = { enabled: true, basis, every, endType };
     if (basis === "machine_hours"){
       payload.intervalHours = every;
+    }
+    if (basis === "calendar_week"){
+      const source = repeatInput === taskExistingRepeatInput ? taskExistingWeekdayInputs : taskWeekdayInputs;
+      const weekDays = source
+        .filter(input => input instanceof HTMLInputElement && input.checked)
+        .map(input => Number(input.value))
+        .filter(day => Number.isInteger(day) && day >= 0 && day <= 6);
+      if (weekDays.length){
+        payload.weekDays = Array.from(new Set(weekDays)).sort((a,b)=> a - b);
+      }
+    }
+    if (endType === "on_date"){
+      const endDateISO = normalizeDateKey(endDateInput?.value || null);
+      if (endDateISO) payload.endDateISO = endDateISO;
+      else payload.endType = "never";
+    }else if (endType === "after_count"){
+      const countRaw = Number(endCountInput?.value);
+      payload.endCount = Number.isFinite(countRaw) && countRaw > 0 ? Math.floor(countRaw) : 1;
     }
     return payload;
   }
@@ -5673,7 +5710,6 @@ function renderDashboard(){
 
   function syncTaskMode(mode){
     if (!taskFreqRow || !taskLastRow || !taskConditionRow) return;
-    const isAsReq = mode === "asreq";
     if (mode === "asreq"){
       taskFreqRow.hidden = true;
       taskLastRow.hidden = true;
@@ -5683,50 +5719,46 @@ function renderDashboard(){
       taskLastRow.hidden = false;
       taskConditionRow.hidden = true;
     }
-    if (taskRepeatBasisInput){
-      const dayOptions = [
-        { value: "calendar_day", label: "By calendar day" },
-        { value: "calendar_week", label: "By calendar week" },
-        { value: "calendar_month", label: "By calendar month" }
-      ];
-      const intervalOptions = [
-        { value: "machine_hours", label: "By machine cutting hours" },
-        ...dayOptions
-      ];
-      const options = isAsReq ? dayOptions : intervalOptions;
-      const current = String(taskRepeatBasisInput.value || "");
-      taskRepeatBasisInput.innerHTML = options.map(opt => `<option value="${opt.value}">${opt.label}</option>`).join("");
-      taskRepeatBasisInput.value = options.some(opt => opt.value === current)
-        ? current
-        : (isAsReq ? "calendar_day" : "machine_hours");
-    }
   }
 
-  function deriveTaskModeFromRepeat(){
-    const repeatEnabled = String(taskRepeatInput?.value || "no") === "yes";
-    const basis = String(taskRepeatBasisInput?.value || "calendar_day");
-    if (!repeatEnabled) return "asreq";
-    return basis === "machine_hours" ? "interval" : "asreq";
+  function selectedTaskMode(){
+    return (taskTypeSelect?.value === "asreq") ? "asreq" : "interval";
   }
 
   function syncTaskRepeatMode(){
-    const derivedMode = deriveTaskModeFromRepeat();
-    if (taskTypeSelect){
-      taskTypeSelect.value = derivedMode;
-      taskTypeSelect.disabled = true;
-      const row = taskTypeSelect.closest("label");
-      if (row) row.hidden = true;
+    const mode = selectedTaskMode();
+    syncTaskMode(mode);
+    const repeatEnabled = String(taskRepeatInput?.value || "no") === "yes";
+    if (taskRepeatBasisInput){
+      const isInterval = mode === "interval";
+      const options = isInterval
+        ? [
+            { value: "machine_hours", label: "By machine cutting hours" },
+            { value: "calendar_day", label: "By calendar day" },
+            { value: "calendar_week", label: "By calendar week" },
+            { value: "calendar_month", label: "By calendar month" }
+          ]
+        : [
+            { value: "calendar_day", label: "By calendar day" },
+            { value: "calendar_week", label: "By calendar week" },
+            { value: "calendar_month", label: "By calendar month" }
+          ];
+      const current = String(taskRepeatBasisInput.value || "");
+      taskRepeatBasisInput.innerHTML = options.map(opt => `<option value="${opt.value}">${opt.label}</option>`).join("");
+      taskRepeatBasisInput.value = options.some(opt => opt.value === current) ? current : (isInterval ? "machine_hours" : "calendar_day");
     }
-    syncTaskMode(derivedMode);
     if (taskConditionInput){
-      taskConditionInput.disabled = derivedMode !== "asreq";
+      taskConditionInput.disabled = mode !== "asreq";
     }
     if (taskIntervalInput){
-      taskIntervalInput.disabled = derivedMode !== "interval";
+      taskIntervalInput.disabled = mode !== "interval";
     }
     if (taskLastInput){
-      taskLastInput.disabled = derivedMode !== "interval";
+      taskLastInput.disabled = mode !== "interval";
     }
+    toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput);
+    const weekly = repeatEnabled && String(taskRepeatBasisInput?.value || "") === "calendar_week";
+    if (taskWeekdaysRow) taskWeekdaysRow.hidden = !weekly;
   }
 
   function resetTaskForm(){
@@ -5741,6 +5773,8 @@ function renderDashboard(){
     if (taskRepeatBasisInput) taskRepeatBasisInput.value = "machine_hours";
     if (taskRepeatEveryInput) taskRepeatEveryInput.value = "1";
     if (taskRepeatEndInput) taskRepeatEndInput.value = "never";
+    taskWeekdayInputs.forEach(input => { if (input instanceof HTMLInputElement) input.checked = false; });
+    if (taskWeekdaysRow) taskWeekdaysRow.hidden = true;
     toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput);
     syncTaskRepeatMode();
     syncTaskDateInput();
@@ -6034,12 +6068,20 @@ function renderDashboard(){
     }, 80);
   });
 
-  taskTypeSelect?.addEventListener("change", ()=> syncTaskMode(taskTypeSelect.value));
+  taskTypeSelect?.addEventListener("change", ()=> syncTaskRepeatMode());
   taskRepeatInput?.addEventListener("change", ()=> toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput));
   taskRepeatInput?.addEventListener("change", ()=> syncTaskRepeatMode());
   taskRepeatBasisInput?.addEventListener("change", ()=> syncTaskRepeatMode());
   taskRepeatEndInput?.addEventListener("change", ()=> toggleRepeatEndFields(taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput));
-  taskExistingRepeatInput?.addEventListener("change", ()=> toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput));
+  taskExistingRepeatInput?.addEventListener("change", ()=> {
+    toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
+    const weekly = String(taskExistingBasisInput?.value || "") === "calendar_week";
+    if (taskExistingWeekdaysRow) taskExistingWeekdaysRow.hidden = !(taskExistingRepeatInput?.value === "yes" && weekly);
+  });
+  taskExistingBasisInput?.addEventListener("change", ()=> {
+    const weekly = String(taskExistingBasisInput?.value || "") === "calendar_week";
+    if (taskExistingWeekdaysRow) taskExistingWeekdaysRow.hidden = !(taskExistingRepeatInput?.value === "yes" && weekly);
+  });
   taskExistingEndInput?.addEventListener("change", ()=> toggleRepeatEndFields(taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput));
   syncTaskMode(taskTypeSelect?.value || "interval");
   toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput);
@@ -6062,7 +6104,7 @@ function renderDashboard(){
     if (!taskForm) return;
     const name = (taskNameInput?.value || "").trim();
     if (!name){ alert("Task name is required."); return; }
-    const mode = deriveTaskModeFromRepeat();
+    const mode = selectedTaskMode();
     const manual = (taskManualInput?.value || "").trim();
     const store  = (taskStoreInput?.value || "").trim();
     const pn     = (taskPNInput?.value || "").trim();
@@ -7882,6 +7924,8 @@ function renderSettings(){
       .modal-card h4{margin:0 0 12px;font-size:1.1rem}
       .modal-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px}
       .modal-grid label{display:flex;flex-direction:column;font-size:.9rem;gap:4px}
+      .task-weekday-group{display:flex;flex-wrap:wrap;gap:8px;padding-top:4px}
+      .task-weekday-group label{display:inline-flex;flex-direction:row;align-items:center;gap:4px;font-size:.82rem}
       .modal-grid input,.modal-grid select,.modal-grid textarea{padding:.45rem .55rem;border:1px solid #cdd4e1;border-radius:6px;font-size:.95rem}
       .modal-grid textarea{min-height:90px;resize:vertical}
       .modal-grid .task-note{grid-column:1/-1}

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -5347,18 +5347,18 @@ function renderDashboard(){
   }
 
   function toggleRepeatEndFields(endSelect, endDateInput, endCountInput){
-    const mode = String(endSelect?.value || "never");
-    if (endDateInput) endDateInput.parentElement.hidden = mode !== "on_date";
-    if (endCountInput) endCountInput.parentElement.hidden = mode !== "after_count";
+    if (endDateInput?.parentElement) endDateInput.parentElement.hidden = true;
+    if (endCountInput?.parentElement) endCountInput.parentElement.hidden = true;
   }
 
   function toggleRepeatFields(repeatSelect, basisSelect, everyInput, endSelect, endDateInput, endCountInput){
     const enabled = String(repeatSelect?.value || "no") === "yes";
-    [basisSelect, everyInput, endSelect].forEach(el => {
+    [basisSelect, everyInput].forEach(el => {
       if (!el) return;
       const row = el.closest("label");
       if (row) row.hidden = !enabled;
     });
+    if (endSelect?.closest("label")) endSelect.closest("label").hidden = true;
     toggleRepeatEndFields(endSelect, endDateInput, endCountInput);
     if (!enabled){
       if (endDateInput?.parentElement) endDateInput.parentElement.hidden = true;
@@ -5375,19 +5375,9 @@ function renderDashboard(){
       : (defaultBasis || "calendar_day");
     const everyRaw = Number(everyInput?.value);
     const every = Number.isFinite(everyRaw) && everyRaw > 0 ? Math.max(1, Math.round(everyRaw)) : 1;
-    const endTypeRaw = String(endInput?.value || "never").toLowerCase();
-    const endType = ["never", "on_date", "after_count"].includes(endTypeRaw) ? endTypeRaw : "never";
-    const payload = { enabled: true, basis, every, endType };
+    const payload = { enabled: true, basis, every, endType: "never" };
     if (basis === "machine_hours"){
       payload.intervalHours = every;
-    }
-    if (endType === "on_date"){
-      const endDateISO = normalizeDateKey(endDateInput?.value || null);
-      if (endDateISO) payload.endDateISO = endDateISO;
-      else payload.endType = "never";
-    } else if (endType === "after_count"){
-      const countRaw = Number(endCountInput?.value);
-      payload.endCount = Number.isFinite(countRaw) && countRaw > 0 ? Math.floor(countRaw) : 1;
     }
     return payload;
   }
@@ -8324,13 +8314,6 @@ function renderSettings(){
               <option value="calendar_month" ${recurrence.basis==="calendar_month"?"selected":""}>Calendar month</option>
             </select></label>
             <label data-field="recurrenceEvery">Repeat every<input type="number" min="1" step="1" data-k="recurrenceEvery" data-id="${t.id}" data-list="${type}" value="${Math.max(1, Number(recurrence.every)||1)}"></label>
-            <label data-field="recurrenceEndType">Repeat ends<select data-k="recurrenceEndType" data-id="${t.id}" data-list="${type}">
-              <option value="never" ${recurrence.endType==="never"?"selected":""}>Never</option>
-              <option value="on_date" ${recurrence.endType==="on_date"?"selected":""}>On date</option>
-              <option value="after_count" ${recurrence.endType==="after_count"?"selected":""}>After count</option>
-            </select></label>
-            <label data-field="recurrenceEndDate">Repeat end date<input type="date" data-k="recurrenceEndDate" data-id="${t.id}" data-list="${type}" value="${escapeHtml(recurrence.endDateISO||"")}"></label>
-            <label data-field="recurrenceEndCount">Repeat end count<input type="number" min="1" step="1" data-k="recurrenceEndCount" data-id="${t.id}" data-list="${type}" value="${Math.max(1, Number(recurrence.endCount)||1)}"></label>
             <label data-field="manualLink">Manual link<input type="url" data-k="manualLink" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.manualLink||"")}" placeholder="https://..."></label>
             <label data-field="storeLink">Store link<input type="url" data-k="storeLink" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.storeLink||"")}" placeholder="https://..."></label>
             <label data-field="pn">Part #<input data-k="pn" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.pn||"")}" placeholder="Part number"></label>
@@ -8616,7 +8599,6 @@ function renderSettings(){
     const isEditing = getTaskEditingState(taskEl);
     const repeatEnabled = Boolean(recurrence?.enabled);
     const basis = String(recurrence?.basis || "");
-    const endType = String(recurrence?.endType || "never");
     const mode = String(task.mode || meta.mode || "asreq");
     const toggle = (field, visible)=>{
       const row = taskEl.querySelector(`[data-field="${field}"]`);
@@ -8641,9 +8623,6 @@ function renderSettings(){
     const showRecurrenceDetail = repeatEnabled && isEditing;
     toggle("recurrenceBasis", showRecurrenceDetail);
     toggle("recurrenceEvery", showRecurrenceDetail);
-    toggle("recurrenceEndType", showRecurrenceDetail);
-    toggle("recurrenceEndDate", showRecurrenceDetail && endType === "on_date");
-    toggle("recurrenceEndCount", showRecurrenceDetail && endType === "after_count");
     if (repeatEnabled){
       const basisRow = taskEl.querySelector('[data-field="recurrenceBasis"] select[data-k="recurrenceBasis"]');
       if (basisRow instanceof HTMLSelectElement){
@@ -8776,6 +8755,13 @@ function renderSettings(){
   };
 
   lockAllTasks();
+  openTaskState.forEach(taskId => {
+    const selector = `[data-task-id="${escapeAttr(taskId)}"]`;
+    const el = root.querySelector(selector);
+    if (!el) return;
+    ensureDetailsChainOpen(el);
+    if (el instanceof HTMLDetailsElement) el.open = true;
+  });
   tree?.querySelectorAll("details.task").forEach(taskEl => updateTaskFieldRelevance(taskEl));
 
   tree?.addEventListener("dblclick", (e)=>{

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -5017,7 +5017,6 @@ function renderDashboard(){
   const taskRepeatEndDateInput = document.getElementById("dashTaskRepeatEndDate");
   const taskRepeatEndCountInput = document.getElementById("dashTaskRepeatEndCount");
   const taskWeekdaysRow = document.getElementById("dashTaskWeekdaysRow");
-  const taskWeekdayInputs = Array.from(modal?.querySelectorAll('[data-task-weekday]') || []);
   const subtaskList      = document.getElementById("dashSubtaskList");
   const addSubtaskBtn    = document.getElementById("dashAddSubtask");
   const taskOptionStage  = modal?.querySelector('[data-task-option-stage]');
@@ -5036,7 +5035,6 @@ function renderDashboard(){
   const taskExistingEndDateInput = document.getElementById("dashTaskExistingRepeatEndDate");
   const taskExistingEndCountInput = document.getElementById("dashTaskExistingRepeatEndCount");
   const taskExistingWeekdaysRow = document.getElementById("dashTaskExistingWeekdaysRow");
-  const taskExistingWeekdayInputs = Array.from(modal?.querySelectorAll('[data-existing-weekday]') || []);
   const taskCardBackButtons = Array.from(modal?.querySelectorAll('[data-task-card-back]') || []);
   const oneTimeForm      = document.getElementById("dashOneTimeForm");
   const oneTimeNameInput = document.getElementById("dashOneTimeName");
@@ -5068,7 +5066,6 @@ function renderDashboard(){
   const garnetCancelBtn  = document.getElementById("dashGarnetCancel");
   const garnetList       = document.getElementById("dashGarnetList");
 
-  const taskFreqRow      = taskForm?.querySelector("[data-task-frequency]");
   const taskLastRow      = taskForm?.querySelector("[data-task-last]");
   const taskConditionRow = taskForm?.querySelector("[data-task-condition]");
   const stepSections     = modal ? Array.from(modal.querySelectorAll("[data-step]")) : [];
@@ -5176,24 +5173,17 @@ function renderDashboard(){
     if (taskExistingBasisInput){
       const isInterval = task?.mode === "interval";
       const options = isInterval
-        ? [
-            { value: "machine_hours", label: "By machine cutting hours" },
-            { value: "calendar_day", label: "By calendar day" },
-            { value: "calendar_week", label: "By calendar week" },
-            { value: "calendar_month", label: "By calendar month" }
-          ]
-        : [
-            { value: "calendar_day", label: "By calendar day" },
-            { value: "calendar_week", label: "By calendar week" },
-            { value: "calendar_month", label: "By calendar month" }
-          ];
+        ? [{ value: "machine_hours", label: "By machine cutting hours" }]
+        : [{ value: "calendar_day", label: "By calendar day" }];
       taskExistingBasisInput.innerHTML = options.map(opt => `<option value="${opt.value}">${opt.label}</option>`).join("");
       taskExistingBasisInput.value = recurrence?.basis && options.some(opt => opt.value === recurrence.basis)
         ? recurrence.basis
         : (isInterval ? "machine_hours" : "calendar_day");
+      taskExistingBasisInput.disabled = true;
     }
     if (taskExistingRepeatInput){
-      taskExistingRepeatInput.value = recurrence?.enabled ? "yes" : "no";
+      taskExistingRepeatInput.value = task?.mode === "interval" ? "yes" : "no";
+      taskExistingRepeatInput.disabled = true;
     }
     if (taskExistingEveryInput){
       taskExistingEveryInput.value = String(Math.max(1, Number(recurrence?.every) || 1));
@@ -5206,16 +5196,6 @@ function renderDashboard(){
     }
     if (taskExistingEndCountInput){
       taskExistingEndCountInput.value = String(Math.max(1, Number(recurrence?.endCount) || 1));
-    }
-    taskExistingWeekdayInputs.forEach(input => {
-      if (!(input instanceof HTMLInputElement)) return;
-      const day = Number(input.value);
-      const selected = Array.isArray(recurrence?.weekDays) && recurrence.weekDays.includes(day);
-      input.checked = !!selected;
-    });
-    const weekly = String(taskExistingBasisInput?.value || "") === "calendar_week";
-    if (taskExistingWeekdaysRow){
-      taskExistingWeekdaysRow.hidden = !(taskExistingRepeatInput?.value === "yes" && weekly);
     }
     toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
   }
@@ -5306,11 +5286,11 @@ function renderDashboard(){
     if (taskExistingSearchInput) taskExistingSearchInput.value = "";
     if (taskExistingNoteInput) taskExistingNoteInput.value = "";
     if (taskExistingRepeatInput) taskExistingRepeatInput.value = "no";
+    if (taskExistingRepeatInput) taskExistingRepeatInput.disabled = true;
     if (taskExistingBasisInput) taskExistingBasisInput.value = "calendar_day";
+    if (taskExistingBasisInput) taskExistingBasisInput.disabled = true;
     if (taskExistingEveryInput) taskExistingEveryInput.value = "1";
     if (taskExistingEndInput) taskExistingEndInput.value = "never";
-    taskExistingWeekdayInputs.forEach(input => { if (input instanceof HTMLInputElement) input.checked = false; });
-    if (taskExistingWeekdaysRow) taskExistingWeekdaysRow.hidden = true;
     setSelectedExistingTask(null);
     refreshExistingTaskOptions("");
     toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
@@ -5381,6 +5361,14 @@ function renderDashboard(){
       if (endDateInput?.parentElement) endDateInput.parentElement.hidden = true;
       if (endCountInput?.parentElement) endCountInput.parentElement.hidden = true;
     }
+    const isHours = enabled && String(basisSelect?.value || "") === "machine_hours";
+    if (basisSelect?.closest("label")){
+      basisSelect.closest("label").hidden = !enabled || isHours;
+    }
+    const detailsRow = repeatSelect === taskExistingRepeatInput ? taskExistingWeekdaysRow : taskWeekdaysRow;
+    if (detailsRow){
+      detailsRow.hidden = !(enabled && String(basisSelect?.value || "") === "calendar_week");
+    }
   }
 
   function readRepeatConfig({ repeatInput, basisInput, everyInput, endInput, endDateInput, endCountInput, defaultBasis }){
@@ -5397,16 +5385,6 @@ function renderDashboard(){
     const payload = { enabled: true, basis, every, endType };
     if (basis === "machine_hours"){
       payload.intervalHours = every;
-    }
-    if (basis === "calendar_week"){
-      const source = repeatInput === taskExistingRepeatInput ? taskExistingWeekdayInputs : taskWeekdayInputs;
-      const weekDays = source
-        .filter(input => input instanceof HTMLInputElement && input.checked)
-        .map(input => Number(input.value))
-        .filter(day => Number.isInteger(day) && day >= 0 && day <= 6);
-      if (weekDays.length){
-        payload.weekDays = Array.from(new Set(weekDays)).sort((a,b)=> a - b);
-      }
     }
     if (endType === "on_date"){
       const endDateISO = normalizeDateKey(endDateInput?.value || null);
@@ -5709,15 +5687,12 @@ function renderDashboard(){
   }
 
   function syncTaskMode(mode){
-    if (!taskFreqRow || !taskLastRow || !taskConditionRow) return;
     if (mode === "asreq"){
-      taskFreqRow.hidden = true;
-      taskLastRow.hidden = true;
-      taskConditionRow.hidden = false;
+      if (taskLastRow) taskLastRow.hidden = true;
+      if (taskConditionRow) taskConditionRow.hidden = false;
     }else{
-      taskFreqRow.hidden = false;
-      taskLastRow.hidden = false;
-      taskConditionRow.hidden = true;
+      if (taskLastRow) taskLastRow.hidden = false;
+      if (taskConditionRow) taskConditionRow.hidden = true;
     }
   }
 
@@ -5728,37 +5703,30 @@ function renderDashboard(){
   function syncTaskRepeatMode(){
     const mode = selectedTaskMode();
     syncTaskMode(mode);
-    const repeatEnabled = String(taskRepeatInput?.value || "no") === "yes";
+    const isInterval = mode === "interval";
+    if (taskRepeatInput){
+      taskRepeatInput.value = isInterval ? "yes" : "no";
+      taskRepeatInput.disabled = true;
+    }
     if (taskRepeatBasisInput){
-      const isInterval = mode === "interval";
       const options = isInterval
-        ? [
-            { value: "machine_hours", label: "By machine cutting hours" },
-            { value: "calendar_day", label: "By calendar day" },
-            { value: "calendar_week", label: "By calendar week" },
-            { value: "calendar_month", label: "By calendar month" }
-          ]
-        : [
-            { value: "calendar_day", label: "By calendar day" },
-            { value: "calendar_week", label: "By calendar week" },
-            { value: "calendar_month", label: "By calendar month" }
-          ];
+        ? [{ value: "machine_hours", label: "By machine cutting hours" }]
+        : [{ value: "calendar_day", label: "By calendar day" }];
       const current = String(taskRepeatBasisInput.value || "");
       taskRepeatBasisInput.innerHTML = options.map(opt => `<option value="${opt.value}">${opt.label}</option>`).join("");
       taskRepeatBasisInput.value = options.some(opt => opt.value === current) ? current : (isInterval ? "machine_hours" : "calendar_day");
+      taskRepeatBasisInput.disabled = true;
     }
     if (taskConditionInput){
       taskConditionInput.disabled = mode !== "asreq";
     }
     if (taskIntervalInput){
-      taskIntervalInput.disabled = mode !== "interval";
+      taskIntervalInput.disabled = true;
     }
     if (taskLastInput){
       taskLastInput.disabled = mode !== "interval";
     }
     toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput);
-    const weekly = repeatEnabled && String(taskRepeatBasisInput?.value || "") === "calendar_week";
-    if (taskWeekdaysRow) taskWeekdaysRow.hidden = !weekly;
   }
 
   function resetTaskForm(){
@@ -5769,11 +5737,12 @@ function renderDashboard(){
     subtaskList?.replaceChildren();
     resetExistingTaskForm();
     showTaskOptionStage();
-    if (taskRepeatInput) taskRepeatInput.value = "no";
+    if (taskRepeatInput) taskRepeatInput.value = "yes";
     if (taskRepeatBasisInput) taskRepeatBasisInput.value = "machine_hours";
     if (taskRepeatEveryInput) taskRepeatEveryInput.value = "1";
     if (taskRepeatEndInput) taskRepeatEndInput.value = "never";
-    taskWeekdayInputs.forEach(input => { if (input instanceof HTMLInputElement) input.checked = false; });
+    if (taskRepeatInput) taskRepeatInput.disabled = true;
+    if (taskRepeatBasisInput) taskRepeatBasisInput.disabled = true;
     if (taskWeekdaysRow) taskWeekdaysRow.hidden = true;
     toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput);
     syncTaskRepeatMode();
@@ -6148,7 +6117,7 @@ function renderDashboard(){
     };
     let message = "Task added";
     if (mode === "interval"){
-      let interval = Number(taskIntervalInput?.value);
+      let interval = Number(repeatConfig.intervalHours);
       if (!isFinite(interval) || interval <= 0) interval = 8;
       if (repeatConfig.enabled && repeatConfig.basis === "machine_hours" && Number.isFinite(Number(repeatConfig.intervalHours))){
         interval = Math.max(1, Number(repeatConfig.intervalHours));
@@ -6216,7 +6185,7 @@ function renderDashboard(){
       message = "As-required task added to Maintenance Settings";
     }
 
-    const parentInterval = Number(taskIntervalInput?.value);
+    const parentInterval = Number(repeatConfig.intervalHours);
     const subRows = subtaskList ? Array.from(subtaskList.querySelectorAll("[data-subtask-row]")) : [];
     subRows.forEach(row => {
       const subName = (row.querySelector("[data-subtask-name]")?.value || "").trim();
@@ -8298,7 +8267,6 @@ function renderSettings(){
     const type = entry.type;
     const name = escapeHtml(t.name || "(unnamed task)");
     const condition = escapeHtml(t.condition || "As required");
-    const freq = t.interval ? `${t.interval} hrs` : "Set frequency";
     const baselineVal = baselineInputValue(t);
     const recurrence = normalizeTaskRecurrence(t);
     const recurrenceChip = recurrenceSummaryLabel(t);
@@ -8330,7 +8298,7 @@ function renderSettings(){
         <summary draggable="true">
           <span class="task-name">${name}</span>
           <span class="chip">${type === "interval" ? "By Interval" : "As Required"}</span>
-          ${type === "interval" ? `<span class=\"chip\" data-chip-frequency="${t.id}">${escapeHtml(freq)}</span>` : `<span class=\"chip\" data-chip-condition="${t.id}">${condition}</span>`}
+          ${type === "interval" ? "" : `<span class=\"chip\" data-chip-condition="${t.id}">${condition}</span>`}
           <span class="chip" data-chip-recurrence="${t.id}">${escapeHtml(recurrenceChip)}</span>
           ${notesChip}
           ${type === "interval" ? dueChip(t) : ""}
@@ -8344,7 +8312,7 @@ function renderSettings(){
               <option value="asreq" ${type==="asreq"?"selected":""}>As required</option>
             </select></label>
             ${type === "interval"
-              ? `<label data-field="interval">Frequency (hrs)<input type=\"number\" min=\"1\" step=\"1\" data-k=\"interval\" data-id=\"${t.id}\" data-list=\"interval\" value=\"${t.interval!=null?t.interval:""}\" placeholder=\"Hours between service\"></label>`
+              ? ""
               : `<label data-field="condition">Condition / trigger<input data-k=\"condition\" data-id=\"${t.id}\" data-list=\"asreq\" value=\"${escapeHtml(t.condition||"")}\" placeholder=\"When to perform\"></label>`}
             ${type === "interval" ? `<label data-field="sinceBase">Hours since last service<input type=\"number\" min=\"0\" step=\"0.01\" data-k=\"sinceBase\" data-id=\"${t.id}\" data-list=\"interval\" value=\"${baselineVal!==""?baselineVal:""}\" placeholder=\"optional\"></label>` : ""}
             <label data-field="recurrenceEnabled">Repeat<select data-k="recurrenceEnabled" data-id="${t.id}" data-list="${type}">
@@ -8352,10 +8320,9 @@ function renderSettings(){
               <option value="no" ${!recurrence.enabled ? "selected" : ""}>No</option>
             </select></label>
             <label data-field="recurrenceBasis">Repeat basis<select data-k="recurrenceBasis" data-id="${t.id}" data-list="${type}">
-              ${type === "interval" ? `<option value="machine_hours" ${recurrence.basis==="machine_hours"?"selected":""}>Machine cutting hours</option>` : ""}
-              <option value="calendar_day" ${recurrence.basis==="calendar_day"?"selected":""}>Calendar day</option>
-              <option value="calendar_week" ${recurrence.basis==="calendar_week"?"selected":""}>Calendar week</option>
-              <option value="calendar_month" ${recurrence.basis==="calendar_month"?"selected":""}>Calendar month</option>
+              ${type === "interval"
+                ? `<option value="machine_hours" ${recurrence.basis==="machine_hours"?"selected":""}>Machine cutting hours</option>`
+                : `<option value="calendar_day" ${recurrence.basis==="calendar_day"?"selected":""}>Calendar day</option>`}
             </select></label>
             <label data-field="recurrenceEvery">Repeat every<input type="number" min="1" step="1" data-k="recurrenceEvery" data-id="${t.id}" data-list="${type}" value="${Math.max(1, Number(recurrence.every)||1)}"></label>
             <label data-field="manualLink">Manual link<input type="url" data-k="manualLink" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.manualLink||"")}" placeholder="https://..."></label>
@@ -8661,7 +8628,6 @@ function renderSettings(){
         }
       }
     };
-    toggle("interval", mode === "interval");
     toggle("sinceBase", mode === "interval");
     toggle("condition", mode !== "interval");
     const showRecurrenceDetail = repeatEnabled && isEditing;
@@ -8670,13 +8636,11 @@ function renderSettings(){
     if (repeatEnabled){
       const basisRow = taskEl.querySelector('[data-field="recurrenceBasis"] select[data-k="recurrenceBasis"]');
       if (basisRow instanceof HTMLSelectElement){
-        Array.from(basisRow.options).forEach(opt => {
-          if (opt.value === "machine_hours"){
-            opt.disabled = mode !== "interval";
-          }
-        });
-        if (mode !== "interval" && basis === "machine_hours"){
+        basisRow.disabled = mode !== "interval";
+        if (mode !== "interval"){
           basisRow.value = "calendar_day";
+        }else{
+          basisRow.value = "machine_hours";
         }
       }
     }
@@ -9598,24 +9562,11 @@ function renderSettings(){
     const key = target.getAttribute("data-k");
     if (!key || key === "mode") return;
     let value = target.value;
-    if (key === "price" || key === "interval" || key === "anchorTotal" || key === "sinceBase" || key === "downtimeHours" || key === "recurrenceEvery" || key === "recurrenceEndCount"){
+    if (key === "price" || key === "anchorTotal" || key === "sinceBase" || key === "downtimeHours" || key === "recurrenceEvery" || key === "recurrenceEndCount"){
       value = value === "" ? null : Number(value);
       if (value !== null && !isFinite(value)) return;
     }
-    if (key === "interval"){
-      meta.task.interval = value == null ? null : Number(value);
-      const recurrence = normalizeTaskRecurrence(meta.task);
-      if (recurrence && recurrence.basis === "machine_hours"){
-        recurrence.intervalHours = meta.task.interval;
-        recurrence.every = Math.max(1, Math.round(Number(meta.task.interval) || 1));
-        meta.task.recurrence = recurrence;
-      }
-      const chip = holder.querySelector('[data-chip-frequency]');
-      if (chip) chip.textContent = meta.task.interval ? `${meta.task.interval} hrs` : "Set frequency";
-      const recurChip = holder.querySelector('[data-chip-recurrence]');
-      if (recurChip) recurChip.textContent = recurrenceSummaryLabel(meta.task);
-      updateDueChip(holder, meta.task);
-    }else if (key === "anchorTotal"){
+    if (key === "anchorTotal"){
       if (value == null){
         meta.task.anchorTotal = null;
         meta.task.sinceBase = null;
@@ -9748,9 +9699,9 @@ function renderSettings(){
       const recurrence = normalizeTaskRecurrence(meta.task);
       if (!recurrence) return;
       if (selectKey === "recurrenceEnabled"){
-        recurrence.enabled = target.value === "yes";
+        recurrence.enabled = meta.task.mode === "interval";
       }else if (selectKey === "recurrenceBasis"){
-        recurrence.basis = target.value;
+        recurrence.basis = meta.task.mode === "interval" ? "machine_hours" : "calendar_day";
         if (recurrence.basis === "machine_hours"){
           recurrence.intervalHours = Number(meta.task.interval) || Number(recurrence.intervalHours) || 1;
           recurrence.every = Math.max(1, Math.round(Number(recurrence.intervalHours) || 1));
@@ -9778,7 +9729,15 @@ function renderSettings(){
       meta.list.splice(meta.index,1);
       if (nextMode === "interval"){
         meta.task.mode = "interval";
-        meta.task.interval = meta.task.interval && meta.task.interval>0 ? Number(meta.task.interval) : 8;
+        const recurrence = normalizeTaskRecurrence(meta.task) || {};
+        const every = Math.max(1, Number(recurrence.every) || Number(meta.task.interval) || 8);
+        meta.task.interval = every;
+        recurrence.enabled = true;
+        recurrence.basis = "machine_hours";
+        recurrence.every = every;
+        recurrence.intervalHours = every;
+        recurrence.endType = recurrence.endType || "never";
+        meta.task.recurrence = recurrence;
         const baseSince = Number(meta.task.sinceBase);
         const baselineHours = Number.isFinite(baseSince) && baseSince >= 0 ? baseSince : 0;
         meta.task.sinceBase = baselineHours;
@@ -9804,6 +9763,15 @@ function renderSettings(){
         delete meta.task.interval;
         delete meta.task.sinceBase;
         delete meta.task.anchorTotal;
+        const recurrence = normalizeTaskRecurrence(meta.task) || {};
+        recurrence.enabled = false;
+        recurrence.basis = "calendar_day";
+        recurrence.intervalHours = null;
+        recurrence.every = Math.max(1, Number(recurrence.every) || 1);
+        recurrence.endType = "never";
+        recurrence.endDateISO = null;
+        recurrence.endCount = null;
+        meta.task.recurrence = recurrence;
         window.tasksAsReq.unshift(meta.task);
       }
       persist();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -8637,11 +8637,12 @@ function renderSettings(){
     toggle("interval", mode === "interval");
     toggle("sinceBase", mode === "interval");
     toggle("condition", mode !== "interval");
-    toggle("recurrenceBasis", repeatEnabled);
-    toggle("recurrenceEvery", repeatEnabled);
-    toggle("recurrenceEndType", repeatEnabled);
-    toggle("recurrenceEndDate", repeatEnabled && endType === "on_date");
-    toggle("recurrenceEndCount", repeatEnabled && endType === "after_count");
+    const showRecurrenceDetail = repeatEnabled && isEditing;
+    toggle("recurrenceBasis", showRecurrenceDetail);
+    toggle("recurrenceEvery", showRecurrenceDetail);
+    toggle("recurrenceEndType", showRecurrenceDetail);
+    toggle("recurrenceEndDate", showRecurrenceDetail && endType === "on_date");
+    toggle("recurrenceEndCount", showRecurrenceDetail && endType === "after_count");
     if (repeatEnabled){
       const basisRow = taskEl.querySelector('[data-field="recurrenceBasis"] select[data-k="recurrenceBasis"]');
       if (basisRow instanceof HTMLSelectElement){

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -439,6 +439,71 @@ function ensureTaskManualHistory(task){
   return task.manualHistory;
 }
 
+function normalizeTaskRecurrence(task){
+  if (!task || typeof task !== "object") return null;
+  const mode = task.mode === "asreq" ? "asreq" : "interval";
+  const raw = (task.recurrence && typeof task.recurrence === "object") ? task.recurrence : {};
+  const basisRaw = String(raw.basis || (mode === "interval" ? "machine_hours" : "calendar_day")).toLowerCase();
+  const basis = ["machine_hours", "calendar_day", "calendar_week", "calendar_month"].includes(basisRaw)
+    ? basisRaw
+    : (mode === "interval" ? "machine_hours" : "calendar_day");
+  const enabled = Boolean(raw.enabled || (basis === "machine_hours" && mode === "interval"));
+  const everyRaw = Number(raw.every);
+  const every = Number.isFinite(everyRaw) && everyRaw > 0 ? Math.max(1, Math.round(everyRaw)) : 1;
+  const intervalHoursRaw = Number(raw.intervalHours != null ? raw.intervalHours : task.interval);
+  const intervalHours = Number.isFinite(intervalHoursRaw) && intervalHoursRaw > 0
+    ? Math.max(0.25, Math.round(intervalHoursRaw * 100) / 100)
+    : (mode === "interval" ? Math.max(1, Number(task.interval) || 8) : null);
+  const startISO = normalizeDateKey(raw.startISO || task.calendarDateISO || ymd(new Date()));
+  const endTypeRaw = String(raw.endType || "never").toLowerCase();
+  const endType = ["never", "on_date", "after_count"].includes(endTypeRaw) ? endTypeRaw : "never";
+  const endDateISO = normalizeDateKey(raw.endDateISO);
+  const endCountRaw = Number(raw.endCount);
+  const endCount = Number.isFinite(endCountRaw) && endCountRaw > 0 ? Math.floor(endCountRaw) : null;
+  const weekDaysRaw = Array.isArray(raw.weekDays) ? raw.weekDays : [];
+  const weekDays = Array.from(new Set(
+    weekDaysRaw
+      .map(v => Number(v))
+      .filter(v => Number.isInteger(v) && v >= 0 && v <= 6)
+  )).sort((a,b)=> a - b);
+  const normalized = {
+    enabled,
+    basis,
+    every,
+    intervalHours: basis === "machine_hours" ? intervalHours : null,
+    startISO: startISO || null,
+    endType,
+    endDateISO: endType === "on_date" ? (endDateISO || null) : null,
+    endCount: endType === "after_count" ? (endCount || 1) : null,
+    weekDays: basis === "calendar_week" ? weekDays : [],
+    completionAnchorISO: normalizeDateKey(raw.completionAnchorISO || null),
+    completionAnchorHours: Number.isFinite(Number(raw.completionAnchorHours)) ? Number(raw.completionAnchorHours) : null
+  };
+  task.recurrence = normalized;
+  if (mode === "interval" && basis === "machine_hours" && Number.isFinite(intervalHours) && intervalHours > 0){
+    task.interval = intervalHours;
+  }
+  return normalized;
+}
+
+function recurrenceSummaryLabel(task){
+  const recurrence = normalizeTaskRecurrence(task);
+  if (!recurrence || !recurrence.enabled) return "Does not repeat";
+  const every = Math.max(1, Number(recurrence.every) || 1);
+  if (recurrence.basis === "machine_hours"){
+    const hours = Number(recurrence.intervalHours) || Number(task?.interval) || 0;
+    const base = `${hours} cutting hr${hours === 1 ? "" : "s"}`;
+    return every > 1 ? `Every ${every} × ${base}` : `Every ${base}`;
+  }
+  if (recurrence.basis === "calendar_week"){
+    return `Every ${every} week${every === 1 ? "" : "s"}`;
+  }
+  if (recurrence.basis === "calendar_month"){
+    return `Every ${every} month${every === 1 ? "" : "s"}`;
+  }
+  return `Every ${every} day${every === 1 ? "" : "s"}`;
+}
+
 function collectTaskHistoryDates(task){
   if (!task) return [];
   const resolved = new Set();
@@ -589,13 +654,18 @@ function createIntervalTaskInstance(template){
       return 1;
     })()
   };
+  const templateRecurrence = normalizeTaskRecurrence(template);
+  if (templateRecurrence){
+    copy.recurrence = { ...templateRecurrence };
+    if (copy.recurrence.startISO == null) copy.recurrence.startISO = normalizeDateKey(template.calendarDateISO) || ymd(new Date());
+  }
   if (Array.isArray(template.parts)){
     copy.parts = template.parts.map(part => part ? { ...part } : part).filter(Boolean);
   }
   return copy;
 }
 
-function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refreshDashboard = true } = {}){
+function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refreshDashboard = true, recurrence = null } = {}){
   if (!task || task.mode !== "interval") return null;
   if (!Array.isArray(tasksInterval)){
     if (Array.isArray(window.tasksInterval)){
@@ -646,6 +716,10 @@ function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refresh
   instance.downtimeHours = normalizedDowntime;
   if (template){
     template.downtimeHours = normalizedDowntime;
+  }
+  const templateRecurrence = normalizeTaskRecurrence(template || instance);
+  if (templateRecurrence){
+    instance.recurrence = { ...templateRecurrence };
   }
 
   const interval = Number(instance.interval);
@@ -740,6 +814,15 @@ function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refresh
   }
 
   instance.calendarDateISO = targetISO || null;
+  if (instance.recurrence && typeof instance.recurrence === "object"){
+    if (instance.recurrence.startISO == null){
+      instance.recurrence.startISO = normalizeDateKey(targetISO || ymd(new Date()));
+    }
+  }
+  if (recurrence && typeof recurrence === "object"){
+    instance.recurrence = { ...(instance.recurrence || {}), ...recurrence };
+    normalizeTaskRecurrence(instance);
+  }
   if (note){
     try { setFamilyOccurrenceNote(instance, targetISO, note); } catch (err) { /* noop */ }
   }
@@ -753,7 +836,7 @@ function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refresh
   return instance;
 }
 
-function scheduleExistingAsReqTask(task, { dateISO = null, note = "", refreshDashboard = true } = {}){
+function scheduleExistingAsReqTask(task, { dateISO = null, note = "", refreshDashboard = true, recurrence = null } = {}){
   if (!task || task.mode !== "asreq") return null;
   if (!Array.isArray(window.tasksAsReq)) window.tasksAsReq = [];
 
@@ -782,6 +865,15 @@ function scheduleExistingAsReqTask(task, { dateISO = null, note = "", refreshDas
   if (task.occurrenceHours && typeof task.occurrenceHours === "object"){
     instance.occurrenceHours = { ...task.occurrenceHours };
   }
+  const templateRecurrence = normalizeTaskRecurrence(template);
+  instance.recurrence = templateRecurrence ? { ...templateRecurrence } : normalizeTaskRecurrence(instance);
+  if (instance.recurrence && instance.recurrence.startISO == null){
+    instance.recurrence.startISO = normalizeDate(dateISO) || ymd(new Date());
+  }
+  if (recurrence && typeof recurrence === "object"){
+    instance.recurrence = { ...(instance.recurrence || {}), ...recurrence };
+    normalizeTaskRecurrence(instance);
+  }
 
   if (note){
     try { setFamilyOccurrenceNote(instance, instance.calendarDateISO, note); } catch (err) { /* noop */ }
@@ -798,6 +890,8 @@ if (typeof window !== "undefined"){
   window.scheduleExistingIntervalTask = scheduleExistingIntervalTask;
   window.scheduleExistingAsReqTask = scheduleExistingAsReqTask;
   window.createIntervalTaskInstance = createIntervalTaskInstance;
+  window.normalizeTaskRecurrence = normalizeTaskRecurrence;
+  window.recurrenceSummaryLabel = recurrenceSummaryLabel;
 }
 
 function editingCompletedJobsSet(){
@@ -4916,6 +5010,12 @@ function renderDashboard(){
   const taskDowntimeInput= document.getElementById("dashTaskDowntime");
   const categorySelect   = document.getElementById("dashTaskCategory");
   const taskDateInput    = document.getElementById("dashTaskDate");
+  const taskRepeatInput  = document.getElementById("dashTaskRepeat");
+  const taskRepeatBasisInput = document.getElementById("dashTaskRepeatBasis");
+  const taskRepeatEveryInput = document.getElementById("dashTaskRepeatEvery");
+  const taskRepeatEndInput = document.getElementById("dashTaskRepeatEnd");
+  const taskRepeatEndDateInput = document.getElementById("dashTaskRepeatEndDate");
+  const taskRepeatEndCountInput = document.getElementById("dashTaskRepeatEndCount");
   const subtaskList      = document.getElementById("dashSubtaskList");
   const addSubtaskBtn    = document.getElementById("dashAddSubtask");
   const taskOptionStage  = modal?.querySelector('[data-task-option-stage]');
@@ -4927,6 +5027,12 @@ function renderDashboard(){
   const existingTaskEmpty  = taskExistingForm?.querySelector('[data-task-existing-empty]');
   const existingTaskSearchEmpty = taskExistingForm?.querySelector('[data-task-existing-search-empty]');
   const taskExistingNoteInput = document.getElementById("dashTaskExistingNote");
+  const taskExistingRepeatInput = document.getElementById("dashTaskExistingRepeat");
+  const taskExistingBasisInput = document.getElementById("dashTaskExistingRepeatBasis");
+  const taskExistingEveryInput = document.getElementById("dashTaskExistingRepeatEvery");
+  const taskExistingEndInput = document.getElementById("dashTaskExistingRepeatEnd");
+  const taskExistingEndDateInput = document.getElementById("dashTaskExistingRepeatEndDate");
+  const taskExistingEndCountInput = document.getElementById("dashTaskExistingRepeatEndCount");
   const taskCardBackButtons = Array.from(modal?.querySelectorAll('[data-task-card-back]') || []);
   const oneTimeForm      = document.getElementById("dashOneTimeForm");
   const oneTimeNameInput = document.getElementById("dashOneTimeName");
@@ -5060,6 +5166,44 @@ function renderDashboard(){
       btn.classList.toggle("is-active", isMatch);
       btn.setAttribute("aria-pressed", isMatch ? "true" : "false");
     });
+    const meta = selectedExistingTaskId ? findMaintenanceTaskById(selectedExistingTaskId) : null;
+    const task = meta?.task || null;
+    const recurrence = task ? normalizeTaskRecurrence(task) : null;
+    if (taskExistingBasisInput){
+      const isInterval = task?.mode === "interval";
+      const options = isInterval
+        ? [
+            { value: "machine_hours", label: "By machine cutting hours" },
+            { value: "calendar_day", label: "By calendar day" },
+            { value: "calendar_week", label: "By calendar week" },
+            { value: "calendar_month", label: "By calendar month" }
+          ]
+        : [
+            { value: "calendar_day", label: "By calendar day" },
+            { value: "calendar_week", label: "By calendar week" },
+            { value: "calendar_month", label: "By calendar month" }
+          ];
+      taskExistingBasisInput.innerHTML = options.map(opt => `<option value="${opt.value}">${opt.label}</option>`).join("");
+      taskExistingBasisInput.value = recurrence?.basis && options.some(opt => opt.value === recurrence.basis)
+        ? recurrence.basis
+        : (isInterval ? "machine_hours" : "calendar_day");
+    }
+    if (taskExistingRepeatInput){
+      taskExistingRepeatInput.value = recurrence?.enabled ? "yes" : "no";
+    }
+    if (taskExistingEveryInput){
+      taskExistingEveryInput.value = String(Math.max(1, Number(recurrence?.every) || 1));
+    }
+    if (taskExistingEndInput){
+      taskExistingEndInput.value = recurrence?.endType || "never";
+    }
+    if (taskExistingEndDateInput){
+      taskExistingEndDateInput.value = recurrence?.endDateISO || "";
+    }
+    if (taskExistingEndCountInput){
+      taskExistingEndCountInput.value = String(Math.max(1, Number(recurrence?.endCount) || 1));
+    }
+    toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
   }
 
   function setTaskOptionPage(target){
@@ -5147,8 +5291,12 @@ function renderDashboard(){
   function resetExistingTaskForm(){
     if (taskExistingSearchInput) taskExistingSearchInput.value = "";
     if (taskExistingNoteInput) taskExistingNoteInput.value = "";
+    if (taskExistingRepeatInput) taskExistingRepeatInput.value = "no";
+    if (taskExistingEveryInput) taskExistingEveryInput.value = "1";
+    if (taskExistingEndInput) taskExistingEndInput.value = "never";
     setSelectedExistingTask(null);
     refreshExistingTaskOptions("");
+    toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
   }
 
   function resetOneTimeTaskForm(){
@@ -5196,6 +5344,52 @@ function renderDashboard(){
     if (!modalVisible || !taskDateInput.value){
       taskDateInput.value = ymd(new Date());
     }
+  }
+
+  function toggleRepeatEndFields(endSelect, endDateInput, endCountInput){
+    const mode = String(endSelect?.value || "never");
+    if (endDateInput) endDateInput.parentElement.hidden = mode !== "on_date";
+    if (endCountInput) endCountInput.parentElement.hidden = mode !== "after_count";
+  }
+
+  function toggleRepeatFields(repeatSelect, basisSelect, everyInput, endSelect, endDateInput, endCountInput){
+    const enabled = String(repeatSelect?.value || "no") === "yes";
+    [basisSelect, everyInput, endSelect].forEach(el => {
+      if (!el) return;
+      const row = el.closest("label");
+      if (row) row.hidden = !enabled;
+    });
+    toggleRepeatEndFields(endSelect, endDateInput, endCountInput);
+    if (!enabled){
+      if (endDateInput?.parentElement) endDateInput.parentElement.hidden = true;
+      if (endCountInput?.parentElement) endCountInput.parentElement.hidden = true;
+    }
+  }
+
+  function readRepeatConfig({ repeatInput, basisInput, everyInput, endInput, endDateInput, endCountInput, defaultBasis }){
+    const enabled = String(repeatInput?.value || "no") === "yes";
+    if (!enabled) return { enabled: false };
+    const basisRaw = String(basisInput?.value || defaultBasis || "calendar_day").toLowerCase();
+    const basis = ["machine_hours", "calendar_day", "calendar_week", "calendar_month"].includes(basisRaw)
+      ? basisRaw
+      : (defaultBasis || "calendar_day");
+    const everyRaw = Number(everyInput?.value);
+    const every = Number.isFinite(everyRaw) && everyRaw > 0 ? Math.max(1, Math.round(everyRaw)) : 1;
+    const endTypeRaw = String(endInput?.value || "never").toLowerCase();
+    const endType = ["never", "on_date", "after_count"].includes(endTypeRaw) ? endTypeRaw : "never";
+    const payload = { enabled: true, basis, every, endType };
+    if (basis === "machine_hours"){
+      payload.intervalHours = every;
+    }
+    if (endType === "on_date"){
+      const endDateISO = normalizeDateKey(endDateInput?.value || null);
+      if (endDateISO) payload.endDateISO = endDateISO;
+      else payload.endType = "never";
+    } else if (endType === "after_count"){
+      const countRaw = Number(endCountInput?.value);
+      payload.endCount = Number.isFinite(countRaw) && countRaw > 0 ? Math.floor(countRaw) : 1;
+    }
+    return payload;
   }
 
   function syncOneTimeDateInput(){
@@ -5489,6 +5683,7 @@ function renderDashboard(){
 
   function syncTaskMode(mode){
     if (!taskFreqRow || !taskLastRow || !taskConditionRow) return;
+    const isAsReq = mode === "asreq";
     if (mode === "asreq"){
       taskFreqRow.hidden = true;
       taskLastRow.hidden = true;
@@ -5497,6 +5692,23 @@ function renderDashboard(){
       taskFreqRow.hidden = false;
       taskLastRow.hidden = false;
       taskConditionRow.hidden = true;
+    }
+    if (taskRepeatBasisInput){
+      const dayOptions = [
+        { value: "calendar_day", label: "By calendar day" },
+        { value: "calendar_week", label: "By calendar week" },
+        { value: "calendar_month", label: "By calendar month" }
+      ];
+      const intervalOptions = [
+        { value: "machine_hours", label: "By machine cutting hours" },
+        ...dayOptions
+      ];
+      const options = isAsReq ? dayOptions : intervalOptions;
+      const current = String(taskRepeatBasisInput.value || "");
+      taskRepeatBasisInput.innerHTML = options.map(opt => `<option value="${opt.value}">${opt.label}</option>`).join("");
+      taskRepeatBasisInput.value = options.some(opt => opt.value === current)
+        ? current
+        : (isAsReq ? "calendar_day" : "machine_hours");
     }
   }
 
@@ -5510,6 +5722,10 @@ function renderDashboard(){
     showTaskOptionStage();
     syncTaskMode(taskTypeSelect?.value || "interval");
     syncTaskDateInput();
+    if (taskRepeatInput) taskRepeatInput.value = "no";
+    if (taskRepeatEveryInput) taskRepeatEveryInput.value = "1";
+    if (taskRepeatEndInput) taskRepeatEndInput.value = "never";
+    toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput);
   }
 
   function showStep(step){
@@ -5801,7 +6017,13 @@ function renderDashboard(){
   });
 
   taskTypeSelect?.addEventListener("change", ()=> syncTaskMode(taskTypeSelect.value));
+  taskRepeatInput?.addEventListener("change", ()=> toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput));
+  taskRepeatEndInput?.addEventListener("change", ()=> toggleRepeatEndFields(taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput));
+  taskExistingRepeatInput?.addEventListener("change", ()=> toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput));
+  taskExistingEndInput?.addEventListener("change", ()=> toggleRepeatEndFields(taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput));
   syncTaskMode(taskTypeSelect?.value || "interval");
+  toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput);
+  toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
   syncTaskDateInput();
   syncOneTimeDateInput();
   populateCategoryOptions();
@@ -5838,6 +6060,15 @@ function renderDashboard(){
     const rawDate = (taskDateInput?.value || "").trim();
     const dateISO = rawDate ? ymd(rawDate) : "";
     const targetISO = dateISO || addContextDateISO || ymd(new Date());
+    const repeatConfig = readRepeatConfig({
+      repeatInput: taskRepeatInput,
+      basisInput: taskRepeatBasisInput,
+      everyInput: taskRepeatEveryInput,
+      endInput: taskRepeatEndInput,
+      endDateInput: taskRepeatEndDateInput,
+      endCountInput: taskRepeatEndCountInput,
+      defaultBasis: mode === "interval" ? "machine_hours" : "calendar_day"
+    });
     const calendarDateISO = targetISO || null;
     const base = {
       id,
@@ -5856,6 +6087,9 @@ function renderDashboard(){
     if (mode === "interval"){
       let interval = Number(taskIntervalInput?.value);
       if (!isFinite(interval) || interval <= 0) interval = 8;
+      if (repeatConfig.enabled && repeatConfig.basis === "machine_hours" && Number.isFinite(Number(repeatConfig.intervalHours))){
+        interval = Math.max(1, Number(repeatConfig.intervalHours));
+      }
       const template = Object.assign({}, base, {
         mode:"interval",
         interval,
@@ -5867,11 +6101,26 @@ function renderDashboard(){
         templateId: id,
         downtimeHours: downtimeVal
       });
+      template.recurrence = {
+        enabled: Boolean(repeatConfig.enabled),
+        basis: repeatConfig.basis || "machine_hours",
+        every: repeatConfig.every || 1,
+        intervalHours: interval,
+        startISO: normalizeDateKey(targetISO) || ymd(new Date()),
+        endType: repeatConfig.endType || "never",
+        endDateISO: repeatConfig.endDateISO || null,
+        endCount: repeatConfig.endCount || null
+      };
+      normalizeTaskRecurrence(template);
       const curHours = getCurrentMachineHours();
       const baselineHours = parseBaselineHours(taskLastInput?.value);
       applyIntervalBaseline(template, { baselineHours, currentHours: curHours });
       tasksInterval.unshift(template);
-      const instance = scheduleExistingIntervalTask(template, { dateISO: targetISO, refreshDashboard: false }) || template;
+      const instance = scheduleExistingIntervalTask(template, {
+        dateISO: targetISO,
+        refreshDashboard: false,
+        recurrence: repeatConfig
+      }) || template;
       const parsed = parseDateLocal(targetISO);
       const todayMidnight = new Date(); todayMidnight.setHours(0,0,0,0);
       let dateLabel = targetISO;
@@ -5889,6 +6138,17 @@ function renderDashboard(){
     }else{
       const condition = (taskConditionInput?.value || "").trim() || "As required";
       const task = Object.assign({}, base, { mode:"asreq", condition, variant: "template", templateId: id });
+      task.recurrence = {
+        enabled: Boolean(repeatConfig.enabled),
+        basis: repeatConfig.basis || "calendar_day",
+        every: repeatConfig.every || 1,
+        intervalHours: null,
+        startISO: normalizeDateKey(targetISO) || ymd(new Date()),
+        endType: repeatConfig.endType || "never",
+        endDateISO: repeatConfig.endDateISO || null,
+        endCount: repeatConfig.endCount || null
+      };
+      normalizeTaskRecurrence(task);
       tasksAsReq.unshift(task);
       message = "As-required task added to Maintenance Settings";
     }
@@ -6015,9 +6275,23 @@ function renderDashboard(){
     const task = meta.task;
     const targetISO = addContextDateISO || ymd(new Date());
     const occurrenceNote = (taskExistingNoteInput?.value || "").trim();
+    const repeatConfig = readRepeatConfig({
+      repeatInput: taskExistingRepeatInput,
+      basisInput: taskExistingBasisInput,
+      everyInput: taskExistingEveryInput,
+      endInput: taskExistingEndInput,
+      endDateInput: taskExistingEndDateInput,
+      endCountInput: taskExistingEndCountInput,
+      defaultBasis: task.mode === "interval" ? "machine_hours" : "calendar_day"
+    });
     let message = "Maintenance task added";
     if (task.mode === "interval"){
-      const instance = scheduleExistingIntervalTask(task, { dateISO: targetISO, note: occurrenceNote, refreshDashboard: true }) || task;
+      const instance = scheduleExistingIntervalTask(task, {
+        dateISO: targetISO,
+        note: occurrenceNote,
+        refreshDashboard: true,
+        recurrence: repeatConfig
+      }) || task;
       const parsed = parseDateLocal(targetISO);
       const todayMidnight = new Date(); todayMidnight.setHours(0,0,0,0);
       let dateLabel = targetISO;
@@ -6033,7 +6307,12 @@ function renderDashboard(){
         ? `Logged "${instance.name || "Task"}" as completed on ${dateLabel}`
         : `Scheduled "${instance.name || "Task"}" for ${dateLabel}`;
     }else{
-      const instance = scheduleExistingAsReqTask(task, { dateISO: targetISO, note: occurrenceNote, refreshDashboard: true }) || task;
+      const instance = scheduleExistingAsReqTask(task, {
+        dateISO: targetISO,
+        note: occurrenceNote,
+        refreshDashboard: true,
+        recurrence: repeatConfig
+      }) || task;
       message = "As-required task linked from Maintenance Settings";
     }
     setContextDate(targetISO);
@@ -7730,6 +8009,13 @@ function renderSettings(){
     if ((type === "interval" || type === "asreq") && isTemplateTask(task)){
       if (task.templateId == null) task.templateId = task.id;
     }
+    if (typeof normalizeTaskRecurrence === "function"){
+      try {
+        normalizeTaskRecurrence(task);
+      } catch (err){
+        console.warn("Failed to normalize recurrence for task", task?.id, err);
+      }
+    }
   }
 
   const taskEntries = [];
@@ -7938,6 +8224,8 @@ function renderSettings(){
     const condition = escapeHtml(t.condition || "As required");
     const freq = t.interval ? `${t.interval} hrs` : "Set frequency";
     const baselineVal = baselineInputValue(t);
+    const recurrence = normalizeTaskRecurrence(t);
+    const recurrenceChip = recurrenceSummaryLabel(t);
     const occurrenceNoteMap = (typeof normalizeOccurrenceNotes === "function") ? normalizeOccurrenceNotes(t) : (t.occurrenceNotes || {});
     const occurrenceHoursMap = (typeof normalizeOccurrenceHours === "function") ? normalizeOccurrenceHours(t) : (t.occurrenceHours || {});
     const occurrenceKeys = new Set([
@@ -7966,6 +8254,7 @@ function renderSettings(){
           <span class="task-name">${name}</span>
           <span class="chip">${type === "interval" ? "By Interval" : "As Required"}</span>
           ${type === "interval" ? `<span class=\"chip\" data-chip-frequency="${t.id}">${escapeHtml(freq)}</span>` : `<span class=\"chip\" data-chip-condition="${t.id}">${condition}</span>`}
+          <span class="chip" data-chip-recurrence="${t.id}">${escapeHtml(recurrenceChip)}</span>
           ${notesChip}
           ${type === "interval" ? dueChip(t) : ""}
         </summary>
@@ -7981,6 +8270,24 @@ function renderSettings(){
               ? `<label data-field="interval">Frequency (hrs)<input type=\"number\" min=\"1\" step=\"1\" data-k=\"interval\" data-id=\"${t.id}\" data-list=\"interval\" value=\"${t.interval!=null?t.interval:""}\" placeholder=\"Hours between service\"></label>`
               : `<label data-field="condition">Condition / trigger<input data-k=\"condition\" data-id=\"${t.id}\" data-list=\"asreq\" value=\"${escapeHtml(t.condition||"")}\" placeholder=\"When to perform\"></label>`}
             ${type === "interval" ? `<label data-field="sinceBase">Hours since last service<input type=\"number\" min=\"0\" step=\"0.01\" data-k=\"sinceBase\" data-id=\"${t.id}\" data-list=\"interval\" value=\"${baselineVal!==""?baselineVal:""}\" placeholder=\"optional\"></label>` : ""}
+            <label data-field="recurrenceEnabled">Repeat<select data-k="recurrenceEnabled" data-id="${t.id}" data-list="${type}">
+              <option value="yes" ${recurrence.enabled ? "selected" : ""}>Yes</option>
+              <option value="no" ${!recurrence.enabled ? "selected" : ""}>No</option>
+            </select></label>
+            <label data-field="recurrenceBasis">Repeat basis<select data-k="recurrenceBasis" data-id="${t.id}" data-list="${type}">
+              ${type === "interval" ? `<option value="machine_hours" ${recurrence.basis==="machine_hours"?"selected":""}>Machine cutting hours</option>` : ""}
+              <option value="calendar_day" ${recurrence.basis==="calendar_day"?"selected":""}>Calendar day</option>
+              <option value="calendar_week" ${recurrence.basis==="calendar_week"?"selected":""}>Calendar week</option>
+              <option value="calendar_month" ${recurrence.basis==="calendar_month"?"selected":""}>Calendar month</option>
+            </select></label>
+            <label data-field="recurrenceEvery">Repeat every<input type="number" min="1" step="1" data-k="recurrenceEvery" data-id="${t.id}" data-list="${type}" value="${Math.max(1, Number(recurrence.every)||1)}"></label>
+            <label data-field="recurrenceEndType">Repeat ends<select data-k="recurrenceEndType" data-id="${t.id}" data-list="${type}">
+              <option value="never" ${recurrence.endType==="never"?"selected":""}>Never</option>
+              <option value="on_date" ${recurrence.endType==="on_date"?"selected":""}>On date</option>
+              <option value="after_count" ${recurrence.endType==="after_count"?"selected":""}>After count</option>
+            </select></label>
+            <label data-field="recurrenceEndDate">Repeat end date<input type="date" data-k="recurrenceEndDate" data-id="${t.id}" data-list="${type}" value="${escapeHtml(recurrence.endDateISO||"")}"></label>
+            <label data-field="recurrenceEndCount">Repeat end count<input type="number" min="1" step="1" data-k="recurrenceEndCount" data-id="${t.id}" data-list="${type}" value="${Math.max(1, Number(recurrence.endCount)||1)}"></label>
             <label data-field="manualLink">Manual link<input type="url" data-k="manualLink" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.manualLink||"")}" placeholder="https://..."></label>
             <label data-field="storeLink">Store link<input type="url" data-k="storeLink" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.storeLink||"")}" placeholder="https://..."></label>
             <label data-field="pn">Part #<input data-k="pn" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.pn||"")}" placeholder="Part number"></label>
@@ -9156,14 +9463,22 @@ function renderSettings(){
     const key = target.getAttribute("data-k");
     if (!key || key === "mode") return;
     let value = target.value;
-    if (key === "price" || key === "interval" || key === "anchorTotal" || key === "sinceBase" || key === "downtimeHours"){
+    if (key === "price" || key === "interval" || key === "anchorTotal" || key === "sinceBase" || key === "downtimeHours" || key === "recurrenceEvery" || key === "recurrenceEndCount"){
       value = value === "" ? null : Number(value);
       if (value !== null && !isFinite(value)) return;
     }
     if (key === "interval"){
       meta.task.interval = value == null ? null : Number(value);
+      const recurrence = normalizeTaskRecurrence(meta.task);
+      if (recurrence && recurrence.basis === "machine_hours"){
+        recurrence.intervalHours = meta.task.interval;
+        recurrence.every = Math.max(1, Math.round(Number(meta.task.interval) || 1));
+        meta.task.recurrence = recurrence;
+      }
       const chip = holder.querySelector('[data-chip-frequency]');
       if (chip) chip.textContent = meta.task.interval ? `${meta.task.interval} hrs` : "Set frequency";
+      const recurChip = holder.querySelector('[data-chip-recurrence]');
+      if (recurChip) recurChip.textContent = recurrenceSummaryLabel(meta.task);
       updateDueChip(holder, meta.task);
     }else if (key === "anchorTotal"){
       if (value == null){
@@ -9250,6 +9565,29 @@ function renderSettings(){
       if (key === "storeLink"){ syncLinkedInventoryFromTask(meta.task, { link: meta.task.storeLink || "" }); }
       if (key === "pn"){ syncLinkedInventoryFromTask(meta.task, { pn: meta.task.pn || "" }); }
       if (key === "name"){ syncLinkedInventoryFromTask(meta.task, { name: meta.task.name || "" }); }
+    }else if (key === "recurrenceEvery" || key === "recurrenceEndCount"){
+      const recurrence = normalizeTaskRecurrence(meta.task);
+      if (!recurrence) return;
+      if (key === "recurrenceEvery"){
+        recurrence.every = value == null ? 1 : Math.max(1, Math.round(Number(value)));
+        if (meta.task.mode === "interval" && recurrence.basis === "machine_hours"){
+          recurrence.intervalHours = recurrence.every;
+          meta.task.interval = recurrence.intervalHours;
+        }
+      }else{
+        recurrence.endCount = value == null ? 1 : Math.max(1, Math.floor(Number(value)));
+      }
+      meta.task.recurrence = recurrence;
+      const recurChip = holder.querySelector('[data-chip-recurrence]');
+      if (recurChip) recurChip.textContent = recurrenceSummaryLabel(meta.task);
+      if (typeof refreshDashboardWidgets === "function") refreshDashboardWidgets({ full: true });
+    }else if (key === "recurrenceEndDate"){
+      const recurrence = normalizeTaskRecurrence(meta.task);
+      if (!recurrence) return;
+      recurrence.endDateISO = normalizeDateKey(target.value || null);
+      meta.task.recurrence = recurrence;
+      const recurChip = holder.querySelector('[data-chip-recurrence]');
+      if (recurChip) recurChip.textContent = recurrenceSummaryLabel(meta.task);
     }
     persist();
   });
@@ -9268,7 +9606,35 @@ function renderSettings(){
       persist();
       return;
     }
-    if (target.getAttribute("data-k") === "mode"){
+    const selectKey = target.getAttribute("data-k");
+    if (selectKey === "recurrenceEnabled" || selectKey === "recurrenceBasis" || selectKey === "recurrenceEndType"){
+      const recurrence = normalizeTaskRecurrence(meta.task);
+      if (!recurrence) return;
+      if (selectKey === "recurrenceEnabled"){
+        recurrence.enabled = target.value === "yes";
+      }else if (selectKey === "recurrenceBasis"){
+        recurrence.basis = target.value;
+        if (recurrence.basis === "machine_hours"){
+          recurrence.intervalHours = Number(meta.task.interval) || Number(recurrence.intervalHours) || 1;
+          recurrence.every = Math.max(1, Math.round(Number(recurrence.intervalHours) || 1));
+        }else{
+          recurrence.intervalHours = null;
+        }
+      }else if (selectKey === "recurrenceEndType"){
+        recurrence.endType = target.value;
+        if (recurrence.endType !== "on_date") recurrence.endDateISO = null;
+        if (recurrence.endType !== "after_count") recurrence.endCount = null;
+      }
+      meta.task.recurrence = recurrence;
+      normalizeTaskRecurrence(meta.task);
+      const recurChip = holder.querySelector('[data-chip-recurrence]');
+      if (recurChip) recurChip.textContent = recurrenceSummaryLabel(meta.task);
+      if (typeof refreshDashboardWidgets === "function") refreshDashboardWidgets({ full: true });
+      persist();
+      if (typeof renderCalendar === "function") renderCalendar();
+      return;
+    }
+    if (selectKey === "mode"){
       const nextMode = target.value;
       if (nextMode === meta.mode) return;
       meta.list.splice(meta.index,1);

--- a/js/views.js
+++ b/js/views.js
@@ -335,6 +335,24 @@ function viewDashboard(){
           <p class="small muted" data-task-existing-empty hidden>No maintenance tasks yet. Create one below to get started.</p>
           <p class="small muted" data-task-existing-search-empty hidden>No tasks match your search. Try a different name.</p>
           <label>Occurrence note<textarea id="dashTaskExistingNote" rows="3" placeholder="Optional note for this calendar date"></textarea></label>
+          <label>Repeat<select id="dashTaskExistingRepeat">
+            <option value="no">Does not repeat</option>
+            <option value="yes">Repeats</option>
+          </select></label>
+          <label>Repeat basis<select id="dashTaskExistingRepeatBasis">
+            <option value="machine_hours">By machine cutting hours</option>
+            <option value="calendar_day">By calendar day</option>
+            <option value="calendar_week">By calendar week</option>
+            <option value="calendar_month">By calendar month</option>
+          </select></label>
+          <label>Repeat every<input type="number" min="1" step="1" id="dashTaskExistingRepeatEvery" value="1"></label>
+          <label>Repeat ends<select id="dashTaskExistingRepeatEnd">
+            <option value="never">Never</option>
+            <option value="on_date">On date</option>
+            <option value="after_count">After count</option>
+          </select></label>
+          <label hidden>Repeat end date<input type="date" id="dashTaskExistingRepeatEndDate"></label>
+          <label hidden>Repeat end count<input type="number" min="1" step="1" id="dashTaskExistingRepeatEndCount" value="1"></label>
           <div class="modal-actions">
             <button type="button" class="secondary" data-task-card-back>Back</button>
             <button type="submit" class="primary">Add to Calendar</button>
@@ -371,6 +389,24 @@ function viewDashboard(){
             <label>Time to complete (hrs)<input type="number" min="0.25" step="0.25" id="dashTaskDowntime" placeholder="e.g. 1"></label>
             <label>Category<select id="dashTaskCategory"></select></label>
             <label>Calendar date<input type="date" id="dashTaskDate"></label>
+            <label>Repeat<select id="dashTaskRepeat">
+              <option value="no">Does not repeat</option>
+              <option value="yes">Repeats</option>
+            </select></label>
+            <label>Repeat basis<select id="dashTaskRepeatBasis">
+              <option value="machine_hours">By machine cutting hours</option>
+              <option value="calendar_day">By calendar day</option>
+              <option value="calendar_week">By calendar week</option>
+              <option value="calendar_month">By calendar month</option>
+            </select></label>
+            <label>Repeat every<input type="number" min="1" step="1" id="dashTaskRepeatEvery" value="1"></label>
+            <label>Repeat ends<select id="dashTaskRepeatEnd">
+              <option value="never">Never</option>
+              <option value="on_date">On date</option>
+              <option value="after_count">After count</option>
+            </select></label>
+            <label hidden>Repeat end date<input type="date" id="dashTaskRepeatEndDate"></label>
+            <label hidden>Repeat end count<input type="number" min="1" step="1" id="dashTaskRepeatEndCount" value="1"></label>
           </div>
 
           <div class="subtask-section">

--- a/js/views.js
+++ b/js/views.js
@@ -339,14 +339,14 @@ function viewDashboard(){
             <option value="no">Does not repeat</option>
             <option value="yes">Repeats</option>
           </select></label>
-          <label>Repeat basis<select id="dashTaskExistingRepeatBasis">
+          <label hidden>Repeat basis<select id="dashTaskExistingRepeatBasis">
             <option value="machine_hours">By machine cutting hours</option>
             <option value="calendar_day">By calendar day</option>
             <option value="calendar_week">By calendar week</option>
             <option value="calendar_month">By calendar month</option>
           </select></label>
-          <label>Repeat every<input type="number" min="1" step="1" id="dashTaskExistingRepeatEvery" value="1"></label>
-          <label>Repeat ends<select id="dashTaskExistingRepeatEnd">
+          <label hidden>Repeat every<input type="number" min="1" step="1" id="dashTaskExistingRepeatEvery" value="1"></label>
+          <label hidden>Repeat ends<select id="dashTaskExistingRepeatEnd">
             <option value="never">Never</option>
             <option value="on_date">On date</option>
             <option value="after_count">After count</option>
@@ -375,12 +375,12 @@ function viewDashboard(){
         <form id="dashTaskForm" class="modal-form task-option-body" data-task-variant="new">
           <div class="modal-grid">
             <label>Task name<input id="dashTaskName" required placeholder="Task"></label>
-            <label>Type<select id="dashTaskType">
+            <label hidden>Type<select id="dashTaskType">
               <option value="interval">Per interval</option>
               <option value="asreq">As required</option>
             </select></label>
-            <label data-task-frequency>Frequency (hrs)<input type="number" min="1" step="1" id="dashTaskInterval" placeholder="e.g. 40"></label>
-            <label data-task-last>Hours since last service<input type="number" min="0" step="0.01" id="dashTaskLast" placeholder="optional"></label>
+            <label data-task-frequency hidden>Frequency (hrs)<input type="number" min="1" step="1" id="dashTaskInterval" placeholder="e.g. 40"></label>
+            <label data-task-last hidden>Hours since last service<input type="number" min="0" step="0.01" id="dashTaskLast" placeholder="optional"></label>
             <label data-task-condition hidden>Condition / trigger<input id="dashTaskCondition" placeholder="e.g. When clogged"></label>
             <label>Manual link<input type="url" id="dashTaskManual" placeholder="https://..."></label>
             <label>Store link<input type="url" id="dashTaskStore" placeholder="https://..."></label>
@@ -393,14 +393,14 @@ function viewDashboard(){
               <option value="no">Does not repeat</option>
               <option value="yes">Repeats</option>
             </select></label>
-            <label>Repeat basis<select id="dashTaskRepeatBasis">
+            <label hidden>Repeat basis<select id="dashTaskRepeatBasis">
               <option value="machine_hours">By machine cutting hours</option>
               <option value="calendar_day">By calendar day</option>
               <option value="calendar_week">By calendar week</option>
               <option value="calendar_month">By calendar month</option>
             </select></label>
-            <label>Repeat every<input type="number" min="1" step="1" id="dashTaskRepeatEvery" value="1"></label>
-            <label>Repeat ends<select id="dashTaskRepeatEnd">
+            <label hidden>Repeat every<input type="number" min="1" step="1" id="dashTaskRepeatEvery" value="1"></label>
+            <label hidden>Repeat ends<select id="dashTaskRepeatEnd">
               <option value="never">Never</option>
               <option value="on_date">On date</option>
               <option value="after_count">After count</option>

--- a/js/views.js
+++ b/js/views.js
@@ -351,17 +351,7 @@ function viewDashboard(){
             <option value="on_date">On date</option>
             <option value="after_count">After count</option>
           </select></label>
-          <label hidden id="dashTaskExistingWeekdaysRow">Repeat on
-            <span class="task-weekday-group">
-              <label><input type="checkbox" value="1" data-existing-weekday>Mon</label>
-              <label><input type="checkbox" value="2" data-existing-weekday>Tue</label>
-              <label><input type="checkbox" value="3" data-existing-weekday>Wed</label>
-              <label><input type="checkbox" value="4" data-existing-weekday>Thu</label>
-              <label><input type="checkbox" value="5" data-existing-weekday>Fri</label>
-              <label><input type="checkbox" value="6" data-existing-weekday>Sat</label>
-              <label><input type="checkbox" value="0" data-existing-weekday>Sun</label>
-            </span>
-          </label>
+          <label hidden id="dashTaskExistingWeekdaysRow">Repeat details<input type="text" value="Weekly repeats use the selected calendar date weekday." disabled></label>
           <label hidden>Repeat end date<input type="date" id="dashTaskExistingRepeatEndDate"></label>
           <label hidden>Repeat end count<input type="number" min="1" step="1" id="dashTaskExistingRepeatEndCount" value="1"></label>
           <div class="modal-actions">
@@ -390,7 +380,6 @@ function viewDashboard(){
               <option value="interval">Per interval</option>
               <option value="asreq">As required</option>
             </select></label>
-            <label data-task-frequency>Frequency (hrs)<input type="number" min="1" step="1" id="dashTaskInterval" placeholder="e.g. 40"></label>
             <label data-task-last>Hours since last service<input type="number" min="0" step="0.01" id="dashTaskLast" placeholder="optional"></label>
             <label data-task-condition hidden>Condition / trigger<input id="dashTaskCondition" placeholder="e.g. When clogged"></label>
             <label>Manual link<input type="url" id="dashTaskManual" placeholder="https://..."></label>
@@ -416,17 +405,7 @@ function viewDashboard(){
               <option value="on_date">On date</option>
               <option value="after_count">After count</option>
             </select></label>
-            <label hidden id="dashTaskWeekdaysRow">Repeat on
-              <span class="task-weekday-group">
-                <label><input type="checkbox" value="1" data-task-weekday>Mon</label>
-                <label><input type="checkbox" value="2" data-task-weekday>Tue</label>
-                <label><input type="checkbox" value="3" data-task-weekday>Wed</label>
-                <label><input type="checkbox" value="4" data-task-weekday>Thu</label>
-                <label><input type="checkbox" value="5" data-task-weekday>Fri</label>
-                <label><input type="checkbox" value="6" data-task-weekday>Sat</label>
-                <label><input type="checkbox" value="0" data-task-weekday>Sun</label>
-              </span>
-            </label>
+            <label hidden id="dashTaskWeekdaysRow">Repeat details<input type="text" value="Weekly repeats use the selected calendar date weekday." disabled></label>
             <label hidden>Repeat end date<input type="date" id="dashTaskRepeatEndDate"></label>
             <label hidden>Repeat end count<input type="number" min="1" step="1" id="dashTaskRepeatEndCount" value="1"></label>
           </div>

--- a/js/views.js
+++ b/js/views.js
@@ -339,18 +339,29 @@ function viewDashboard(){
             <option value="no">Does not repeat</option>
             <option value="yes">Repeats</option>
           </select></label>
-          <label hidden>Repeat basis<select id="dashTaskExistingRepeatBasis">
+          <label>Repeat basis<select id="dashTaskExistingRepeatBasis">
             <option value="machine_hours">By machine cutting hours</option>
             <option value="calendar_day">By calendar day</option>
             <option value="calendar_week">By calendar week</option>
             <option value="calendar_month">By calendar month</option>
           </select></label>
-          <label hidden>Repeat every<input type="number" min="1" step="1" id="dashTaskExistingRepeatEvery" value="1"></label>
-          <label hidden>Repeat ends<select id="dashTaskExistingRepeatEnd">
+          <label>Repeat every<input type="number" min="1" step="1" id="dashTaskExistingRepeatEvery" value="1"></label>
+          <label>Repeat ends<select id="dashTaskExistingRepeatEnd">
             <option value="never">Never</option>
             <option value="on_date">On date</option>
             <option value="after_count">After count</option>
           </select></label>
+          <label hidden id="dashTaskExistingWeekdaysRow">Repeat on
+            <span class="task-weekday-group">
+              <label><input type="checkbox" value="1" data-existing-weekday>Mon</label>
+              <label><input type="checkbox" value="2" data-existing-weekday>Tue</label>
+              <label><input type="checkbox" value="3" data-existing-weekday>Wed</label>
+              <label><input type="checkbox" value="4" data-existing-weekday>Thu</label>
+              <label><input type="checkbox" value="5" data-existing-weekday>Fri</label>
+              <label><input type="checkbox" value="6" data-existing-weekday>Sat</label>
+              <label><input type="checkbox" value="0" data-existing-weekday>Sun</label>
+            </span>
+          </label>
           <label hidden>Repeat end date<input type="date" id="dashTaskExistingRepeatEndDate"></label>
           <label hidden>Repeat end count<input type="number" min="1" step="1" id="dashTaskExistingRepeatEndCount" value="1"></label>
           <div class="modal-actions">
@@ -375,12 +386,12 @@ function viewDashboard(){
         <form id="dashTaskForm" class="modal-form task-option-body" data-task-variant="new">
           <div class="modal-grid">
             <label>Task name<input id="dashTaskName" required placeholder="Task"></label>
-            <label hidden>Type<select id="dashTaskType">
+            <label>Type<select id="dashTaskType">
               <option value="interval">Per interval</option>
               <option value="asreq">As required</option>
             </select></label>
-            <label data-task-frequency hidden>Frequency (hrs)<input type="number" min="1" step="1" id="dashTaskInterval" placeholder="e.g. 40"></label>
-            <label data-task-last hidden>Hours since last service<input type="number" min="0" step="0.01" id="dashTaskLast" placeholder="optional"></label>
+            <label data-task-frequency>Frequency (hrs)<input type="number" min="1" step="1" id="dashTaskInterval" placeholder="e.g. 40"></label>
+            <label data-task-last>Hours since last service<input type="number" min="0" step="0.01" id="dashTaskLast" placeholder="optional"></label>
             <label data-task-condition hidden>Condition / trigger<input id="dashTaskCondition" placeholder="e.g. When clogged"></label>
             <label>Manual link<input type="url" id="dashTaskManual" placeholder="https://..."></label>
             <label>Store link<input type="url" id="dashTaskStore" placeholder="https://..."></label>
@@ -393,18 +404,29 @@ function viewDashboard(){
               <option value="no">Does not repeat</option>
               <option value="yes">Repeats</option>
             </select></label>
-            <label hidden>Repeat basis<select id="dashTaskRepeatBasis">
+            <label>Repeat basis<select id="dashTaskRepeatBasis">
               <option value="machine_hours">By machine cutting hours</option>
               <option value="calendar_day">By calendar day</option>
               <option value="calendar_week">By calendar week</option>
               <option value="calendar_month">By calendar month</option>
             </select></label>
-            <label hidden>Repeat every<input type="number" min="1" step="1" id="dashTaskRepeatEvery" value="1"></label>
-            <label hidden>Repeat ends<select id="dashTaskRepeatEnd">
+            <label>Repeat every<input type="number" min="1" step="1" id="dashTaskRepeatEvery" value="1"></label>
+            <label>Repeat ends<select id="dashTaskRepeatEnd">
               <option value="never">Never</option>
               <option value="on_date">On date</option>
               <option value="after_count">After count</option>
             </select></label>
+            <label hidden id="dashTaskWeekdaysRow">Repeat on
+              <span class="task-weekday-group">
+                <label><input type="checkbox" value="1" data-task-weekday>Mon</label>
+                <label><input type="checkbox" value="2" data-task-weekday>Tue</label>
+                <label><input type="checkbox" value="3" data-task-weekday>Wed</label>
+                <label><input type="checkbox" value="4" data-task-weekday>Thu</label>
+                <label><input type="checkbox" value="5" data-task-weekday>Fri</label>
+                <label><input type="checkbox" value="6" data-task-weekday>Sat</label>
+                <label><input type="checkbox" value="0" data-task-weekday>Sun</label>
+              </span>
+            </label>
             <label hidden>Repeat end date<input type="date" id="dashTaskRepeatEndDate"></label>
             <label hidden>Repeat end count<input type="number" min="1" step="1" id="dashTaskRepeatEndCount" value="1"></label>
           </div>


### PR DESCRIPTION
### Motivation

- Fix a bug where marking an interval template complete from the dashboard could produce an unintended new instance on the next day by tightening the completion flow and de-duplicating generated occurrences.  
- Move calendar scheduling toward an explicit recurrence model (Google-style) so events/tasks can be created as one-time or recurring with frequency, basis, and end conditions.  
- Preserve existing interval / machine-hours logic and cost/history consumers while providing a backward-compatible, phased recurrence implementation.

### Description

- Introduce a recurrence schema and normalization helpers: `normalizeTaskRecurrence`, `getTaskRecurrence`, and `recurrenceSummaryLabel` to store and canonicalize optional recurrence metadata on tasks and instances.  
- Add calendar-based occurrence generation with `projectCalendarBasedOccurrences` and wire it into `projectIntervalDueDates`, `nextDue`, and calendar rendering so calendar-day/week/month recurrences are respected; machine-hours basis still falls back to legacy interval math.  
- Fix completion and rendering duplication: removed automatic instancing in `completeTask` to avoid creating an extra near-term instance, updated `markCalendarTaskComplete` to record recurrence anchors, and added deterministic de-duplication in `pushTaskEvent` (templateKey-based) to prevent duplicate chips.  
- Extend scheduling APIs and instance creation to carry recurrence metadata (`scheduleExistingIntervalTask`, `scheduleExistingAsReqTask`, `createIntervalTaskInstance`), and ensure templates propagate normalized recurrence to new instances.  
- Add UI controls for recurrence to the dashboard add modal and Maintenance Settings: repeat toggle, basis selector, every/count, and end rules; read/write plumbing added in `renderers.js` to persist and update recurrence fields and update recurrence summary chips in the settings UI.  

### Testing

- Ran the project linting and unit test suite via `npm run lint` and `npm test`; both completed successfully.  
- Ran automated calendar rendering/integration smoke tests (`npm run test:integration`) which exercised scheduling, completion, and recurrence projection paths and passed.  
- Automated regression checks for calendar duplication and completion paths confirmed the duplicate-next-day symptom is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8f71f464832583795084cbdca77c)