### PR TITLE
Add optional calendar recurrence rules and fix interval completion duplication

### DIFF
--- a/docs/calendar-recurrence-google-style-plan.md
+++ b/docs/calendar-recurrence-google-style-plan.md
@@ -1,0 +1,142 @@
+# Dashboard Calendar Recurrence & Completion Behavior Plan (Google-Style)
+
+## Scope of request
+- Fix bug: marking an interval task complete on the dashboard calendar (e.g., **Mixing tube rotation**) is causing a new copy to appear on the next day.
+- Move calendar behavior toward a Google Calendar-like recurrence model:
+  - When adding/scheduling events/tasks, explicitly choose whether it repeats.
+  - If repeating, choose the recurrence frequency.
+- Update Maintenance Settings so recurrence controls are aligned with calendar behavior.
+- Preserve existing interval/per-hour maintenance logic and avoid breaking forecasting/cost logic.
+
+---
+
+## Code reading summary (pass 1)
+
+### 1) Where the duplicate-next-day behavior comes from
+The current completion path for interval template tasks creates a new **instance** and then completes it immediately:
+1. `completeTask(taskId)` in `js/calendar.js` checks if the selected item is an interval template.
+2. If it is, it calls `scheduleExistingIntervalTask(template, { dateISO: today })`, which can create a new instance and assign today as `calendarDateISO`.
+3. Then `markCalendarTaskComplete(...)` marks completion and records `completedDates`/`manualHistory`.
+
+This instance/template split, plus projection logic and manual-history merge logic, can produce “extra copy” behavior depending on what dates are already in manual/completed/projection sets. The symptom aligns with this flow.
+
+### 2) Recurrence/event scheduling touchpoints
+- Calendar rendering and event composition:
+  - `renderCalendar()`, `projectIntervalDueDates()`, `pushTaskEvent(...)` in `js/calendar.js`.
+- Completion/uncompletion/removal behavior:
+  - `markCalendarTaskComplete`, `unmarkCalendarTaskComplete`, `removeCalendarTaskOccurrences` in `js/calendar.js`.
+- Task scheduling/instancing:
+  - `scheduleExistingIntervalTask`, `scheduleExistingAsReqTask`, `createIntervalTaskInstance` in `js/renderers.js`.
+- Add-task modal UI and submit handlers:
+  - Dashboard picker/forms in `js/views.js` + handler wiring in `js/renderers.js`.
+- Baseline/per-interval math:
+  - `nextDue`, `liveSince` in `js/computations.js`.
+  - `applyIntervalBaseline`, `ensureTaskManualHistory` in `js/renderers.js`.
+
+### 3) Current model mismatch with requested UX
+Current model is maintenance-centric (interval + as-required + optional scheduling) and stores recurrence implicitly through interval math and projections. Requested behavior requires explicit scheduling recurrence settings per added calendar event (none/daily/weekly/monthly/custom) similar to Google Calendar.
+
+---
+
+## Initial implementation plan (draft)
+
+1. **Define recurrence schema (non-breaking).**
+   - Add optional recurrence fields to scheduled task instances (and one-time tasks where needed):
+     - `scheduleMode`: `"none" | "recurring"`
+     - `recurrenceType`: `"daily" | "weekly" | "monthly" | "hours_interval"`
+     - `recurrenceInterval`: number (e.g., every 2 days/weeks/months)
+     - `recurrenceDaysOfWeek`: optional array for weekly rules
+     - `recurrenceEnd`: `"never" | "on_date" | "after_count"`
+     - `recurrenceEndDate` / `recurrenceCount`
+   - Keep legacy fields (`interval`, `manualHistory`, `completedDates`, etc.) untouched for compatibility.
+
+2. **Add recurrence controls to Add Task flow (dashboard modal).**
+   - In “existing task” and “new task” forms, add UI:
+     - Repeat: No / Yes
+     - Frequency selector (daily/weekly/monthly/hour-interval)
+     - Frequency value input
+     - End condition (never/end date/after count)
+   - Ensure defaults preserve old behavior (for interval templates default to recurring by interval-hours when appropriate).
+
+3. **Add recurrence controls to Maintenance Settings cards.**
+   - Add editable recurrence fields alongside existing interval/condition fields.
+   - Hook into `data-k` input persistence path in `renderers.js` without breaking current edit-mode gating.
+
+4. **Introduce a unified occurrence generator layer.**
+   - New helper(s) that produce occurrences from either:
+     - explicit recurrence schema, or
+     - legacy interval projection fallback.
+   - Calendar renderer should consume this unified occurrence list so both old and new tasks behave consistently.
+
+5. **Fix completion behavior for interval templates.**
+   - Refactor `completeTask(...)` so “mark complete” updates the right task occurrence without creating an accidental additional near-term occurrence.
+   - Ensure the next due/recurrence computation excludes the completed occurrence in a deterministic way.
+
+6. **Preserve cost and analytics compatibility.**
+   - Ensure `computeCostModel()` and history extraction still rely on completed/manual history dates.
+   - If recurrence fields are added, they should be optional metadata and not replace existing completion records used by cost calculations.
+
+7. **Migration + normalization.**
+   - Add normalization so older saved tasks without recurrence fields behave exactly as before.
+   - Add guardrails for invalid recurrence values.
+
+8. **Validation matrix.**
+   - Interval template completion (today/past/future).
+   - As-required scheduled once vs repeated.
+   - One-time tasks remain one-time by default.
+   - Remove single/future/all occurrence behavior still works.
+   - Forecast/cost widgets still render and derive values correctly.
+
+---
+
+## Code reading summary (pass 2 review + adjustments)
+
+After re-reading the scheduling/completion/render paths, I am adjusting the plan to reduce risk in this complex codebase:
+
+### Key findings from second pass
+1. **Instances are heavily integrated** in settings organization, cost history, and calendar rendering. Fully replacing instance behavior now is risky.
+2. `renderCalendar()` currently expects interval *instances* for projected/due rendering (`isInstanceTask` filters). Any immediate model replacement could break visibility.
+3. Cost model and history logic pull from `manualHistory`, `completedDates`, and task activity checks; these must remain the source of truth.
+4. The bug is likely solvable quickly by tightening completion flow and projection exclusion, independent of full recurrence redesign.
+
+### Revised plan (safer phased rollout)
+
+#### Phase 1 — Stabilization + bug fix
+1. **Patch completion logic first** (minimal invasive):
+   - Update `completeTask(...)` path so marking an interval task complete does not create an unintended extra calendar occurrence.
+   - Add explicit de-duplication guard around “today + next projected date” collision.
+2. **Add deterministic event dedupe in calendar assembly**:
+   - Normalize composite keys (`templateId/taskId + date + status precedence`) before pushing chips.
+   - Keep completed > manual > due priority, but prevent duplicate semantic occurrences.
+3. **Regression pass for removal/uncomplete operations** using existing scope logic (`single/future/all`).
+
+#### Phase 2 — Google-style recurrence controls (additive)
+4. **Add recurrence metadata fields** (optional, backward-compatible) for newly scheduled tasks/events.
+5. **Extend Add Task / Existing Task scheduling UI** with repeat controls.
+6. **Extend Maintenance Settings UI** with same repeat controls so users can edit recurrence after creation.
+
+#### Phase 3 — Unified recurrence engine behind feature-compat facade
+7. Build a unified occurrence generator that first checks explicit recurrence metadata; if absent, falls back to current interval projection logic.
+8. Keep existing `manualHistory` + `completedDates` writes intact so cost/forecast code stays stable.
+
+#### Phase 4 — Hardening + migration
+9. Add normalization migration for recurrence defaults on load.
+10. Add test checklist + manual validation scripts for all recurrence/completion modes and cost widgets.
+
+---
+
+## Implementation notes / guardrails
+- **Do not break existing task schema consumers** (`computeCostModel`, history cards, next-due widget).
+- **Completion semantics remain event-based**: completing an occurrence writes completion history for that date.
+- **Recurrence semantics are generation-only**: they generate candidate dates but do not auto-mark completion.
+- **As-required defaults to non-repeating** unless user enables recurrence explicitly.
+- **Interval maintenance can default to repeating** but user must be able to set “does not repeat” when adding from calendar.
+
+---
+
+## Deliverables for implementation phase
+1. Completion bug fix in calendar logic.
+2. New recurrence UI controls in dashboard add modal and maintenance settings cards.
+3. Recurrence metadata persistence + normalization.
+4. Unified occurrence generation with legacy fallback.
+5. Validation checklist run and documented.

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1028,14 +1028,6 @@ function makeBubble(anchor){
 function completeTask(taskId){
   let meta = findCalendarTaskMeta(taskId);
   if (!meta) return;
-  if (isTemplateTask(meta.task) && meta.task.mode === "interval"){
-    const instance = scheduleExistingIntervalTask(meta.task, { dateISO: ymd(new Date()) });
-    if (instance){
-      const nextMeta = findCalendarTaskMeta(instance.id);
-      if (nextMeta) meta = nextMeta;
-      else meta = { task: instance, mode: "interval", list: window.tasksInterval, index: window.tasksInterval.indexOf(instance) };
-    }
-  }
   const todayKey = normalizeDateKey(new Date());
   if (!todayKey) return;
   const changed = markCalendarTaskComplete(meta, todayKey);
@@ -1984,6 +1976,79 @@ function renderCalendar(){
     });
   }
 
+  const recurrenceForTask = (task)=>{
+    const fallback = task && task.mode === "interval"
+      ? { type: "machine_hours", every: Math.max(1, Math.round(Number(task.interval) || 1)), endType: "never", endDateISO: null, count: null }
+      : { type: "none", every: 1, endType: "never", endDateISO: null, count: null };
+    if (typeof recurrenceRuleForTask === "function"){
+      try { return recurrenceRuleForTask(task); } catch (_err){}
+    }
+    const raw = task && task.recurrenceRule && typeof task.recurrenceRule === "object" ? task.recurrenceRule : null;
+    if (!raw) return fallback;
+    const type = typeof raw.type === "string" ? raw.type : fallback.type;
+    const every = Number.isFinite(Number(raw.every)) && Number(raw.every) > 0 ? Math.max(1, Math.round(Number(raw.every))) : fallback.every;
+    const endType = raw.endType === "on_date" || raw.endType === "after_count" ? raw.endType : "never";
+    const endDateISO = typeof raw.endDateISO === "string" ? raw.endDateISO : null;
+    const count = Number.isFinite(Number(raw.count)) && Number(raw.count) > 0 ? Math.max(1, Math.round(Number(raw.count))) : null;
+    return { type, every, endType, endDateISO, count };
+  };
+
+  const projectCalendarRecurringDates = (task, rule, { skipDates = new Set(), minOccurrences = 1, maxOccurrences = 1 } = {})=>{
+    if (!task || !rule || !String(rule.type || "").startsWith("calendar_")) return [];
+    const toStart = (value)=>{
+      const key = normalizeDateKey(value);
+      if (!key) return null;
+      const parsed = parseDateLocal(key);
+      if (!(parsed instanceof Date) || Number.isNaN(parsed.getTime())) return null;
+      parsed.setHours(0,0,0,0);
+      return parsed;
+    };
+    const completedDates = Array.isArray(task.completedDates) ? task.completedDates.map(normalizeDateKey).filter(Boolean) : [];
+    const manualDates = Array.isArray(task.manualHistory) ? task.manualHistory.map(item => normalizeDateKey(item?.dateISO)).filter(Boolean) : [];
+    const explicit = normalizeDateKey(task.calendarDateISO);
+    const baseCandidates = [...completedDates, ...manualDates];
+    if (explicit) baseCandidates.push(explicit);
+    let base = null;
+    if (baseCandidates.length){
+      baseCandidates.sort();
+      base = toStart(baseCandidates[baseCandidates.length - 1]);
+    }
+    if (!(base instanceof Date)){
+      base = toStart(new Date()) || new Date();
+      base.setHours(0,0,0,0);
+    }
+    const every = Math.max(1, Math.round(Number(rule.every) || 1));
+    const today = toStart(new Date()) || new Date();
+    today.setHours(0,0,0,0);
+    const out = [];
+    let generated = 0;
+    let cursor = new Date(base.getTime());
+    const maxIterations = 180;
+    while (generated < maxIterations && out.length < Math.max(minOccurrences, maxOccurrences || 1)){
+      generated += 1;
+      if (rule.type === "calendar_daily"){
+        cursor.setDate(cursor.getDate() + every);
+      }else if (rule.type === "calendar_weekly"){
+        cursor.setDate(cursor.getDate() + (every * 7));
+      }else if (rule.type === "calendar_monthly"){
+        cursor.setMonth(cursor.getMonth() + every);
+      }else{
+        break;
+      }
+      const key = ymd(cursor);
+      if (!key || skipDates.has(key)) continue;
+      if (rule.endType === "on_date" && rule.endDateISO && key > rule.endDateISO) break;
+      if (rule.endType === "after_count" && rule.count != null && out.length >= rule.count) break;
+      if (cursor < today && out.length < minOccurrences){
+        out.push({ dateISO: key, dueDate: new Date(cursor.getTime()) });
+        continue;
+      }
+      out.push({ dateISO: key, dueDate: new Date(cursor.getTime()) });
+    }
+    if (maxOccurrences != null) return out.slice(0, maxOccurrences);
+    return out;
+  };
+
   const intervalTasks = Array.isArray(window.tasksInterval)
     ? window.tasksInterval.filter(t => t && t.mode === "interval" && isInstanceTask(t))
     : [];
@@ -2048,12 +2113,22 @@ function renderCalendar(){
     const skipDates = new Set(completedKeys);
     manualDates.forEach(dateKey => skipDates.add(dateKey));
     removedSet.forEach(dateKey => skipDates.add(dateKey));
-    const projections = projectIntervalDueDates(t, {
-      monthsAhead: 3,
-      excludeDates: skipDates,
-      minOccurrences: 1,
-      maxOccurrences: 1
-    });
+    const recurrence = recurrenceForTask(t);
+    let projections = [];
+    if (recurrence.type === "machine_hours"){
+      projections = projectIntervalDueDates(t, {
+        monthsAhead: 3,
+        excludeDates: skipDates,
+        minOccurrences: 1,
+        maxOccurrences: 1
+      });
+    } else if (String(recurrence.type || "").startsWith("calendar_")){
+      projections = projectCalendarRecurringDates(t, recurrence, {
+        skipDates,
+        minOccurrences: 1,
+        maxOccurrences: 1
+      });
+    }
     if (projections.length){
       const pred = projections[0];
       const dueKey = normalizeDateKey(pred?.dateISO);
@@ -2063,6 +2138,7 @@ function renderCalendar(){
       return;
     }
 
+    if (recurrence.type !== "machine_hours") return;
     const nd = nextDue(t);
     if (!nd) return;
     const dueKey = normalizeDateKey(nd.due);
@@ -2083,6 +2159,18 @@ function renderCalendar(){
     const manualKey = normalizeDateKey(t.calendarDateISO);
     if (manualKey){
       pushTaskEvent(t, manualKey, completedDates.has(manualKey) ? "completed" : "manual");
+    }
+    const recurrence = recurrenceForTask(t);
+    if (String(recurrence.type || "").startsWith("calendar_")){
+      const skipDates = new Set(completedDates);
+      if (manualKey) skipDates.add(manualKey);
+      const projections = projectCalendarRecurringDates(t, recurrence, { skipDates, minOccurrences: 1, maxOccurrences: 1 });
+      if (projections.length){
+        const dueKey = normalizeDateKey(projections[0]?.dateISO);
+        if (dueKey && !skipDates.has(dueKey)){
+          pushTaskEvent(t, dueKey, "due");
+        }
+      }
     }
   });
 

--- a/js/core.js
+++ b/js/core.js
@@ -2254,8 +2254,17 @@ function ensureTaskCategories(){
     if (!t) return;
     if (!t.cat) t.cat = "interval";
     if (!Array.isArray(t.completedDates)) t.completedDates = [];
+    if (typeof window !== "undefined" && typeof window.normalizeRecurrenceRule === "function"){
+      t.recurrenceRule = window.normalizeRecurrenceRule(t.recurrenceRule, t);
+    }
   });
-  tasksAsReq.forEach(t =>    { if (t && !t.cat) t.cat = "asreq"; });
+  tasksAsReq.forEach(t => {
+    if (!t) return;
+    if (!t.cat) t.cat = "asreq";
+    if (typeof window !== "undefined" && typeof window.normalizeRecurrenceRule === "function"){
+      t.recurrenceRule = window.normalizeRecurrenceRule(t.recurrenceRule, t);
+    }
+  });
 }
 
 function ensureJobCategories(){

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -382,6 +382,52 @@ function baselineInputValue(task){
   return "";
 }
 
+const DEFAULT_RECURRENCE_RULE = Object.freeze({
+  type: "none",
+  every: 1,
+  endType: "never",
+  endDateISO: null,
+  count: null
+});
+
+function normalizeRecurrenceRule(rawRule, task = null){
+  const src = (rawRule && typeof rawRule === "object") ? rawRule : {};
+  let type = typeof src.type === "string" ? src.type : "";
+  if (!type){
+    if (task && task.mode === "interval"){
+      type = "machine_hours";
+    }else{
+      type = "none";
+    }
+  }
+  const allowedTypes = new Set(["none", "machine_hours", "calendar_daily", "calendar_weekly", "calendar_monthly"]);
+  if (!allowedTypes.has(type)) type = "none";
+  const everyRaw = Number(src.every);
+  const every = Number.isFinite(everyRaw) && everyRaw > 0 ? Math.max(1, Math.round(everyRaw)) : 1;
+  let endType = typeof src.endType === "string" ? src.endType : "never";
+  if (!["never", "on_date", "after_count"].includes(endType)) endType = "never";
+  const endDateISO = (typeof src.endDateISO === "string" && /^\d{4}-\d{2}-\d{2}$/.test(src.endDateISO.trim()))
+    ? src.endDateISO.trim()
+    : null;
+  const countRaw = Number(src.count);
+  const count = Number.isFinite(countRaw) && countRaw > 0 ? Math.max(1, Math.round(countRaw)) : null;
+  return { type, every, endType, endDateISO, count };
+}
+
+function recurrenceRuleForTask(task){
+  if (!task || typeof task !== "object") return { ...DEFAULT_RECURRENCE_RULE };
+  const normalized = normalizeRecurrenceRule(task.recurrenceRule, task);
+  task.recurrenceRule = normalized;
+  return normalized;
+}
+
+function setTaskRecurrenceRule(task, nextRule){
+  if (!task || typeof task !== "object") return null;
+  const normalized = normalizeRecurrenceRule(nextRule, task);
+  task.recurrenceRule = normalized;
+  return normalized;
+}
+
 const DASHBOARD_DAY_MS = 24 * 60 * 60 * 1000;
 
 function hoursSnapshotOnOrBefore(dateISO){
@@ -583,6 +629,7 @@ function createIntervalTaskInstance(template){
     occurrenceNotes: {},
     occurrenceHours: {},
     note: template.note || "",
+    recurrenceRule: normalizeRecurrenceRule(template.recurrenceRule, template),
     downtimeHours: (()=>{
       const raw = Number(template.downtimeHours);
       if (Number.isFinite(raw) && raw > 0) return Math.max(1, Math.round(raw * 100) / 100);
@@ -595,7 +642,7 @@ function createIntervalTaskInstance(template){
   return copy;
 }
 
-function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refreshDashboard = true } = {}){
+function scheduleExistingIntervalTask(task, { dateISO = null, note = "", recurrenceRule = null, refreshDashboard = true } = {}){
   if (!task || task.mode !== "interval") return null;
   if (!Array.isArray(tasksInterval)){
     if (Array.isArray(window.tasksInterval)){
@@ -629,6 +676,12 @@ function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refresh
     if (template && template.templateId != null) instance.templateId = template.templateId;
     else if (template && template.id != null) instance.templateId = template.id;
     else instance.templateId = instance.id;
+  }
+  const templateRule = normalizeRecurrenceRule(template?.recurrenceRule, template || instance);
+  const instanceRule = normalizeRecurrenceRule(recurrenceRule || instance.recurrenceRule || templateRule, instance);
+  instance.recurrenceRule = instanceRule;
+  if (template && !isInstanceTask(template)){
+    template.recurrenceRule = templateRule;
   }
 
   const resolveDowntime = ()=>{
@@ -753,7 +806,7 @@ function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refresh
   return instance;
 }
 
-function scheduleExistingAsReqTask(task, { dateISO = null, note = "", refreshDashboard = true } = {}){
+function scheduleExistingAsReqTask(task, { dateISO = null, note = "", recurrenceRule = null, refreshDashboard = true } = {}){
   if (!task || task.mode !== "asreq") return null;
   if (!Array.isArray(window.tasksAsReq)) window.tasksAsReq = [];
 
@@ -771,7 +824,8 @@ function scheduleExistingAsReqTask(task, { dateISO = null, note = "", refreshDas
     id: genId(task.name || "task"),
     variant: "instance",
     templateId: templateId != null ? templateId : null,
-    calendarDateISO: normalizeDate(dateISO)
+    calendarDateISO: normalizeDate(dateISO),
+    recurrenceRule: normalizeRecurrenceRule(recurrenceRule || task.recurrenceRule, task)
   };
 
   if (Array.isArray(task.parts)) instance.parts = task.parts.map(part => part ? { ...part } : part).filter(Boolean);
@@ -798,6 +852,9 @@ if (typeof window !== "undefined"){
   window.scheduleExistingIntervalTask = scheduleExistingIntervalTask;
   window.scheduleExistingAsReqTask = scheduleExistingAsReqTask;
   window.createIntervalTaskInstance = createIntervalTaskInstance;
+  window.normalizeRecurrenceRule = normalizeRecurrenceRule;
+  window.recurrenceRuleForTask = recurrenceRuleForTask;
+  window.setTaskRecurrenceRule = setTaskRecurrenceRule;
 }
 
 function editingCompletedJobsSet(){
@@ -2310,6 +2367,10 @@ function renderNextDueWidget(ndBox){
   const upcoming = tasksInterval
     .filter(task => task && task.mode === "interval" && isInstanceTask(task))
     .map(t => {
+      const recurrence = recurrenceRuleForTask(t);
+      if (recurrence.type !== "machine_hours" && recurrence.type !== "calendar_daily" && recurrence.type !== "calendar_weekly" && recurrence.type !== "calendar_monthly"){
+        return null;
+      }
       const nd = nextDue(t);
       if (!nd || !(nd.due instanceof Date)) return null;
 
@@ -4914,6 +4975,13 @@ function renderDashboard(){
   const taskPNInput      = document.getElementById("dashTaskPN");
   const taskPriceInput   = document.getElementById("dashTaskPrice");
   const taskDowntimeInput= document.getElementById("dashTaskDowntime");
+  const taskRepeatTypeInput = document.getElementById("dashTaskRepeatType");
+  const taskRepeatEveryInput = document.getElementById("dashTaskRepeatEvery");
+  const taskRepeatEndTypeInput = document.getElementById("dashTaskRepeatEndType");
+  const taskRepeatEndDateInput = document.getElementById("dashTaskRepeatEndDate");
+  const taskRepeatCountInput = document.getElementById("dashTaskRepeatCount");
+  const taskRepeatEndDateRow = taskForm?.querySelector("[data-repeat-end-date]");
+  const taskRepeatEndCountRow = taskForm?.querySelector("[data-repeat-end-count]");
   const categorySelect   = document.getElementById("dashTaskCategory");
   const taskDateInput    = document.getElementById("dashTaskDate");
   const subtaskList      = document.getElementById("dashSubtaskList");
@@ -4922,6 +4990,13 @@ function renderDashboard(){
   const taskOptionButtons= Array.from(modal?.querySelectorAll('[data-task-option]') || []);
   const taskCards        = Array.from(modal?.querySelectorAll('[data-task-card]') || []);
   const taskExistingSearchInput = document.getElementById("dashTaskExistingSearch");
+  const taskExistingRepeatTypeInput = document.getElementById("dashTaskExistingRepeatType");
+  const taskExistingRepeatEveryInput = document.getElementById("dashTaskExistingRepeatEvery");
+  const taskExistingRepeatEndTypeInput = document.getElementById("dashTaskExistingRepeatEndType");
+  const taskExistingRepeatEndDateInput = document.getElementById("dashTaskExistingRepeatEndDate");
+  const taskExistingRepeatCountInput = document.getElementById("dashTaskExistingRepeatCount");
+  const taskExistingRepeatEndDateRow = taskExistingForm?.querySelector("[data-existing-repeat-end-date]");
+  const taskExistingRepeatEndCountRow = taskExistingForm?.querySelector("[data-existing-repeat-end-count]");
   const taskExistingSearchWrapper = taskExistingForm?.querySelector(".task-existing-search");
   const existingTaskResults = taskExistingForm?.querySelector('[data-task-existing-results]');
   const existingTaskEmpty  = taskExistingForm?.querySelector('[data-task-existing-empty]');
@@ -5060,6 +5135,16 @@ function renderDashboard(){
       btn.classList.toggle("is-active", isMatch);
       btn.setAttribute("aria-pressed", isMatch ? "true" : "false");
     });
+    if (!selectedExistingTaskId) return;
+    const meta = findMaintenanceTaskById(selectedExistingTaskId);
+    if (!meta || !meta.task) return;
+    const rule = recurrenceRuleForTask(meta.task);
+    if (taskExistingRepeatTypeInput) taskExistingRepeatTypeInput.value = rule.type || "none";
+    if (taskExistingRepeatEveryInput) taskExistingRepeatEveryInput.value = String(rule.every || 1);
+    if (taskExistingRepeatEndTypeInput) taskExistingRepeatEndTypeInput.value = rule.endType || "never";
+    if (taskExistingRepeatEndDateInput) taskExistingRepeatEndDateInput.value = rule.endDateISO || "";
+    if (taskExistingRepeatCountInput) taskExistingRepeatCountInput.value = rule.count != null ? String(rule.count) : "";
+    toggleRepeatEndRows(taskExistingRepeatEndTypeInput?.value || "never", taskExistingRepeatEndDateRow, taskExistingRepeatEndCountRow);
   }
 
   function setTaskOptionPage(target){
@@ -5147,6 +5232,12 @@ function renderDashboard(){
   function resetExistingTaskForm(){
     if (taskExistingSearchInput) taskExistingSearchInput.value = "";
     if (taskExistingNoteInput) taskExistingNoteInput.value = "";
+    if (taskExistingRepeatTypeInput) taskExistingRepeatTypeInput.value = "none";
+    if (taskExistingRepeatEveryInput) taskExistingRepeatEveryInput.value = "1";
+    if (taskExistingRepeatEndTypeInput) taskExistingRepeatEndTypeInput.value = "never";
+    if (taskExistingRepeatEndDateInput) taskExistingRepeatEndDateInput.value = "";
+    if (taskExistingRepeatCountInput) taskExistingRepeatCountInput.value = "";
+    toggleRepeatEndRows("never", taskExistingRepeatEndDateRow, taskExistingRepeatEndCountRow);
     setSelectedExistingTask(null);
     refreshExistingTaskOptions("");
   }
@@ -5196,6 +5287,31 @@ function renderDashboard(){
     if (!modalVisible || !taskDateInput.value){
       taskDateInput.value = ymd(new Date());
     }
+  }
+
+  function toggleRepeatEndRows(endType, rowDate, rowCount){
+    if (rowDate) rowDate.hidden = endType !== "on_date";
+    if (rowCount) rowCount.hidden = endType !== "after_count";
+  }
+
+  function readRecurrenceFromInputs({
+    typeInput,
+    everyInput,
+    endTypeInput,
+    endDateInput,
+    countInput,
+    fallbackTask = null
+  } = {}){
+    const type = typeInput?.value || (fallbackTask?.mode === "interval" ? "machine_hours" : "none");
+    const everyRaw = Number(everyInput?.value);
+    const endType = endTypeInput?.value || "never";
+    return normalizeRecurrenceRule({
+      type,
+      every: Number.isFinite(everyRaw) && everyRaw > 0 ? everyRaw : 1,
+      endType,
+      endDateISO: endDateInput?.value || null,
+      count: countInput?.value || null
+    }, fallbackTask);
   }
 
   function syncOneTimeDateInput(){
@@ -5493,10 +5609,16 @@ function renderDashboard(){
       taskFreqRow.hidden = true;
       taskLastRow.hidden = true;
       taskConditionRow.hidden = false;
+      if (taskRepeatTypeInput && taskRepeatTypeInput.value === "machine_hours"){
+        taskRepeatTypeInput.value = "none";
+      }
     }else{
       taskFreqRow.hidden = false;
       taskLastRow.hidden = false;
       taskConditionRow.hidden = true;
+      if (taskRepeatTypeInput && (!taskRepeatTypeInput.value || taskRepeatTypeInput.value === "none")){
+        taskRepeatTypeInput.value = "machine_hours";
+      }
     }
   }
 
@@ -5505,6 +5627,12 @@ function renderDashboard(){
     if (taskDowntimeInput){
       taskDowntimeInput.value = "1";
     }
+    if (taskRepeatTypeInput) taskRepeatTypeInput.value = "machine_hours";
+    if (taskRepeatEveryInput) taskRepeatEveryInput.value = "1";
+    if (taskRepeatEndTypeInput) taskRepeatEndTypeInput.value = "never";
+    if (taskRepeatEndDateInput) taskRepeatEndDateInput.value = "";
+    if (taskRepeatCountInput) taskRepeatCountInput.value = "";
+    toggleRepeatEndRows("never", taskRepeatEndDateRow, taskRepeatEndCountRow);
     subtaskList?.replaceChildren();
     resetExistingTaskForm();
     showTaskOptionStage();
@@ -5801,6 +5929,12 @@ function renderDashboard(){
   });
 
   taskTypeSelect?.addEventListener("change", ()=> syncTaskMode(taskTypeSelect.value));
+  taskRepeatEndTypeInput?.addEventListener("change", ()=>{
+    toggleRepeatEndRows(taskRepeatEndTypeInput.value, taskRepeatEndDateRow, taskRepeatEndCountRow);
+  });
+  taskExistingRepeatEndTypeInput?.addEventListener("change", ()=>{
+    toggleRepeatEndRows(taskExistingRepeatEndTypeInput.value, taskExistingRepeatEndDateRow, taskExistingRepeatEndCountRow);
+  });
   syncTaskMode(taskTypeSelect?.value || "interval");
   syncTaskDateInput();
   syncOneTimeDateInput();
@@ -5839,6 +5973,14 @@ function renderDashboard(){
     const dateISO = rawDate ? ymd(rawDate) : "";
     const targetISO = dateISO || addContextDateISO || ymd(new Date());
     const calendarDateISO = targetISO || null;
+    const recurrenceRule = readRecurrenceFromInputs({
+      typeInput: taskRepeatTypeInput,
+      everyInput: taskRepeatEveryInput,
+      endTypeInput: taskRepeatEndTypeInput,
+      endDateInput: taskRepeatEndDateInput,
+      countInput: taskRepeatCountInput,
+      fallbackTask: { mode }
+    });
     const base = {
       id,
       name,
@@ -5850,7 +5992,8 @@ function renderDashboard(){
       parentTask: null,
       order: ++window._maintOrderCounter,
       calendarDateISO: null,
-      downtimeHours: downtimeVal
+      downtimeHours: downtimeVal,
+      recurrenceRule
     };
     let message = "Task added";
     if (mode === "interval"){
@@ -5871,7 +6014,7 @@ function renderDashboard(){
       const baselineHours = parseBaselineHours(taskLastInput?.value);
       applyIntervalBaseline(template, { baselineHours, currentHours: curHours });
       tasksInterval.unshift(template);
-      const instance = scheduleExistingIntervalTask(template, { dateISO: targetISO, refreshDashboard: false }) || template;
+      const instance = scheduleExistingIntervalTask(template, { dateISO: targetISO, recurrenceRule, refreshDashboard: false }) || template;
       const parsed = parseDateLocal(targetISO);
       const todayMidnight = new Date(); todayMidnight.setHours(0,0,0,0);
       let dateLabel = targetISO;
@@ -5926,7 +6069,8 @@ function renderDashboard(){
           completedDates: [],
           manualHistory: [],
           variant: "template",
-          templateId: subBase.id
+          templateId: subBase.id,
+          recurrenceRule: normalizeRecurrenceRule({ type: "machine_hours", every: subInterval }, { mode: "interval", interval: subInterval })
         });
         const curHours = getCurrentMachineHours();
         const lastField = row.querySelector("[data-subtask-last]");
@@ -5939,7 +6083,8 @@ function renderDashboard(){
           mode:"asreq",
           condition: (condInput?.value || "").trim() || "As required",
           variant: "template",
-          templateId: subBase.id
+          templateId: subBase.id,
+          recurrenceRule: normalizeRecurrenceRule({ type: "none" }, { mode: "asreq" })
         });
         tasksAsReq.unshift(subTask);
       }
@@ -6015,9 +6160,17 @@ function renderDashboard(){
     const task = meta.task;
     const targetISO = addContextDateISO || ymd(new Date());
     const occurrenceNote = (taskExistingNoteInput?.value || "").trim();
+    const recurrenceRule = readRecurrenceFromInputs({
+      typeInput: taskExistingRepeatTypeInput,
+      everyInput: taskExistingRepeatEveryInput,
+      endTypeInput: taskExistingRepeatEndTypeInput,
+      endDateInput: taskExistingRepeatEndDateInput,
+      countInput: taskExistingRepeatCountInput,
+      fallbackTask: task
+    });
     let message = "Maintenance task added";
     if (task.mode === "interval"){
-      const instance = scheduleExistingIntervalTask(task, { dateISO: targetISO, note: occurrenceNote, refreshDashboard: true }) || task;
+      const instance = scheduleExistingIntervalTask(task, { dateISO: targetISO, note: occurrenceNote, recurrenceRule, refreshDashboard: true }) || task;
       const parsed = parseDateLocal(targetISO);
       const todayMidnight = new Date(); todayMidnight.setHours(0,0,0,0);
       let dateLabel = targetISO;
@@ -6033,7 +6186,7 @@ function renderDashboard(){
         ? `Logged "${instance.name || "Task"}" as completed on ${dateLabel}`
         : `Scheduled "${instance.name || "Task"}" for ${dateLabel}`;
     }else{
-      const instance = scheduleExistingAsReqTask(task, { dateISO: targetISO, note: occurrenceNote, refreshDashboard: true }) || task;
+      const instance = scheduleExistingAsReqTask(task, { dateISO: targetISO, note: occurrenceNote, recurrenceRule, refreshDashboard: true }) || task;
       message = "As-required task linked from Maintenance Settings";
     }
     setContextDate(targetISO);
@@ -7938,6 +8091,14 @@ function renderSettings(){
     const condition = escapeHtml(t.condition || "As required");
     const freq = t.interval ? `${t.interval} hrs` : "Set frequency";
     const baselineVal = baselineInputValue(t);
+    const recurrence = recurrenceRuleForTask(t);
+    const recurrenceTypeLabel = ({
+      none: "No repeat",
+      machine_hours: "By machine hours",
+      calendar_daily: "Daily",
+      calendar_weekly: "Weekly",
+      calendar_monthly: "Monthly"
+    })[recurrence.type] || "No repeat";
     const occurrenceNoteMap = (typeof normalizeOccurrenceNotes === "function") ? normalizeOccurrenceNotes(t) : (t.occurrenceNotes || {});
     const occurrenceHoursMap = (typeof normalizeOccurrenceHours === "function") ? normalizeOccurrenceHours(t) : (t.occurrenceHours || {});
     const occurrenceKeys = new Set([
@@ -7966,6 +8127,7 @@ function renderSettings(){
           <span class="task-name">${name}</span>
           <span class="chip">${type === "interval" ? "By Interval" : "As Required"}</span>
           ${type === "interval" ? `<span class=\"chip\" data-chip-frequency="${t.id}">${escapeHtml(freq)}</span>` : `<span class=\"chip\" data-chip-condition="${t.id}">${condition}</span>`}
+          <span class="chip" data-chip-repeat="${t.id}">${escapeHtml(recurrenceTypeLabel)}</span>
           ${notesChip}
           ${type === "interval" ? dueChip(t) : ""}
         </summary>
@@ -7981,6 +8143,25 @@ function renderSettings(){
               ? `<label data-field="interval">Frequency (hrs)<input type=\"number\" min=\"1\" step=\"1\" data-k=\"interval\" data-id=\"${t.id}\" data-list=\"interval\" value=\"${t.interval!=null?t.interval:""}\" placeholder=\"Hours between service\"></label>`
               : `<label data-field="condition">Condition / trigger<input data-k=\"condition\" data-id=\"${t.id}\" data-list=\"asreq\" value=\"${escapeHtml(t.condition||"")}\" placeholder=\"When to perform\"></label>`}
             ${type === "interval" ? `<label data-field="sinceBase">Hours since last service<input type=\"number\" min=\"0\" step=\"0.01\" data-k=\"sinceBase\" data-id=\"${t.id}\" data-list=\"interval\" value=\"${baselineVal!==""?baselineVal:""}\" placeholder=\"optional\"></label>` : ""}
+            <label data-field="recurrenceType">Repeat
+              <select data-k="recurrenceType" data-id="${t.id}" data-list="${type}">
+                <option value="none" ${recurrence.type === "none" ? "selected" : ""}>Does not repeat</option>
+                <option value="machine_hours" ${recurrence.type === "machine_hours" ? "selected" : ""}>By machine hours</option>
+                <option value="calendar_daily" ${recurrence.type === "calendar_daily" ? "selected" : ""}>Daily</option>
+                <option value="calendar_weekly" ${recurrence.type === "calendar_weekly" ? "selected" : ""}>Weekly</option>
+                <option value="calendar_monthly" ${recurrence.type === "calendar_monthly" ? "selected" : ""}>Monthly</option>
+              </select>
+            </label>
+            <label data-field="recurrenceEvery">Repeat every<input type="number" min="1" step="1" data-k="recurrenceEvery" data-id="${t.id}" data-list="${type}" value="${recurrence.every || 1}"></label>
+            <label data-field="recurrenceEndType">Repeat until
+              <select data-k="recurrenceEndType" data-id="${t.id}" data-list="${type}">
+                <option value="never" ${recurrence.endType === "never" ? "selected" : ""}>Never ends</option>
+                <option value="on_date" ${recurrence.endType === "on_date" ? "selected" : ""}>End on date</option>
+                <option value="after_count" ${recurrence.endType === "after_count" ? "selected" : ""}>End after count</option>
+              </select>
+            </label>
+            <label data-field="recurrenceEndDate">End date<input type="date" data-k="recurrenceEndDate" data-id="${t.id}" data-list="${type}" value="${recurrence.endDateISO || ""}"></label>
+            <label data-field="recurrenceCount">Occurrences<input type="number" min="1" step="1" data-k="recurrenceCount" data-id="${t.id}" data-list="${type}" value="${recurrence.count != null ? recurrence.count : ""}" placeholder="e.g. 20"></label>
             <label data-field="manualLink">Manual link<input type="url" data-k="manualLink" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.manualLink||"")}" placeholder="https://..."></label>
             <label data-field="storeLink">Store link<input type="url" data-k="storeLink" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.storeLink||"")}" placeholder="https://..."></label>
             <label data-field="pn">Part #<input data-k="pn" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.pn||"")}" placeholder="Part number"></label>
@@ -9156,7 +9337,7 @@ function renderSettings(){
     const key = target.getAttribute("data-k");
     if (!key || key === "mode") return;
     let value = target.value;
-    if (key === "price" || key === "interval" || key === "anchorTotal" || key === "sinceBase" || key === "downtimeHours"){
+    if (key === "price" || key === "interval" || key === "anchorTotal" || key === "sinceBase" || key === "downtimeHours" || key === "recurrenceEvery" || key === "recurrenceCount"){
       value = value === "" ? null : Number(value);
       if (value !== null && !isFinite(value)) return;
     }
@@ -9250,6 +9431,29 @@ function renderSettings(){
       if (key === "storeLink"){ syncLinkedInventoryFromTask(meta.task, { link: meta.task.storeLink || "" }); }
       if (key === "pn"){ syncLinkedInventoryFromTask(meta.task, { pn: meta.task.pn || "" }); }
       if (key === "name"){ syncLinkedInventoryFromTask(meta.task, { name: meta.task.name || "" }); }
+    }else if (key === "recurrenceEvery" || key === "recurrenceCount" || key === "recurrenceEndDate"){
+      const nextRule = { ...(meta.task.recurrenceRule || {}) };
+      if (key === "recurrenceEvery"){
+        nextRule.every = value == null ? 1 : Math.max(1, Math.round(Number(value)));
+        if (value != null) target.value = String(nextRule.every);
+      }else if (key === "recurrenceCount"){
+        nextRule.count = value == null ? null : Math.max(1, Math.round(Number(value)));
+        if (nextRule.count != null) target.value = String(nextRule.count);
+      }else{
+        nextRule.endDateISO = target.value || null;
+      }
+      const rule = setTaskRecurrenceRule(meta.task, nextRule);
+      const chip = holder.querySelector('[data-chip-repeat]');
+      if (chip){
+        const label = ({
+          none: "No repeat",
+          machine_hours: "By machine hours",
+          calendar_daily: "Daily",
+          calendar_weekly: "Weekly",
+          calendar_monthly: "Monthly"
+        })[rule?.type] || "No repeat";
+        chip.textContent = label;
+      }
     }
     persist();
   });
@@ -9268,7 +9472,30 @@ function renderSettings(){
       persist();
       return;
     }
-    if (target.getAttribute("data-k") === "mode"){
+    const selectKey = target.getAttribute("data-k");
+    if (selectKey === "recurrenceType" || selectKey === "recurrenceEndType"){
+      const nextRule = { ...(meta.task.recurrenceRule || {}) };
+      if (selectKey === "recurrenceType"){
+        nextRule.type = target.value;
+      }else{
+        nextRule.endType = target.value;
+      }
+      const rule = setTaskRecurrenceRule(meta.task, nextRule);
+      const chip = holder.querySelector('[data-chip-repeat]');
+      if (chip){
+        const label = ({
+          none: "No repeat",
+          machine_hours: "By machine hours",
+          calendar_daily: "Daily",
+          calendar_weekly: "Weekly",
+          calendar_monthly: "Monthly"
+        })[rule?.type] || "No repeat";
+        chip.textContent = label;
+      }
+      persist();
+      return;
+    }
+    if (selectKey === "mode"){
       const nextMode = target.value;
       if (nextMode === meta.mode) return;
       meta.list.splice(meta.index,1);
@@ -9280,6 +9507,7 @@ function renderSettings(){
         meta.task.sinceBase = baselineHours;
         applyIntervalBaseline(meta.task, { baselineHours });
         delete meta.task.condition;
+        meta.task.recurrenceRule = normalizeRecurrenceRule(meta.task.recurrenceRule, meta.task);
         window.tasksInterval.unshift(meta.task);
       }else{
         let removeOccurrences = false;
@@ -9300,6 +9528,7 @@ function renderSettings(){
         delete meta.task.interval;
         delete meta.task.sinceBase;
         delete meta.task.anchorTotal;
+        meta.task.recurrenceRule = normalizeRecurrenceRule({ type: "none", every: 1 }, meta.task);
         window.tasksAsReq.unshift(meta.task);
       }
       persist();

--- a/js/views.js
+++ b/js/views.js
@@ -334,6 +334,25 @@ function viewDashboard(){
           <p class="small muted">Pick a task saved in Maintenance Settings to schedule it on the calendar.</p>
           <p class="small muted" data-task-existing-empty hidden>No maintenance tasks yet. Create one below to get started.</p>
           <p class="small muted" data-task-existing-search-empty hidden>No tasks match your search. Try a different name.</p>
+          <label>Repeat
+            <select id="dashTaskExistingRepeatType">
+              <option value="none">Does not repeat</option>
+              <option value="machine_hours">Repeat by machine hours</option>
+              <option value="calendar_daily">Repeat daily</option>
+              <option value="calendar_weekly">Repeat weekly</option>
+              <option value="calendar_monthly">Repeat monthly</option>
+            </select>
+          </label>
+          <label>Repeat every<input type="number" min="1" step="1" id="dashTaskExistingRepeatEvery" value="1"></label>
+          <label>Repeat until
+            <select id="dashTaskExistingRepeatEndType">
+              <option value="never">Never ends</option>
+              <option value="on_date">End on date</option>
+              <option value="after_count">End after count</option>
+            </select>
+          </label>
+          <label data-existing-repeat-end-date hidden>End date<input type="date" id="dashTaskExistingRepeatEndDate"></label>
+          <label data-existing-repeat-end-count hidden>Occurrences<input type="number" min="1" step="1" id="dashTaskExistingRepeatCount" placeholder="e.g. 20"></label>
           <label>Occurrence note<textarea id="dashTaskExistingNote" rows="3" placeholder="Optional note for this calendar date"></textarea></label>
           <div class="modal-actions">
             <button type="button" class="secondary" data-task-card-back>Back</button>
@@ -371,6 +390,25 @@ function viewDashboard(){
             <label>Time to complete (hrs)<input type="number" min="0.25" step="0.25" id="dashTaskDowntime" placeholder="e.g. 1"></label>
             <label>Category<select id="dashTaskCategory"></select></label>
             <label>Calendar date<input type="date" id="dashTaskDate"></label>
+            <label>Repeat
+              <select id="dashTaskRepeatType">
+                <option value="machine_hours">Repeat by machine hours</option>
+                <option value="none">Does not repeat</option>
+                <option value="calendar_daily">Repeat daily</option>
+                <option value="calendar_weekly">Repeat weekly</option>
+                <option value="calendar_monthly">Repeat monthly</option>
+              </select>
+            </label>
+            <label>Repeat every<input type="number" min="1" step="1" id="dashTaskRepeatEvery" value="1"></label>
+            <label>Repeat until
+              <select id="dashTaskRepeatEndType">
+                <option value="never">Never ends</option>
+                <option value="on_date">End on date</option>
+                <option value="after_count">End after count</option>
+              </select>
+            </label>
+            <label data-repeat-end-date hidden>End date<input type="date" id="dashTaskRepeatEndDate"></label>
+            <label data-repeat-end-count hidden>Occurrences<input type="number" min="1" step="1" id="dashTaskRepeatCount" placeholder="e.g. 20"></label>
           </div>
 
           <div class="subtask-section">


### PR DESCRIPTION
### Motivation
- Fix a bug where marking an interval template complete from the dashboard could create an unintended instance that produced a duplicate next-day occurrence.
- Move calendar scheduling toward explicit recurrence metadata so users can choose no-repeat vs recurring (daily/weekly/monthly/by machine hours) when adding events.
- Preserve legacy interval/forecasting/cost behavior by keeping `completedDates`/`manualHistory` as the source of truth while adding additive recurrence metadata.

### Description
- Prevent accidental instance creation on completion by removing the instance-creation branch from `completeTask` so completing a calendar occurrence no longer constructs a new near-term instance.
- Introduce a normalized recurrence schema and helpers: `recurrenceRule` on tasks plus `normalizeRecurrenceRule`, `recurrenceRuleForTask`, and `setTaskRecurrenceRule` to validate and persist rules with types `none`, `machine_hours`, `calendar_daily`, `calendar_weekly`, and `calendar_monthly`.
- Wire recurrence into scheduling and rendering: `scheduleExistingIntervalTask` and `scheduleExistingAsReqTask` accept and persist recurrence rules, `renderCalendar` uses `recurrenceForTask` and a new `projectCalendarRecurringDates` projection for calendar-style rules while falling back to `projectIntervalDueDates`/`nextDue` for machine-hour intervals.
- Add dashboard and settings UI controls and plumbing: new inputs for repeat type/interval/end (IDs like `dashTaskRepeatType`, `dashTaskExistingRepeatType`, `dashTaskRepeatEvery`, `dashTaskRepeatEndType`, etc.), update modals and task settings rendering to display/update recurrence chips and fields, and hook input handlers to persist recurrence changes.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8f71f464832583795084cbdca77c)