### PR TITLE
Add recurrence metadata and calendar recurrence UI; fix interval completion duplication

### DIFF
--- a/docs/calendar-recurrence-google-style-plan.md
+++ b/docs/calendar-recurrence-google-style-plan.md
@@ -1,0 +1,142 @@
+# Dashboard Calendar Recurrence & Completion Behavior Plan (Google-Style)
+
+## Scope of request
+- Fix bug: marking an interval task complete on the dashboard calendar (e.g., **Mixing tube rotation**) is causing a new copy to appear on the next day.
+- Move calendar behavior toward a Google Calendar-like recurrence model:
+  - When adding/scheduling events/tasks, explicitly choose whether it repeats.
+  - If repeating, choose the recurrence frequency.
+- Update Maintenance Settings so recurrence controls are aligned with calendar behavior.
+- Preserve existing interval/per-hour maintenance logic and avoid breaking forecasting/cost logic.
+
+---
+
+## Code reading summary (pass 1)
+
+### 1) Where the duplicate-next-day behavior comes from
+The current completion path for interval template tasks creates a new **instance** and then completes it immediately:
+1. `completeTask(taskId)` in `js/calendar.js` checks if the selected item is an interval template.
+2. If it is, it calls `scheduleExistingIntervalTask(template, { dateISO: today })`, which can create a new instance and assign today as `calendarDateISO`.
+3. Then `markCalendarTaskComplete(...)` marks completion and records `completedDates`/`manualHistory`.
+
+This instance/template split, plus projection logic and manual-history merge logic, can produce “extra copy” behavior depending on what dates are already in manual/completed/projection sets. The symptom aligns with this flow.
+
+### 2) Recurrence/event scheduling touchpoints
+- Calendar rendering and event composition:
+  - `renderCalendar()`, `projectIntervalDueDates()`, `pushTaskEvent(...)` in `js/calendar.js`.
+- Completion/uncompletion/removal behavior:
+  - `markCalendarTaskComplete`, `unmarkCalendarTaskComplete`, `removeCalendarTaskOccurrences` in `js/calendar.js`.
+- Task scheduling/instancing:
+  - `scheduleExistingIntervalTask`, `scheduleExistingAsReqTask`, `createIntervalTaskInstance` in `js/renderers.js`.
+- Add-task modal UI and submit handlers:
+  - Dashboard picker/forms in `js/views.js` + handler wiring in `js/renderers.js`.
+- Baseline/per-interval math:
+  - `nextDue`, `liveSince` in `js/computations.js`.
+  - `applyIntervalBaseline`, `ensureTaskManualHistory` in `js/renderers.js`.
+
+### 3) Current model mismatch with requested UX
+Current model is maintenance-centric (interval + as-required + optional scheduling) and stores recurrence implicitly through interval math and projections. Requested behavior requires explicit scheduling recurrence settings per added calendar event (none/daily/weekly/monthly/custom) similar to Google Calendar.
+
+---
+
+## Initial implementation plan (draft)
+
+1. **Define recurrence schema (non-breaking).**
+   - Add optional recurrence fields to scheduled task instances (and one-time tasks where needed):
+     - `scheduleMode`: `"none" | "recurring"`
+     - `recurrenceType`: `"daily" | "weekly" | "monthly" | "hours_interval"`
+     - `recurrenceInterval`: number (e.g., every 2 days/weeks/months)
+     - `recurrenceDaysOfWeek`: optional array for weekly rules
+     - `recurrenceEnd`: `"never" | "on_date" | "after_count"`
+     - `recurrenceEndDate` / `recurrenceCount`
+   - Keep legacy fields (`interval`, `manualHistory`, `completedDates`, etc.) untouched for compatibility.
+
+2. **Add recurrence controls to Add Task flow (dashboard modal).**
+   - In “existing task” and “new task” forms, add UI:
+     - Repeat: No / Yes
+     - Frequency selector (daily/weekly/monthly/hour-interval)
+     - Frequency value input
+     - End condition (never/end date/after count)
+   - Ensure defaults preserve old behavior (for interval templates default to recurring by interval-hours when appropriate).
+
+3. **Add recurrence controls to Maintenance Settings cards.**
+   - Add editable recurrence fields alongside existing interval/condition fields.
+   - Hook into `data-k` input persistence path in `renderers.js` without breaking current edit-mode gating.
+
+4. **Introduce a unified occurrence generator layer.**
+   - New helper(s) that produce occurrences from either:
+     - explicit recurrence schema, or
+     - legacy interval projection fallback.
+   - Calendar renderer should consume this unified occurrence list so both old and new tasks behave consistently.
+
+5. **Fix completion behavior for interval templates.**
+   - Refactor `completeTask(...)` so “mark complete” updates the right task occurrence without creating an accidental additional near-term occurrence.
+   - Ensure the next due/recurrence computation excludes the completed occurrence in a deterministic way.
+
+6. **Preserve cost and analytics compatibility.**
+   - Ensure `computeCostModel()` and history extraction still rely on completed/manual history dates.
+   - If recurrence fields are added, they should be optional metadata and not replace existing completion records used by cost calculations.
+
+7. **Migration + normalization.**
+   - Add normalization so older saved tasks without recurrence fields behave exactly as before.
+   - Add guardrails for invalid recurrence values.
+
+8. **Validation matrix.**
+   - Interval template completion (today/past/future).
+   - As-required scheduled once vs repeated.
+   - One-time tasks remain one-time by default.
+   - Remove single/future/all occurrence behavior still works.
+   - Forecast/cost widgets still render and derive values correctly.
+
+---
+
+## Code reading summary (pass 2 review + adjustments)
+
+After re-reading the scheduling/completion/render paths, I am adjusting the plan to reduce risk in this complex codebase:
+
+### Key findings from second pass
+1. **Instances are heavily integrated** in settings organization, cost history, and calendar rendering. Fully replacing instance behavior now is risky.
+2. `renderCalendar()` currently expects interval *instances* for projected/due rendering (`isInstanceTask` filters). Any immediate model replacement could break visibility.
+3. Cost model and history logic pull from `manualHistory`, `completedDates`, and task activity checks; these must remain the source of truth.
+4. The bug is likely solvable quickly by tightening completion flow and projection exclusion, independent of full recurrence redesign.
+
+### Revised plan (safer phased rollout)
+
+#### Phase 1 — Stabilization + bug fix
+1. **Patch completion logic first** (minimal invasive):
+   - Update `completeTask(...)` path so marking an interval task complete does not create an unintended extra calendar occurrence.
+   - Add explicit de-duplication guard around “today + next projected date” collision.
+2. **Add deterministic event dedupe in calendar assembly**:
+   - Normalize composite keys (`templateId/taskId + date + status precedence`) before pushing chips.
+   - Keep completed > manual > due priority, but prevent duplicate semantic occurrences.
+3. **Regression pass for removal/uncomplete operations** using existing scope logic (`single/future/all`).
+
+#### Phase 2 — Google-style recurrence controls (additive)
+4. **Add recurrence metadata fields** (optional, backward-compatible) for newly scheduled tasks/events.
+5. **Extend Add Task / Existing Task scheduling UI** with repeat controls.
+6. **Extend Maintenance Settings UI** with same repeat controls so users can edit recurrence after creation.
+
+#### Phase 3 — Unified recurrence engine behind feature-compat facade
+7. Build a unified occurrence generator that first checks explicit recurrence metadata; if absent, falls back to current interval projection logic.
+8. Keep existing `manualHistory` + `completedDates` writes intact so cost/forecast code stays stable.
+
+#### Phase 4 — Hardening + migration
+9. Add normalization migration for recurrence defaults on load.
+10. Add test checklist + manual validation scripts for all recurrence/completion modes and cost widgets.
+
+---
+
+## Implementation notes / guardrails
+- **Do not break existing task schema consumers** (`computeCostModel`, history cards, next-due widget).
+- **Completion semantics remain event-based**: completing an occurrence writes completion history for that date.
+- **Recurrence semantics are generation-only**: they generate candidate dates but do not auto-mark completion.
+- **As-required defaults to non-repeating** unless user enables recurrence explicitly.
+- **Interval maintenance can default to repeating** but user must be able to set “does not repeat” when adding from calendar.
+
+---
+
+## Deliverables for implementation phase
+1. Completion bug fix in calendar logic.
+2. New recurrence UI controls in dashboard add modal and maintenance settings cards.
+3. Recurrence metadata persistence + normalization.
+4. Unified occurrence generation with legacy fallback.
+5. Validation checklist run and documented.

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -617,6 +617,7 @@ function markCalendarTaskComplete(meta, dateISO){
     if (!task.calendarDateISO || normalizeDateKey(task.calendarDateISO) === key){
       task.calendarDateISO = key;
     }
+    task.recurrenceStartDate = key;
     changed = true;
   }else{
     if (!Array.isArray(task.completedDates)) task.completedDates = [];
@@ -629,6 +630,7 @@ function markCalendarTaskComplete(meta, dateISO){
       task.calendarDateISO = key;
       changed = true;
     }
+    task.recurrenceStartDate = key;
   }
 
   return changed;
@@ -1029,7 +1031,12 @@ function completeTask(taskId){
   let meta = findCalendarTaskMeta(taskId);
   if (!meta) return;
   if (isTemplateTask(meta.task) && meta.task.mode === "interval"){
-    const instance = scheduleExistingIntervalTask(meta.task, { dateISO: ymd(new Date()) });
+    const templateId = String(meta.task.id);
+    const intervalList = Array.isArray(window.tasksInterval) ? window.tasksInterval : [];
+    let instance = intervalList.find(item => item && isInstanceTask(item) && String(item.templateId) === templateId) || null;
+    if (!instance){
+      instance = scheduleExistingIntervalTask(meta.task, { dateISO: ymd(new Date()), refreshDashboard: false });
+    }
     if (instance){
       const nextMeta = findCalendarTaskMeta(instance.id);
       if (nextMeta) meta = nextMeta;
@@ -1135,6 +1142,7 @@ function showTaskBubble(taskId, anchor, options = {}){
   }
   if (canMarkComplete){
     actions.push(`<button data-bbl-complete>Mark complete</button>`);
+    actions.push(`<button data-bbl-complete-custom class="secondary">Mark complete on…</button>`);
   }
   if (canUnmarkComplete){
     actions.push(`<button data-bbl-uncomplete>Unmark complete</button>`);
@@ -1194,6 +1202,25 @@ function showTaskBubble(taskId, anchor, options = {}){
 
   b.querySelector("[data-bbl-complete]")?.addEventListener("click", ()=>{
     const changed = markCalendarTaskComplete(meta, targetKey);
+    if (changed){
+      if (typeof saveCloudNow === "function") saveCloudNow();
+      else saveCloudDebounced();
+      toast("Task marked complete");
+      hideBubble();
+      route();
+    }
+  });
+
+  b.querySelector("[data-bbl-complete-custom]")?.addEventListener("click", ()=>{
+    const defaultDate = targetKey || normalizeDateKey(new Date());
+    const raw = window.prompt ? window.prompt("Complete on date (YYYY-MM-DD):", defaultDate || "") : defaultDate;
+    if (raw == null) return;
+    const selected = normalizeDateKey(raw);
+    if (!selected){
+      toast("Enter a valid completion date (YYYY-MM-DD)");
+      return;
+    }
+    const changed = markCalendarTaskComplete(meta, selected);
     if (changed){
       if (typeof saveCloudNow === "function") saveCloudNow();
       else saveCloudDebounced();
@@ -1853,6 +1880,123 @@ function projectIntervalDueDates(task, options = {}){
   return events;
 }
 
+function normalizeTaskRecurrenceLocal(task, fallbackType = "none"){
+  if (!task || typeof task !== "object"){
+    return { enabled: false, type: "none", every: 1, endType: "never", endDate: null, count: null, startDate: null };
+  }
+  if (typeof normalizeTaskRecurrence === "function"){
+    try {
+      return normalizeTaskRecurrence(task, { fallbackHoursMode: fallbackType });
+    } catch (_err){}
+  }
+  const typeRaw = String(task.recurrenceType || fallbackType || "none").toLowerCase();
+  const type = ["none", "hours", "daily", "weekly", "monthly"].includes(typeRaw) ? typeRaw : "none";
+  const enabled = task.recurrenceEnabled == null ? type !== "none" : Boolean(task.recurrenceEnabled);
+  const everyRaw = Number(task.recurrenceInterval ?? 1);
+  const every = Number.isFinite(everyRaw) && everyRaw > 0 ? Math.max(1, Math.round(everyRaw)) : 1;
+  const endRaw = String(task.recurrenceEndType || "never").toLowerCase();
+  const endType = (endRaw === "on_date" || endRaw === "after_count") ? endRaw : "never";
+  const endDate = normalizeDateKey(task.recurrenceEndDate) || null;
+  const countRaw = Number(task.recurrenceCount);
+  const count = Number.isFinite(countRaw) && countRaw > 0 ? Math.max(1, Math.round(countRaw)) : null;
+  const startDate = normalizeDateKey(task.recurrenceStartDate || task.calendarDateISO) || null;
+  return { enabled, type: enabled ? type : "none", every, endType, endDate, count, startDate };
+}
+
+function projectCalendarRecurrenceDates(task, recurrence, options = {}){
+  const rec = recurrence || normalizeTaskRecurrenceLocal(task, "none");
+  if (!rec.enabled || !["daily", "weekly", "monthly"].includes(rec.type)) return [];
+  const excludeSet = new Set();
+  const excludeRaw = options.excludeDates;
+  if (excludeRaw && typeof excludeRaw.forEach === "function"){
+    excludeRaw.forEach(value => {
+      const key = normalizeDateKey(value);
+      if (key) excludeSet.add(key);
+    });
+  }
+  const startISO = normalizeDateKey(options.startDate || rec.startDate || task?.calendarDateISO || new Date());
+  const start = toDayStart(startISO);
+  if (!(start instanceof Date) || Number.isNaN(start.getTime())) return [];
+  const monthsAheadRaw = Number(options.monthsAhead);
+  const monthsAhead = Number.isFinite(monthsAheadRaw) && monthsAheadRaw > 0 ? monthsAheadRaw : 3;
+  const horizon = new Date(start.getTime());
+  horizon.setMonth(horizon.getMonth() + monthsAhead);
+  const maxOccurrencesRaw = Number(options.maxOccurrences);
+  const maxOccurrences = Number.isFinite(maxOccurrencesRaw) && maxOccurrencesRaw > 0 ? Math.round(maxOccurrencesRaw) : 40;
+  const out = [];
+  const cursor = new Date(start.getTime());
+  let produced = 0;
+  while (produced < maxOccurrences){
+    const key = ymd(cursor);
+    if (!key) break;
+    if (!excludeSet.has(key)){
+      if (rec.endType === "on_date" && rec.endDate && key > rec.endDate) break;
+      if (rec.endType === "after_count" && rec.count != null && out.length >= rec.count) break;
+      out.push({ dateISO: key, dueDate: new Date(cursor.getTime()) });
+    }
+    produced += 1;
+    if (cursor > horizon && out.length > 0) break;
+    if (rec.type === "daily"){
+      cursor.setDate(cursor.getDate() + rec.every);
+    }else if (rec.type === "weekly"){
+      cursor.setDate(cursor.getDate() + (7 * rec.every));
+    }else{
+      cursor.setMonth(cursor.getMonth() + rec.every);
+    }
+  }
+  return out;
+}
+
+function projectHoursRecurrenceDates(task, recurrence, options = {}){
+  const rec = recurrence || normalizeTaskRecurrenceLocal(task, "hours");
+  if (!rec.enabled || rec.type !== "hours") return [];
+  const excludeSet = new Set();
+  const excludeRaw = options.excludeDates;
+  if (excludeRaw && typeof excludeRaw.forEach === "function"){
+    excludeRaw.forEach(value => {
+      const key = normalizeDateKey(value);
+      if (key) excludeSet.add(key);
+    });
+  }
+  const nd = typeof nextDue === "function" ? nextDue(task) : null;
+  const firstDue = nd && nd.due instanceof Date ? new Date(nd.due.getTime()) : null;
+  if (!(firstDue instanceof Date) || Number.isNaN(firstDue.getTime())) return [];
+  firstDue.setHours(0,0,0,0);
+  const effDaily = (()=>{
+    if (typeof getPredictionHoursSummary === "function"){
+      const summary = getPredictionHoursSummary();
+      const hrs = Number(summary?.effectiveHours);
+      if (Number.isFinite(hrs) && hrs > 0) return hrs;
+    }
+    const configured = Number(configuredDailyHours());
+    return Number.isFinite(configured) && configured > 0 ? configured : 8;
+  })();
+  const intervalHours = Number(task?.interval) || 0;
+  const everyMultiplier = Number(rec.every) || 1;
+  const hoursForCycle = intervalHours * Math.max(1, everyMultiplier);
+  const daysStep = Math.max(1, Math.ceil(hoursForCycle / effDaily));
+  const monthsAheadRaw = Number(options.monthsAhead);
+  const monthsAhead = Number.isFinite(monthsAheadRaw) && monthsAheadRaw > 0 ? monthsAheadRaw : 3;
+  const horizon = new Date(firstDue.getTime());
+  horizon.setMonth(horizon.getMonth() + monthsAhead);
+  const maxOccurrencesRaw = Number(options.maxOccurrences);
+  const maxOccurrences = Number.isFinite(maxOccurrencesRaw) && maxOccurrencesRaw > 0 ? Math.round(maxOccurrencesRaw) : 40;
+  const events = [];
+  const cursor = new Date(firstDue.getTime());
+  for (let i = 0; i < maxOccurrences; i++){
+    const key = ymd(cursor);
+    if (!key) break;
+    if (!(rec.endType === "on_date" && rec.endDate && key > rec.endDate)
+      && !(rec.endType === "after_count" && rec.count != null && events.length >= rec.count)
+      && !excludeSet.has(key)){
+      events.push({ dateISO: key, dueDate: new Date(cursor.getTime()) });
+    }
+    if (cursor > horizon && events.length > 0) break;
+    cursor.setDate(cursor.getDate() + daysStep);
+  }
+  return events;
+}
+
 function renderCalendar(){
   const container = $("#months");
   if (!container) return;
@@ -2048,29 +2192,36 @@ function renderCalendar(){
     const skipDates = new Set(completedKeys);
     manualDates.forEach(dateKey => skipDates.add(dateKey));
     removedSet.forEach(dateKey => skipDates.add(dateKey));
-    const projections = projectIntervalDueDates(t, {
-      monthsAhead: 3,
-      excludeDates: skipDates,
-      minOccurrences: 1,
-      maxOccurrences: 1
-    });
-    if (projections.length){
-      const pred = projections[0];
+    const recurrence = normalizeTaskRecurrenceLocal(t, "hours");
+    let projections = [];
+    if (recurrence.enabled && recurrence.type === "hours"){
+      projections = projectHoursRecurrenceDates(t, recurrence, {
+        monthsAhead: 3,
+        excludeDates: skipDates,
+        maxOccurrences: 24
+      });
+    }else if (recurrence.enabled && ["daily", "weekly", "monthly"].includes(recurrence.type)){
+      projections = projectCalendarRecurrenceDates(t, recurrence, {
+        monthsAhead: 3,
+        excludeDates: skipDates,
+        startDate: t.calendarDateISO || recurrence.startDate || ymd(new Date()),
+        maxOccurrences: 24
+      });
+    }else{
+      projections = projectIntervalDueDates(t, {
+        monthsAhead: 3,
+        excludeDates: skipDates,
+        minOccurrences: 1,
+        maxOccurrences: 1
+      });
+    }
+    projections.forEach(pred => {
       const dueKey = normalizeDateKey(pred?.dateISO);
-      if (dueKey && !completedKeys.has(dueKey) && (!manualKey || manualKey !== dueKey || completedKeys.has(dueKey))){
-        pushTaskEvent(t, dueKey, "due");
-      }
-      return;
-    }
-
-    const nd = nextDue(t);
-    if (!nd) return;
-    const dueKey = normalizeDateKey(nd.due);
-    if (!dueKey) return;
-    if (completedKeys.has(dueKey)) return;
-    if (!manualKey || manualKey !== dueKey){
+      if (!dueKey) return;
+      if (completedKeys.has(dueKey)) return;
+      if (manualKey && manualKey === dueKey && !completedKeys.has(dueKey)) return;
       pushTaskEvent(t, dueKey, "due");
-    }
+    });
   });
 
   const asReqTasks = Array.isArray(window.tasksAsReq) ? window.tasksAsReq : [];
@@ -2083,6 +2234,24 @@ function renderCalendar(){
     const manualKey = normalizeDateKey(t.calendarDateISO);
     if (manualKey){
       pushTaskEvent(t, manualKey, completedDates.has(manualKey) ? "completed" : "manual");
+    }
+    const recurrence = normalizeTaskRecurrenceLocal(t, "none");
+    if (recurrence.enabled && recurrence.type !== "none"){
+      const skipDates = new Set(completedDates);
+      if (manualKey) skipDates.add(manualKey);
+      const projections = recurrence.type === "hours"
+        ? projectHoursRecurrenceDates(t, recurrence, { monthsAhead: 3, excludeDates: skipDates, maxOccurrences: 24 })
+        : projectCalendarRecurrenceDates(t, recurrence, {
+          monthsAhead: 3,
+          excludeDates: skipDates,
+          startDate: manualKey || recurrence.startDate || ymd(new Date()),
+          maxOccurrences: 24
+        });
+      projections.forEach(pred => {
+        const dueKey = normalizeDateKey(pred?.dateISO);
+        if (!dueKey || skipDates.has(dueKey)) return;
+        pushTaskEvent(t, dueKey, "due");
+      });
     }
   });
 

--- a/js/core.js
+++ b/js/core.js
@@ -2254,8 +2254,17 @@ function ensureTaskCategories(){
     if (!t) return;
     if (!t.cat) t.cat = "interval";
     if (!Array.isArray(t.completedDates)) t.completedDates = [];
+    if (typeof normalizeTaskRecurrence === "function"){
+      try { normalizeTaskRecurrence(t, { fallbackHoursMode: "hours" }); } catch (_err){}
+    }
   });
-  tasksAsReq.forEach(t =>    { if (t && !t.cat) t.cat = "asreq"; });
+  tasksAsReq.forEach(t =>    {
+    if (!t) return;
+    if (!t.cat) t.cat = "asreq";
+    if (typeof normalizeTaskRecurrence === "function"){
+      try { normalizeTaskRecurrence(t, { fallbackHoursMode: "none" }); } catch (_err){}
+    }
+  });
 }
 
 function ensureJobCategories(){

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -382,6 +382,64 @@ function baselineInputValue(task){
   return "";
 }
 
+function normalizeTaskRecurrence(task, options = {}){
+  if (!task || typeof task !== "object") return null;
+  const fallbackHours = options.fallbackHoursMode || (task.mode === "interval" ? "hours" : "none");
+  const typeRaw = String(task.recurrenceType || task.repeatType || fallbackHours || "none").toLowerCase();
+  const allowedType = new Set(["none", "hours", "daily", "weekly", "monthly"]);
+  const type = allowedType.has(typeRaw) ? typeRaw : "none";
+  const enabledExplicit = task.recurrenceEnabled;
+  const enabled = (enabledExplicit == null)
+    ? type !== "none"
+    : Boolean(enabledExplicit);
+  const everyRaw = Number(task.recurrenceInterval ?? task.repeatEvery ?? 1);
+  const every = Number.isFinite(everyRaw) && everyRaw > 0 ? Math.max(1, Math.round(everyRaw)) : 1;
+  const endRaw = String(task.recurrenceEndType || task.repeatEndType || "never").toLowerCase();
+  const endType = (endRaw === "on_date" || endRaw === "after_count") ? endRaw : "never";
+  const endDate = normalizeDateISO(task.recurrenceEndDate || task.repeatEndDate || "") || null;
+  const countRaw = Number(task.recurrenceCount ?? task.repeatCount ?? 0);
+  const count = Number.isFinite(countRaw) && countRaw > 0 ? Math.max(1, Math.round(countRaw)) : null;
+  const startDate = normalizeDateISO(task.recurrenceStartDate || task.calendarDateISO || "") || null;
+  const normalized = {
+    enabled,
+    type: enabled ? type : "none",
+    every,
+    endType,
+    endDate,
+    count,
+    startDate
+  };
+  task.recurrenceEnabled = normalized.enabled;
+  task.recurrenceType = normalized.type;
+  task.recurrenceInterval = normalized.every;
+  task.recurrenceEndType = normalized.endType;
+  task.recurrenceEndDate = normalized.endDate;
+  task.recurrenceCount = normalized.count;
+  task.recurrenceStartDate = normalized.startDate;
+  return normalized;
+}
+
+function applyTaskRecurrence(task, recurrence){
+  if (!task || !recurrence || typeof recurrence !== "object") return;
+  const normalized = normalizeTaskRecurrence({
+    ...task,
+    recurrenceEnabled: recurrence.enabled,
+    recurrenceType: recurrence.type,
+    recurrenceInterval: recurrence.every,
+    recurrenceEndType: recurrence.endType,
+    recurrenceEndDate: recurrence.endDate,
+    recurrenceCount: recurrence.count,
+    recurrenceStartDate: recurrence.startDate || task.calendarDateISO || null
+  }, { fallbackHoursMode: task.mode === "interval" ? "hours" : "none" });
+  task.recurrenceEnabled = normalized.enabled;
+  task.recurrenceType = normalized.type;
+  task.recurrenceInterval = normalized.every;
+  task.recurrenceEndType = normalized.endType;
+  task.recurrenceEndDate = normalized.endDate;
+  task.recurrenceCount = normalized.count;
+  task.recurrenceStartDate = normalized.startDate;
+}
+
 const DASHBOARD_DAY_MS = 24 * 60 * 60 * 1000;
 
 function hoursSnapshotOnOrBefore(dateISO){
@@ -589,13 +647,14 @@ function createIntervalTaskInstance(template){
       return 1;
     })()
   };
+  applyTaskRecurrence(copy, normalizeTaskRecurrence(template, { fallbackHoursMode: "hours" }));
   if (Array.isArray(template.parts)){
     copy.parts = template.parts.map(part => part ? { ...part } : part).filter(Boolean);
   }
   return copy;
 }
 
-function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refreshDashboard = true } = {}){
+function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refreshDashboard = true, recurrence = null } = {}){
   if (!task || task.mode !== "interval") return null;
   if (!Array.isArray(tasksInterval)){
     if (Array.isArray(window.tasksInterval)){
@@ -747,13 +806,18 @@ function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refresh
     ensureTaskVariant(template, "interval");
     if (template.templateId == null) template.templateId = template.id;
   }
+  const recurrenceConfig = recurrence && typeof recurrence === "object"
+    ? recurrence
+    : normalizeTaskRecurrence(template || instance, { fallbackHoursMode: "hours" });
+  applyTaskRecurrence(instance, recurrenceConfig);
+  if (template) applyTaskRecurrence(template, recurrenceConfig);
   if (refreshDashboard && typeof refreshDashboardWidgets === "function"){
     refreshDashboardWidgets({ full: true });
   }
   return instance;
 }
 
-function scheduleExistingAsReqTask(task, { dateISO = null, note = "", refreshDashboard = true } = {}){
+function scheduleExistingAsReqTask(task, { dateISO = null, note = "", refreshDashboard = true, recurrence = null } = {}){
   if (!task || task.mode !== "asreq") return null;
   if (!Array.isArray(window.tasksAsReq)) window.tasksAsReq = [];
 
@@ -786,6 +850,11 @@ function scheduleExistingAsReqTask(task, { dateISO = null, note = "", refreshDas
   if (note){
     try { setFamilyOccurrenceNote(instance, instance.calendarDateISO, note); } catch (err) { /* noop */ }
   }
+  const recurrenceConfig = recurrence && typeof recurrence === "object"
+    ? recurrence
+    : normalizeTaskRecurrence(template, { fallbackHoursMode: "none" });
+  applyTaskRecurrence(instance, recurrenceConfig);
+  applyTaskRecurrence(template, recurrenceConfig);
 
   window.tasksAsReq.unshift(instance);
   if (refreshDashboard && typeof refreshDashboardWidgets === "function"){
@@ -798,6 +867,8 @@ if (typeof window !== "undefined"){
   window.scheduleExistingIntervalTask = scheduleExistingIntervalTask;
   window.scheduleExistingAsReqTask = scheduleExistingAsReqTask;
   window.createIntervalTaskInstance = createIntervalTaskInstance;
+  window.normalizeTaskRecurrence = normalizeTaskRecurrence;
+  window.applyTaskRecurrence = applyTaskRecurrence;
 }
 
 function editingCompletedJobsSet(){
@@ -4916,6 +4987,15 @@ function renderDashboard(){
   const taskDowntimeInput= document.getElementById("dashTaskDowntime");
   const categorySelect   = document.getElementById("dashTaskCategory");
   const taskDateInput    = document.getElementById("dashTaskDate");
+  const taskRepeatSelect = document.getElementById("dashTaskRepeat");
+  const taskRepeatEveryInput = document.getElementById("dashTaskRepeatEvery");
+  const taskRepeatEndSelect = document.getElementById("dashTaskRepeatEnd");
+  const taskRepeatEndDateInput = document.getElementById("dashTaskRepeatEndDate");
+  const taskRepeatCountInput = document.getElementById("dashTaskRepeatCount");
+  const taskRepeatEveryRow = taskForm?.querySelector("[data-task-repeat-every]");
+  const taskRepeatEndRow = taskForm?.querySelector("[data-task-repeat-end]");
+  const taskRepeatEndDateRow = taskForm?.querySelector("[data-task-repeat-end-date]");
+  const taskRepeatEndCountRow = taskForm?.querySelector("[data-task-repeat-end-count]");
   const subtaskList      = document.getElementById("dashSubtaskList");
   const addSubtaskBtn    = document.getElementById("dashAddSubtask");
   const taskOptionStage  = modal?.querySelector('[data-task-option-stage]');
@@ -4927,6 +5007,15 @@ function renderDashboard(){
   const existingTaskEmpty  = taskExistingForm?.querySelector('[data-task-existing-empty]');
   const existingTaskSearchEmpty = taskExistingForm?.querySelector('[data-task-existing-search-empty]');
   const taskExistingNoteInput = document.getElementById("dashTaskExistingNote");
+  const taskExistingRepeatSelect = document.getElementById("dashTaskExistingRepeat");
+  const taskExistingRepeatEveryInput = document.getElementById("dashTaskExistingRepeatEvery");
+  const taskExistingRepeatEndSelect = document.getElementById("dashTaskExistingRepeatEnd");
+  const taskExistingRepeatEndDateInput = document.getElementById("dashTaskExistingRepeatEndDate");
+  const taskExistingRepeatCountInput = document.getElementById("dashTaskExistingRepeatCount");
+  const taskExistingRepeatEveryRow = taskExistingForm?.querySelector("[data-task-existing-repeat-every]");
+  const taskExistingRepeatEndRow = taskExistingForm?.querySelector("[data-task-existing-repeat-end]");
+  const taskExistingRepeatEndDateRow = taskExistingForm?.querySelector("[data-task-existing-repeat-end-date]");
+  const taskExistingRepeatEndCountRow = taskExistingForm?.querySelector("[data-task-existing-repeat-end-count]");
   const taskCardBackButtons = Array.from(modal?.querySelectorAll('[data-task-card-back]') || []);
   const oneTimeForm      = document.getElementById("dashOneTimeForm");
   const oneTimeNameInput = document.getElementById("dashOneTimeName");
@@ -5059,6 +5148,18 @@ function renderDashboard(){
       const isMatch = btn.getAttribute("data-task-id") === String(selectedExistingTaskId);
       btn.classList.toggle("is-active", isMatch);
       btn.setAttribute("aria-pressed", isMatch ? "true" : "false");
+      if (isMatch && taskExistingRepeatSelect){
+        const mode = btn.dataset.mode === "interval" ? "interval" : "asreq";
+        if (!taskExistingRepeatSelect.value || taskExistingRepeatSelect.value === "none"){
+          taskExistingRepeatSelect.value = mode === "interval" ? "hours" : "none";
+        }
+        syncRepeatRows(taskExistingRepeatSelect, taskExistingRepeatEndSelect, {
+          every: taskExistingRepeatEveryRow,
+          end: taskExistingRepeatEndRow,
+          endDate: taskExistingRepeatEndDateRow,
+          endCount: taskExistingRepeatEndCountRow
+        });
+      }
     });
   }
 
@@ -5147,6 +5248,17 @@ function renderDashboard(){
   function resetExistingTaskForm(){
     if (taskExistingSearchInput) taskExistingSearchInput.value = "";
     if (taskExistingNoteInput) taskExistingNoteInput.value = "";
+    if (taskExistingRepeatSelect) taskExistingRepeatSelect.value = "none";
+    if (taskExistingRepeatEveryInput) taskExistingRepeatEveryInput.value = "1";
+    if (taskExistingRepeatEndSelect) taskExistingRepeatEndSelect.value = "never";
+    if (taskExistingRepeatEndDateInput) taskExistingRepeatEndDateInput.value = "";
+    if (taskExistingRepeatCountInput) taskExistingRepeatCountInput.value = "10";
+    syncRepeatRows(taskExistingRepeatSelect, taskExistingRepeatEndSelect, {
+      every: taskExistingRepeatEveryRow,
+      end: taskExistingRepeatEndRow,
+      endDate: taskExistingRepeatEndDateRow,
+      endCount: taskExistingRepeatEndCountRow
+    });
     setSelectedExistingTask(null);
     refreshExistingTaskOptions("");
   }
@@ -5196,6 +5308,47 @@ function renderDashboard(){
     if (!modalVisible || !taskDateInput.value){
       taskDateInput.value = ymd(new Date());
     }
+  }
+
+  function syncRepeatRows(selectEl, endEl, rows){
+    const repeatType = String(selectEl?.value || "none").toLowerCase();
+    const showRepeat = repeatType !== "none";
+    if (rows.every) rows.every.hidden = !showRepeat;
+    if (rows.end) rows.end.hidden = !showRepeat;
+    const endType = String(endEl?.value || "never").toLowerCase();
+    const showEndDate = showRepeat && endType === "on_date";
+    const showCount = showRepeat && endType === "after_count";
+    if (rows.endDate) rows.endDate.hidden = !showEndDate;
+    if (rows.endCount) rows.endCount.hidden = !showCount;
+  }
+
+  function readRecurrenceFromInputs({
+    typeSelect,
+    everyInput,
+    endSelect,
+    endDateInput,
+    countInput,
+    defaultStartDate = null,
+    fallbackHoursMode = "none"
+  }){
+    const type = String(typeSelect?.value || "none").toLowerCase();
+    const enabled = type !== "none";
+    const everyVal = Number(everyInput?.value);
+    const every = Number.isFinite(everyVal) && everyVal > 0 ? Math.round(everyVal) : 1;
+    const endTypeRaw = String(endSelect?.value || "never").toLowerCase();
+    const endType = (endTypeRaw === "on_date" || endTypeRaw === "after_count") ? endTypeRaw : "never";
+    const endDate = endType === "on_date" ? normalizeDateISO(endDateInput?.value || "") : null;
+    const countRaw = Number(countInput?.value);
+    const count = endType === "after_count" && Number.isFinite(countRaw) && countRaw > 0 ? Math.round(countRaw) : null;
+    return normalizeTaskRecurrence({
+      recurrenceEnabled: enabled,
+      recurrenceType: enabled ? type : "none",
+      recurrenceInterval: every,
+      recurrenceEndType: endType,
+      recurrenceEndDate: endDate,
+      recurrenceCount: count,
+      recurrenceStartDate: defaultStartDate
+    }, { fallbackHoursMode });
   }
 
   function syncOneTimeDateInput(){
@@ -5510,6 +5663,17 @@ function renderDashboard(){
     showTaskOptionStage();
     syncTaskMode(taskTypeSelect?.value || "interval");
     syncTaskDateInput();
+    if (taskRepeatSelect) taskRepeatSelect.value = taskTypeSelect?.value === "interval" ? "hours" : "none";
+    if (taskRepeatEveryInput) taskRepeatEveryInput.value = "1";
+    if (taskRepeatEndSelect) taskRepeatEndSelect.value = "never";
+    if (taskRepeatEndDateInput) taskRepeatEndDateInput.value = "";
+    if (taskRepeatCountInput) taskRepeatCountInput.value = "10";
+    syncRepeatRows(taskRepeatSelect, taskRepeatEndSelect, {
+      every: taskRepeatEveryRow,
+      end: taskRepeatEndRow,
+      endDate: taskRepeatEndDateRow,
+      endCount: taskRepeatEndCountRow
+    });
   }
 
   function showStep(step){
@@ -5801,7 +5965,62 @@ function renderDashboard(){
   });
 
   taskTypeSelect?.addEventListener("change", ()=> syncTaskMode(taskTypeSelect.value));
+  taskTypeSelect?.addEventListener("change", ()=>{
+    if (taskRepeatSelect && taskTypeSelect.value === "interval" && taskRepeatSelect.value === "none"){
+      taskRepeatSelect.value = "hours";
+    }
+    syncRepeatRows(taskRepeatSelect, taskRepeatEndSelect, {
+      every: taskRepeatEveryRow,
+      end: taskRepeatEndRow,
+      endDate: taskRepeatEndDateRow,
+      endCount: taskRepeatEndCountRow
+    });
+  });
+  taskRepeatSelect?.addEventListener("change", ()=>{
+    syncRepeatRows(taskRepeatSelect, taskRepeatEndSelect, {
+      every: taskRepeatEveryRow,
+      end: taskRepeatEndRow,
+      endDate: taskRepeatEndDateRow,
+      endCount: taskRepeatEndCountRow
+    });
+  });
+  taskRepeatEndSelect?.addEventListener("change", ()=>{
+    syncRepeatRows(taskRepeatSelect, taskRepeatEndSelect, {
+      every: taskRepeatEveryRow,
+      end: taskRepeatEndRow,
+      endDate: taskRepeatEndDateRow,
+      endCount: taskRepeatEndCountRow
+    });
+  });
+  taskExistingRepeatSelect?.addEventListener("change", ()=>{
+    syncRepeatRows(taskExistingRepeatSelect, taskExistingRepeatEndSelect, {
+      every: taskExistingRepeatEveryRow,
+      end: taskExistingRepeatEndRow,
+      endDate: taskExistingRepeatEndDateRow,
+      endCount: taskExistingRepeatEndCountRow
+    });
+  });
+  taskExistingRepeatEndSelect?.addEventListener("change", ()=>{
+    syncRepeatRows(taskExistingRepeatSelect, taskExistingRepeatEndSelect, {
+      every: taskExistingRepeatEveryRow,
+      end: taskExistingRepeatEndRow,
+      endDate: taskExistingRepeatEndDateRow,
+      endCount: taskExistingRepeatEndCountRow
+    });
+  });
   syncTaskMode(taskTypeSelect?.value || "interval");
+  syncRepeatRows(taskRepeatSelect, taskRepeatEndSelect, {
+    every: taskRepeatEveryRow,
+    end: taskRepeatEndRow,
+    endDate: taskRepeatEndDateRow,
+    endCount: taskRepeatEndCountRow
+  });
+  syncRepeatRows(taskExistingRepeatSelect, taskExistingRepeatEndSelect, {
+    every: taskExistingRepeatEveryRow,
+    end: taskExistingRepeatEndRow,
+    endDate: taskExistingRepeatEndDateRow,
+    endCount: taskExistingRepeatEndCountRow
+  });
   syncTaskDateInput();
   syncOneTimeDateInput();
   populateCategoryOptions();
@@ -5839,6 +6058,15 @@ function renderDashboard(){
     const dateISO = rawDate ? ymd(rawDate) : "";
     const targetISO = dateISO || addContextDateISO || ymd(new Date());
     const calendarDateISO = targetISO || null;
+    const recurrenceConfig = readRecurrenceFromInputs({
+      typeSelect: taskRepeatSelect,
+      everyInput: taskRepeatEveryInput,
+      endSelect: taskRepeatEndSelect,
+      endDateInput: taskRepeatEndDateInput,
+      countInput: taskRepeatCountInput,
+      defaultStartDate: calendarDateISO,
+      fallbackHoursMode: mode === "interval" ? "hours" : "none"
+    });
     const base = {
       id,
       name,
@@ -5867,11 +6095,16 @@ function renderDashboard(){
         templateId: id,
         downtimeHours: downtimeVal
       });
+      applyTaskRecurrence(template, recurrenceConfig);
       const curHours = getCurrentMachineHours();
       const baselineHours = parseBaselineHours(taskLastInput?.value);
       applyIntervalBaseline(template, { baselineHours, currentHours: curHours });
       tasksInterval.unshift(template);
-      const instance = scheduleExistingIntervalTask(template, { dateISO: targetISO, refreshDashboard: false }) || template;
+      const instance = scheduleExistingIntervalTask(template, {
+        dateISO: targetISO,
+        refreshDashboard: false,
+        recurrence: recurrenceConfig
+      }) || template;
       const parsed = parseDateLocal(targetISO);
       const todayMidnight = new Date(); todayMidnight.setHours(0,0,0,0);
       let dateLabel = targetISO;
@@ -5889,7 +6122,15 @@ function renderDashboard(){
     }else{
       const condition = (taskConditionInput?.value || "").trim() || "As required";
       const task = Object.assign({}, base, { mode:"asreq", condition, variant: "template", templateId: id });
+      applyTaskRecurrence(task, recurrenceConfig);
       tasksAsReq.unshift(task);
+      if (calendarDateISO){
+        scheduleExistingAsReqTask(task, {
+          dateISO: calendarDateISO,
+          refreshDashboard: false,
+          recurrence: recurrenceConfig
+        });
+      }
       message = "As-required task added to Maintenance Settings";
     }
 
@@ -6015,9 +6256,23 @@ function renderDashboard(){
     const task = meta.task;
     const targetISO = addContextDateISO || ymd(new Date());
     const occurrenceNote = (taskExistingNoteInput?.value || "").trim();
+    const recurrenceConfig = readRecurrenceFromInputs({
+      typeSelect: taskExistingRepeatSelect,
+      everyInput: taskExistingRepeatEveryInput,
+      endSelect: taskExistingRepeatEndSelect,
+      endDateInput: taskExistingRepeatEndDateInput,
+      countInput: taskExistingRepeatCountInput,
+      defaultStartDate: targetISO,
+      fallbackHoursMode: task.mode === "interval" ? "hours" : "none"
+    });
     let message = "Maintenance task added";
     if (task.mode === "interval"){
-      const instance = scheduleExistingIntervalTask(task, { dateISO: targetISO, note: occurrenceNote, refreshDashboard: true }) || task;
+      const instance = scheduleExistingIntervalTask(task, {
+        dateISO: targetISO,
+        note: occurrenceNote,
+        refreshDashboard: true,
+        recurrence: recurrenceConfig
+      }) || task;
       const parsed = parseDateLocal(targetISO);
       const todayMidnight = new Date(); todayMidnight.setHours(0,0,0,0);
       let dateLabel = targetISO;
@@ -6033,7 +6288,12 @@ function renderDashboard(){
         ? `Logged "${instance.name || "Task"}" as completed on ${dateLabel}`
         : `Scheduled "${instance.name || "Task"}" for ${dateLabel}`;
     }else{
-      const instance = scheduleExistingAsReqTask(task, { dateISO: targetISO, note: occurrenceNote, refreshDashboard: true }) || task;
+      const instance = scheduleExistingAsReqTask(task, {
+        dateISO: targetISO,
+        note: occurrenceNote,
+        refreshDashboard: true,
+        recurrence: recurrenceConfig
+      }) || task;
       message = "As-required task linked from Maintenance Settings";
     }
     setContextDate(targetISO);
@@ -7938,6 +8198,7 @@ function renderSettings(){
     const condition = escapeHtml(t.condition || "As required");
     const freq = t.interval ? `${t.interval} hrs` : "Set frequency";
     const baselineVal = baselineInputValue(t);
+    const recurrence = normalizeTaskRecurrence(t, { fallbackHoursMode: type === "interval" ? "hours" : "none" });
     const occurrenceNoteMap = (typeof normalizeOccurrenceNotes === "function") ? normalizeOccurrenceNotes(t) : (t.occurrenceNotes || {});
     const occurrenceHoursMap = (typeof normalizeOccurrenceHours === "function") ? normalizeOccurrenceHours(t) : (t.occurrenceHours || {});
     const occurrenceKeys = new Set([
@@ -7980,6 +8241,21 @@ function renderSettings(){
             ${type === "interval"
               ? `<label data-field="interval">Frequency (hrs)<input type=\"number\" min=\"1\" step=\"1\" data-k=\"interval\" data-id=\"${t.id}\" data-list=\"interval\" value=\"${t.interval!=null?t.interval:""}\" placeholder=\"Hours between service\"></label>`
               : `<label data-field="condition">Condition / trigger<input data-k=\"condition\" data-id=\"${t.id}\" data-list=\"asreq\" value=\"${escapeHtml(t.condition||"")}\" placeholder=\"When to perform\"></label>`}
+            <label data-field="recurrenceType">Repeat<select data-k="recurrenceType" data-id="${t.id}" data-list="${type}">
+              <option value="none" ${recurrence.type === "none" ? "selected" : ""}>Does not repeat</option>
+              <option value="hours" ${recurrence.type === "hours" ? "selected" : ""}>Machine hours</option>
+              <option value="daily" ${recurrence.type === "daily" ? "selected" : ""}>Days</option>
+              <option value="weekly" ${recurrence.type === "weekly" ? "selected" : ""}>Weeks</option>
+              <option value="monthly" ${recurrence.type === "monthly" ? "selected" : ""}>Months</option>
+            </select></label>
+            <label data-field="recurrenceInterval">Repeat every<input type="number" min="1" step="1" data-k="recurrenceInterval" data-id="${t.id}" data-list="${type}" value="${recurrence.every}"></label>
+            <label data-field="recurrenceEndType">Repeat ends<select data-k="recurrenceEndType" data-id="${t.id}" data-list="${type}">
+              <option value="never" ${recurrence.endType === "never" ? "selected" : ""}>Never</option>
+              <option value="on_date" ${recurrence.endType === "on_date" ? "selected" : ""}>On date</option>
+              <option value="after_count" ${recurrence.endType === "after_count" ? "selected" : ""}>After occurrences</option>
+            </select></label>
+            <label data-field="recurrenceEndDate">Repeat end date<input type="date" data-k="recurrenceEndDate" data-id="${t.id}" data-list="${type}" value="${recurrence.endDate || ""}"></label>
+            <label data-field="recurrenceCount">Occurrence count<input type="number" min="1" step="1" data-k="recurrenceCount" data-id="${t.id}" data-list="${type}" value="${recurrence.count != null ? recurrence.count : ""}" placeholder="optional"></label>
             ${type === "interval" ? `<label data-field="sinceBase">Hours since last service<input type=\"number\" min=\"0\" step=\"0.01\" data-k=\"sinceBase\" data-id=\"${t.id}\" data-list=\"interval\" value=\"${baselineVal!==""?baselineVal:""}\" placeholder=\"optional\"></label>` : ""}
             <label data-field="manualLink">Manual link<input type="url" data-k="manualLink" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.manualLink||"")}" placeholder="https://..."></label>
             <label data-field="storeLink">Store link<input type="url" data-k="storeLink" data-id="${t.id}" data-list="${type}" value="${escapeHtml(t.storeLink||"")}" placeholder="https://..."></label>
@@ -9156,7 +9432,7 @@ function renderSettings(){
     const key = target.getAttribute("data-k");
     if (!key || key === "mode") return;
     let value = target.value;
-    if (key === "price" || key === "interval" || key === "anchorTotal" || key === "sinceBase" || key === "downtimeHours"){
+    if (key === "price" || key === "interval" || key === "anchorTotal" || key === "sinceBase" || key === "downtimeHours" || key === "recurrenceInterval" || key === "recurrenceCount"){
       value = value === "" ? null : Number(value);
       if (value !== null && !isFinite(value)) return;
     }
@@ -9243,6 +9519,24 @@ function renderSettings(){
           renderCosts();
         }
       }
+    }else if (key === "recurrenceInterval"){
+      meta.task.recurrenceInterval = value == null ? 1 : Math.max(1, Math.round(Number(value)));
+      const rec = normalizeTaskRecurrence(meta.task, { fallbackHoursMode: meta.mode === "interval" ? "hours" : "none" });
+      applyTaskRecurrence(meta.task, rec);
+      if (typeof visitTaskFamily === "function") visitTaskFamily(meta.task, member => applyTaskRecurrence(member, rec));
+      if (typeof refreshDashboardWidgets === "function") refreshDashboardWidgets({ full: true });
+    }else if (key === "recurrenceCount"){
+      meta.task.recurrenceCount = value == null ? null : Math.max(1, Math.round(Number(value)));
+      const rec = normalizeTaskRecurrence(meta.task, { fallbackHoursMode: meta.mode === "interval" ? "hours" : "none" });
+      applyTaskRecurrence(meta.task, rec);
+      if (typeof visitTaskFamily === "function") visitTaskFamily(meta.task, member => applyTaskRecurrence(member, rec));
+      if (typeof refreshDashboardWidgets === "function") refreshDashboardWidgets({ full: true });
+    }else if (key === "recurrenceEndDate"){
+      meta.task.recurrenceEndDate = normalizeDateISO(target.value || "") || null;
+      const rec = normalizeTaskRecurrence(meta.task, { fallbackHoursMode: meta.mode === "interval" ? "hours" : "none" });
+      applyTaskRecurrence(meta.task, rec);
+      if (typeof visitTaskFamily === "function") visitTaskFamily(meta.task, member => applyTaskRecurrence(member, rec));
+      if (typeof refreshDashboardWidgets === "function") refreshDashboardWidgets({ full: true });
     }else if (key === "manualLink" || key === "storeLink" || key === "pn" || key === "name" || key === "condition" || key === "note"){
       meta.task[key] = target.value;
       if (key === "name"){ const label = holder.querySelector('.task-name'); if (label) label.textContent = target.value || "(unnamed task)"; }
@@ -9266,6 +9560,25 @@ function renderSettings(){
     if (target.hasAttribute("data-task-inventory")){
       relinkTaskInventory(meta.task, target.value || "");
       persist();
+      return;
+    }
+    if (target.getAttribute("data-k") === "recurrenceType"){
+      meta.task.recurrenceType = target.value || "none";
+      meta.task.recurrenceEnabled = target.value !== "none";
+      const rec = normalizeTaskRecurrence(meta.task, { fallbackHoursMode: meta.mode === "interval" ? "hours" : "none" });
+      applyTaskRecurrence(meta.task, rec);
+      if (typeof visitTaskFamily === "function") visitTaskFamily(meta.task, member => applyTaskRecurrence(member, rec));
+      persist();
+      renderSettings();
+      return;
+    }
+    if (target.getAttribute("data-k") === "recurrenceEndType"){
+      meta.task.recurrenceEndType = target.value || "never";
+      const rec = normalizeTaskRecurrence(meta.task, { fallbackHoursMode: meta.mode === "interval" ? "hours" : "none" });
+      applyTaskRecurrence(meta.task, rec);
+      if (typeof visitTaskFamily === "function") visitTaskFamily(meta.task, member => applyTaskRecurrence(member, rec));
+      persist();
+      renderSettings();
       return;
     }
     if (target.getAttribute("data-k") === "mode"){

--- a/js/views.js
+++ b/js/views.js
@@ -334,6 +334,21 @@ function viewDashboard(){
           <p class="small muted">Pick a task saved in Maintenance Settings to schedule it on the calendar.</p>
           <p class="small muted" data-task-existing-empty hidden>No maintenance tasks yet. Create one below to get started.</p>
           <p class="small muted" data-task-existing-search-empty hidden>No tasks match your search. Try a different name.</p>
+          <label>Repeat<select id="dashTaskExistingRepeat">
+            <option value="none">Does not repeat</option>
+            <option value="hours">Repeat by machine hours</option>
+            <option value="daily">Repeat by days</option>
+            <option value="weekly">Repeat by weeks</option>
+            <option value="monthly">Repeat by months</option>
+          </select></label>
+          <label data-task-existing-repeat-every hidden>Repeat every<input type="number" min="1" step="1" id="dashTaskExistingRepeatEvery" value="1"></label>
+          <label data-task-existing-repeat-end hidden>Repeat ends<select id="dashTaskExistingRepeatEnd">
+            <option value="never">Never</option>
+            <option value="on_date">On date</option>
+            <option value="after_count">After occurrences</option>
+          </select></label>
+          <label data-task-existing-repeat-end-date hidden>End date<input type="date" id="dashTaskExistingRepeatEndDate"></label>
+          <label data-task-existing-repeat-end-count hidden>Occurrences<input type="number" min="1" step="1" id="dashTaskExistingRepeatCount" value="10"></label>
           <label>Occurrence note<textarea id="dashTaskExistingNote" rows="3" placeholder="Optional note for this calendar date"></textarea></label>
           <div class="modal-actions">
             <button type="button" class="secondary" data-task-card-back>Back</button>
@@ -371,6 +386,21 @@ function viewDashboard(){
             <label>Time to complete (hrs)<input type="number" min="0.25" step="0.25" id="dashTaskDowntime" placeholder="e.g. 1"></label>
             <label>Category<select id="dashTaskCategory"></select></label>
             <label>Calendar date<input type="date" id="dashTaskDate"></label>
+            <label>Repeat<select id="dashTaskRepeat">
+              <option value="none">Does not repeat</option>
+              <option value="hours">Repeat by machine hours</option>
+              <option value="daily">Repeat by days</option>
+              <option value="weekly">Repeat by weeks</option>
+              <option value="monthly">Repeat by months</option>
+            </select></label>
+            <label data-task-repeat-every hidden>Repeat every<input type="number" min="1" step="1" id="dashTaskRepeatEvery" value="1"></label>
+            <label data-task-repeat-end hidden>Repeat ends<select id="dashTaskRepeatEnd">
+              <option value="never">Never</option>
+              <option value="on_date">On date</option>
+              <option value="after_count">After occurrences</option>
+            </select></label>
+            <label data-task-repeat-end-date hidden>End date<input type="date" id="dashTaskRepeatEndDate"></label>
+            <label data-task-repeat-end-count hidden>Occurrences<input type="number" min="1" step="1" id="dashTaskRepeatCount" value="10"></label>
           </div>
 
           <div class="subtask-section">


### PR DESCRIPTION
### Motivation
- Fix a bug where marking an interval template complete on the dashboard could create an unintended next-day copy and make calendar behaviour deterministic. 
- Introduce explicit, optional recurrence metadata and Google-style repeat controls so events/tasks can be scheduled as one-time or recurring (daily/weekly/monthly/hours). 
- Keep legacy interval/forecast/cost logic intact and provide a backwards-compatible fallback to the existing projection engine.

### Description
- Added a planning doc `docs/calendar-recurrence-google-style-plan.md` describing scope and phased rollout. 
- Implemented recurrence normalization and persistence helpers (`normalizeTaskRecurrence`, `applyTaskRecurrence`, `normalizeTaskRecurrenceLocal`). 
- Added recurrence projection engines: `projectCalendarRecurrenceDates` for day/week/month rules and `projectHoursRecurrenceDates` for hours-interval recurrence, and wired those into `renderCalendar` to prefer explicit recurrence when present with a legacy fallback to `projectIntervalDueDates`. 
- Prevented accidental creation of duplicate instances when completing an interval template by looking up an existing instance first in `completeTask` and by setting/using `recurrenceStartDate` in completion paths. 
- Exposed recurrence configuration during scheduling functions by adding optional `recurrence` args to `scheduleExistingIntervalTask` and `scheduleExistingAsReqTask`, applied the recurrence to instances/templates, and propagated recurrence when creating instances. 
- Enhanced calendar bubble UI to support marking an occurrence complete for a custom date via a new "Mark complete on…" action. 
- Extended Maintenance Settings and Dashboard Add Task modals with repeat controls, input handlers, and UI sync logic (`readRecurrenceFromInputs`, `syncRepeatRows`) and persisted recurrence fields on edit. 
- Ensured tasks get normalized recurrence metadata on startup via `ensureTaskCategories`, and added plumbing to apply recurrence changes to family members when recurrence-related settings are edited. 

### Testing
- Built and ran the web UI in development to exercise the calendar and dashboard flows and verify no build regressions (build succeeded). 
- Exercised scheduling and completion flows in the dashboard manually to confirm: completing an interval occurrence no longer creates the extra next-day copy; explicit recurrence events render on the calendar; custom completion date via bubble works (manual smoke checks passed). 
- Did not add new automated unit tests in this change; existing JS runtime checks and UI build succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8f71f464832583795084cbdca77c)