### PR TITLE
Prefer actual calendar occurrence when navigating from Next Due widget

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1005,11 +1005,11 @@ function shouldOfferEndRepeatAfterSingleRemoval(task, removedDateISO){
   return diffDays >= 0 && diffDays <= 1;
 }
 
-function removeIntervalOccurrenceScopeAcrossFamily(task, dateISO, scope){
+function removeIntervalOccurrenceScopeAcrossInstances(task, dateISO, scope){
   if (!task) return false;
   let changed = false;
   visitTaskFamily(task, member => {
-    if (!member || member.mode !== "interval") return;
+    if (!member || member.mode !== "interval" || !isInstanceTask(member)) return;
     const memberMeta = { task: member, mode: "interval" };
     if (removeCalendarTaskOccurrences(memberMeta, dateISO, scope)){
       changed = true;
@@ -1292,11 +1292,7 @@ function showTaskBubble(taskId, anchor, options = {}){
         : "Remove this occurrence from the calendar?";
     const shouldRemove = window.confirm ? window.confirm(confirmText) : true;
     if (!shouldRemove) return;
-    const intervalScopeRemoval = (scope === "future" || scope === "all")
-      && (meta.mode === "interval" || task.mode === "interval");
-    const changed = intervalScopeRemoval
-      ? removeIntervalOccurrenceScopeAcrossFamily(task, targetKey, scope)
-      : removeCalendarTaskOccurrences(meta, targetKey, scope);
+    const changed = removeCalendarTaskOccurrences(meta, targetKey, scope);
     if (changed){
       let endedRepeat = false;
       if (scope === "single" && (meta.mode === "interval" || task.mode === "interval")){
@@ -1308,7 +1304,7 @@ function showTaskBubble(taskId, anchor, options = {}){
             : targetKey;
           const shouldEndRepeat = window.confirm(`This task repeats and the next occurrence is already scheduled. End repeating from ${display} onward?`);
           if (shouldEndRepeat){
-            endedRepeat = removeIntervalOccurrenceScopeAcrossFamily(task, targetKey, "future");
+            endedRepeat = removeIntervalOccurrenceScopeAcrossInstances(task, targetKey, "future");
           }
         }
       }

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -949,42 +949,6 @@ function removeCalendarTaskOccurrences(meta, dateISO, scope = "single"){
   return changed;
 }
 
-function removeIntervalOccurrenceScopeAcrossInstances(task, dateISO, scope){
-  if (!task) return false;
-  let changed = false;
-  const selfMeta = { task, mode: task.mode === "asreq" ? "asreq" : "interval" };
-  if (removeCalendarTaskOccurrences(selfMeta, dateISO, scope)){
-    changed = true;
-  }
-  visitTaskFamily(task, member => {
-    if (!member || member.mode !== "interval" || !isInstanceTask(member)) return;
-    if (String(member.id) === String(task.id)) return;
-    const memberMeta = { task: member, mode: "interval" };
-    if (removeCalendarTaskOccurrences(memberMeta, dateISO, scope)){
-      changed = true;
-    }
-  });
-  return changed;
-}
-
-function setIntervalRepeatPausedAcrossFamily(task, paused){
-  if (!task) return false;
-  let changed = false;
-  visitTaskFamily(task, member => {
-    if (!member || member.mode !== "interval") return;
-    if (typeof setIntervalRepeatPaused === "function"){
-      if (setIntervalRepeatPaused(member, paused)) changed = true;
-      return;
-    }
-    const next = paused === true;
-    if ((member.repeatPaused === true) !== next){
-      member.repeatPaused = next;
-      changed = true;
-    }
-  });
-  return changed;
-}
-
 function removeCalendarTaskEverywhere(meta){
   if (!meta || !meta.list || typeof meta.index !== "number" || meta.index < 0) return false;
   const list = meta.list;
@@ -1259,20 +1223,18 @@ function showTaskBubble(taskId, anchor, options = {}){
         : "Remove this occurrence from the calendar?";
     const shouldRemove = window.confirm ? window.confirm(confirmText) : true;
     if (!shouldRemove) return;
-    const singleIntervalRemoval = scope === "single"
-      && (meta.mode === "interval" || task.mode === "interval");
-    let changed = singleIntervalRemoval
-      ? removeIntervalOccurrenceScopeAcrossInstances(task, targetKey, "single")
-      : removeCalendarTaskOccurrences(meta, targetKey, scope);
-    if (!changed && singleIntervalRemoval){
-      changed = removeCalendarTaskOccurrences(meta, targetKey, "single");
-    }
+    const changed = removeCalendarTaskOccurrences(meta, targetKey, scope);
     if (changed){
       let pausedRepeat = false;
       if (scope === "single" && (meta.mode === "interval" || task.mode === "interval") && typeof window.confirm === "function"){
         const shouldPauseRepeat = window.confirm("Pause repeat predictions for this task until you manually add it again?");
         if (shouldPauseRepeat){
-          pausedRepeat = setIntervalRepeatPausedAcrossFamily(task, true);
+          if (typeof setIntervalRepeatPaused === "function"){
+            pausedRepeat = setIntervalRepeatPaused(task, true);
+          }else{
+            task.repeatPaused = true;
+            pausedRepeat = true;
+          }
         }
       }
       if (typeof saveCloudNow === "function") saveCloudNow();

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -949,6 +949,62 @@ function removeCalendarTaskOccurrences(meta, dateISO, scope = "single"){
   return changed;
 }
 
+function getNextProjectedIntervalOccurrenceKey(task){
+  if (!task || task.mode === "asreq") return null;
+
+  const completedKeys = new Set(
+    Array.isArray(task.completedDates)
+      ? task.completedDates.map(normalizeDateKey).filter(Boolean)
+      : []
+  );
+
+  const manualHistory = Array.isArray(task.manualHistory) ? task.manualHistory : [];
+  const manualDates = new Set();
+  manualHistory.forEach(entry => {
+    if (!entry) return;
+    const entryKey = normalizeDateKey(entry.dateISO);
+    if (!entryKey) return;
+    const status = entry.status || "logged";
+    if (status === "completed"){
+      completedKeys.add(entryKey);
+      return;
+    }
+    manualDates.add(entryKey);
+  });
+
+  const removedSet = normalizeRemovedOccurrences(task);
+  removedSet.forEach(key => manualDates.add(key));
+
+  const manualKey = normalizeDateKey(task.calendarDateISO);
+  if (manualKey) manualDates.add(manualKey);
+
+  const skipDates = new Set(completedKeys);
+  manualDates.forEach(key => skipDates.add(key));
+
+  const projections = projectIntervalDueDates(task, {
+    monthsAhead: 3,
+    excludeDates: skipDates,
+    minOccurrences: 1,
+    maxOccurrences: 1
+  });
+
+  return normalizeDateKey(projections?.[0]?.dateISO);
+}
+
+function shouldOfferEndRepeatAfterSingleRemoval(task, removedDateISO){
+  if (!task || task.mode === "asreq") return false;
+  const removedKey = normalizeDateKey(removedDateISO);
+  if (!removedKey) return false;
+  const nextKey = getNextProjectedIntervalOccurrenceKey(task);
+  if (!nextKey) return false;
+  const removedDate = toDayStart(removedKey);
+  const nextDate = toDayStart(nextKey);
+  if (!(removedDate instanceof Date) || Number.isNaN(removedDate.getTime())) return false;
+  if (!(nextDate instanceof Date) || Number.isNaN(nextDate.getTime())) return false;
+  const diffDays = Math.round((nextDate.getTime() - removedDate.getTime()) / CALENDAR_DAY_MS);
+  return diffDays >= 0 && diffDays <= 1;
+}
+
 function removeCalendarTaskEverywhere(meta){
   if (!meta || !meta.list || typeof meta.index !== "number" || meta.index < 0) return false;
   const list = meta.list;
@@ -1225,9 +1281,25 @@ function showTaskBubble(taskId, anchor, options = {}){
     if (!shouldRemove) return;
     const changed = removeCalendarTaskOccurrences(meta, targetKey, scope);
     if (changed){
+      let endedRepeat = false;
+      if (scope === "single" && (meta.mode === "interval" || task.mode === "interval")){
+        const shouldOfferEndRepeat = shouldOfferEndRepeatAfterSingleRemoval(task, targetKey);
+        if (shouldOfferEndRepeat && typeof window.confirm === "function"){
+          const parsed = parseDateLocal(targetKey);
+          const display = (parsed instanceof Date && !Number.isNaN(parsed.getTime()))
+            ? parsed.toLocaleDateString()
+            : targetKey;
+          const shouldEndRepeat = window.confirm(`This task repeats and the next occurrence is already scheduled. End repeating from ${display} onward?`);
+          if (shouldEndRepeat){
+            endedRepeat = removeCalendarTaskOccurrences(meta, targetKey, "future");
+          }
+        }
+      }
       if (typeof saveCloudNow === "function") saveCloudNow();
       else saveCloudDebounced();
-      const toastMessage = scope === "future"
+      const toastMessage = endedRepeat
+        ? "Recurring schedule ended from this occurrence"
+        : scope === "future"
         ? "Current and future occurrences removed"
         : scope === "all"
           ? "All occurrences removed"

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1292,7 +1292,11 @@ function showTaskBubble(taskId, anchor, options = {}){
         : "Remove this occurrence from the calendar?";
     const shouldRemove = window.confirm ? window.confirm(confirmText) : true;
     if (!shouldRemove) return;
-    const changed = removeCalendarTaskOccurrences(meta, targetKey, scope);
+    const singleIntervalRemoval = scope === "single"
+      && (meta.mode === "interval" || task.mode === "interval");
+    const changed = singleIntervalRemoval
+      ? removeIntervalOccurrenceScopeAcrossInstances(task, targetKey, "single")
+      : removeCalendarTaskOccurrences(meta, targetKey, scope);
     if (changed){
       let endedRepeat = false;
       if (scope === "single" && (meta.mode === "interval" || task.mode === "interval")){

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1005,6 +1005,19 @@ function shouldOfferEndRepeatAfterSingleRemoval(task, removedDateISO){
   return diffDays >= 0 && diffDays <= 1;
 }
 
+function removeIntervalOccurrenceScopeAcrossFamily(task, dateISO, scope){
+  if (!task) return false;
+  let changed = false;
+  visitTaskFamily(task, member => {
+    if (!member || member.mode !== "interval") return;
+    const memberMeta = { task: member, mode: "interval" };
+    if (removeCalendarTaskOccurrences(memberMeta, dateISO, scope)){
+      changed = true;
+    }
+  });
+  return changed;
+}
+
 function removeCalendarTaskEverywhere(meta){
   if (!meta || !meta.list || typeof meta.index !== "number" || meta.index < 0) return false;
   const list = meta.list;
@@ -1279,7 +1292,11 @@ function showTaskBubble(taskId, anchor, options = {}){
         : "Remove this occurrence from the calendar?";
     const shouldRemove = window.confirm ? window.confirm(confirmText) : true;
     if (!shouldRemove) return;
-    const changed = removeCalendarTaskOccurrences(meta, targetKey, scope);
+    const intervalScopeRemoval = (scope === "future" || scope === "all")
+      && (meta.mode === "interval" || task.mode === "interval");
+    const changed = intervalScopeRemoval
+      ? removeIntervalOccurrenceScopeAcrossFamily(task, targetKey, scope)
+      : removeCalendarTaskOccurrences(meta, targetKey, scope);
     if (changed){
       let endedRepeat = false;
       if (scope === "single" && (meta.mode === "interval" || task.mode === "interval")){
@@ -1291,7 +1308,7 @@ function showTaskBubble(taskId, anchor, options = {}){
             : targetKey;
           const shouldEndRepeat = window.confirm(`This task repeats and the next occurrence is already scheduled. End repeating from ${display} onward?`);
           if (shouldEndRepeat){
-            endedRepeat = removeCalendarTaskOccurrences(meta, targetKey, "future");
+            endedRepeat = removeIntervalOccurrenceScopeAcrossFamily(task, targetKey, "future");
           }
         }
       }

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -949,62 +949,6 @@ function removeCalendarTaskOccurrences(meta, dateISO, scope = "single"){
   return changed;
 }
 
-function getNextProjectedIntervalOccurrenceKey(task){
-  if (!task || task.mode === "asreq") return null;
-
-  const completedKeys = new Set(
-    Array.isArray(task.completedDates)
-      ? task.completedDates.map(normalizeDateKey).filter(Boolean)
-      : []
-  );
-
-  const manualHistory = Array.isArray(task.manualHistory) ? task.manualHistory : [];
-  const manualDates = new Set();
-  manualHistory.forEach(entry => {
-    if (!entry) return;
-    const entryKey = normalizeDateKey(entry.dateISO);
-    if (!entryKey) return;
-    const status = entry.status || "logged";
-    if (status === "completed"){
-      completedKeys.add(entryKey);
-      return;
-    }
-    manualDates.add(entryKey);
-  });
-
-  const removedSet = normalizeRemovedOccurrences(task);
-  removedSet.forEach(key => manualDates.add(key));
-
-  const manualKey = normalizeDateKey(task.calendarDateISO);
-  if (manualKey) manualDates.add(manualKey);
-
-  const skipDates = new Set(completedKeys);
-  manualDates.forEach(key => skipDates.add(key));
-
-  const projections = projectIntervalDueDates(task, {
-    monthsAhead: 3,
-    excludeDates: skipDates,
-    minOccurrences: 1,
-    maxOccurrences: 1
-  });
-
-  return normalizeDateKey(projections?.[0]?.dateISO);
-}
-
-function shouldOfferEndRepeatAfterSingleRemoval(task, removedDateISO){
-  if (!task || task.mode === "asreq") return false;
-  const removedKey = normalizeDateKey(removedDateISO);
-  if (!removedKey) return false;
-  const nextKey = getNextProjectedIntervalOccurrenceKey(task);
-  if (!nextKey) return false;
-  const removedDate = toDayStart(removedKey);
-  const nextDate = toDayStart(nextKey);
-  if (!(removedDate instanceof Date) || Number.isNaN(removedDate.getTime())) return false;
-  if (!(nextDate instanceof Date) || Number.isNaN(nextDate.getTime())) return false;
-  const diffDays = Math.round((nextDate.getTime() - removedDate.getTime()) / CALENDAR_DAY_MS);
-  return diffDays >= 0 && diffDays <= 1;
-}
-
 function removeIntervalOccurrenceScopeAcrossInstances(task, dateISO, scope){
   if (!task) return false;
   let changed = false;
@@ -1012,6 +956,24 @@ function removeIntervalOccurrenceScopeAcrossInstances(task, dateISO, scope){
     if (!member || member.mode !== "interval" || !isInstanceTask(member)) return;
     const memberMeta = { task: member, mode: "interval" };
     if (removeCalendarTaskOccurrences(memberMeta, dateISO, scope)){
+      changed = true;
+    }
+  });
+  return changed;
+}
+
+function setIntervalRepeatPausedAcrossFamily(task, paused){
+  if (!task) return false;
+  let changed = false;
+  visitTaskFamily(task, member => {
+    if (!member || member.mode !== "interval") return;
+    if (typeof setIntervalRepeatPaused === "function"){
+      if (setIntervalRepeatPaused(member, paused)) changed = true;
+      return;
+    }
+    const next = paused === true;
+    if ((member.repeatPaused === true) !== next){
+      member.repeatPaused = next;
       changed = true;
     }
   });
@@ -1298,24 +1260,17 @@ function showTaskBubble(taskId, anchor, options = {}){
       ? removeIntervalOccurrenceScopeAcrossInstances(task, targetKey, "single")
       : removeCalendarTaskOccurrences(meta, targetKey, scope);
     if (changed){
-      let endedRepeat = false;
-      if (scope === "single" && (meta.mode === "interval" || task.mode === "interval")){
-        const shouldOfferEndRepeat = shouldOfferEndRepeatAfterSingleRemoval(task, targetKey);
-        if (shouldOfferEndRepeat && typeof window.confirm === "function"){
-          const parsed = parseDateLocal(targetKey);
-          const display = (parsed instanceof Date && !Number.isNaN(parsed.getTime()))
-            ? parsed.toLocaleDateString()
-            : targetKey;
-          const shouldEndRepeat = window.confirm(`This task repeats and the next occurrence is already scheduled. End repeating from ${display} onward?`);
-          if (shouldEndRepeat){
-            endedRepeat = removeIntervalOccurrenceScopeAcrossInstances(task, targetKey, "future");
-          }
+      let pausedRepeat = false;
+      if (scope === "single" && (meta.mode === "interval" || task.mode === "interval") && typeof window.confirm === "function"){
+        const shouldPauseRepeat = window.confirm("Pause repeat predictions for this task until you manually add it again?");
+        if (shouldPauseRepeat){
+          pausedRepeat = setIntervalRepeatPausedAcrossFamily(task, true);
         }
       }
       if (typeof saveCloudNow === "function") saveCloudNow();
       else saveCloudDebounced();
-      const toastMessage = endedRepeat
-        ? "Recurring schedule ended from this occurrence"
+      const toastMessage = pausedRepeat
+        ? "Occurrence removed and repeat paused until manually added again"
         : scope === "future"
         ? "Current and future occurrences removed"
         : scope === "all"
@@ -1755,6 +1710,7 @@ function estimateIntervalDailyHours(task, baselineEntry, today){
 
 function projectIntervalDueDates(task, options = {}){
   if (!task || task.mode !== "interval") return [];
+  if (typeof isIntervalRepeatPaused === "function" && isIntervalRepeatPaused(task)) return [];
   const interval = Number(task.interval);
   if (!Number.isFinite(interval) || interval <= 0) return [];
 

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -952,8 +952,13 @@ function removeCalendarTaskOccurrences(meta, dateISO, scope = "single"){
 function removeIntervalOccurrenceScopeAcrossInstances(task, dateISO, scope){
   if (!task) return false;
   let changed = false;
+  const selfMeta = { task, mode: task.mode === "asreq" ? "asreq" : "interval" };
+  if (removeCalendarTaskOccurrences(selfMeta, dateISO, scope)){
+    changed = true;
+  }
   visitTaskFamily(task, member => {
     if (!member || member.mode !== "interval" || !isInstanceTask(member)) return;
+    if (String(member.id) === String(task.id)) return;
     const memberMeta = { task: member, mode: "interval" };
     if (removeCalendarTaskOccurrences(memberMeta, dateISO, scope)){
       changed = true;
@@ -1256,9 +1261,12 @@ function showTaskBubble(taskId, anchor, options = {}){
     if (!shouldRemove) return;
     const singleIntervalRemoval = scope === "single"
       && (meta.mode === "interval" || task.mode === "interval");
-    const changed = singleIntervalRemoval
+    let changed = singleIntervalRemoval
       ? removeIntervalOccurrenceScopeAcrossInstances(task, targetKey, "single")
       : removeCalendarTaskOccurrences(meta, targetKey, scope);
+    if (!changed && singleIntervalRemoval){
+      changed = removeCalendarTaskOccurrences(meta, targetKey, "single");
+    }
     if (changed){
       let pausedRepeat = false;
       if (scope === "single" && (meta.mode === "interval" || task.mode === "interval") && typeof window.confirm === "function"){

--- a/js/computations.js
+++ b/js/computations.js
@@ -182,6 +182,7 @@ function liveSince(task){
 
 function nextDue(task){
   if (!task || task.interval == null) return null;
+  if (typeof isIntervalRepeatPaused === "function" && isIntervalRepeatPaused(task)) return null;
   const sinceRaw = liveSince(task);
   if (sinceRaw == null) return null;
   const since = Math.max(0, Number(sinceRaw) || 0);

--- a/js/core.js
+++ b/js/core.js
@@ -857,6 +857,24 @@ function ensureTaskVariant(task, type){
   }
 }
 
+function isIntervalRepeatPaused(task){
+  return !!(task && task.mode === "interval" && task.repeatPaused === true);
+}
+
+function setIntervalRepeatPaused(task, paused){
+  if (!task || task.mode !== "interval") return false;
+  const next = paused === true;
+  const prev = task.repeatPaused === true;
+  if (prev === next) return false;
+  task.repeatPaused = next;
+  if (next){
+    task.repeatPausedAtISO = new Date().toISOString();
+  }else{
+    delete task.repeatPausedAtISO;
+  }
+  return true;
+}
+
 function pruneCurrentAndFutureIntervalOccurrences(templateId){
   const tid = templateId != null ? String(templateId) : null;
   if (!tid || !Array.isArray(window.tasksInterval)) return;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -582,6 +582,7 @@ function createIntervalTaskInstance(template){
     manualHistory: [],
     occurrenceNotes: {},
     occurrenceHours: {},
+    repeatPaused: template.repeatPaused === true,
     note: template.note || "",
     downtimeHours: (()=>{
       const raw = Number(template.downtimeHours);
@@ -678,6 +679,21 @@ function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refresh
     }
     clearForTask(instance);
   };
+  const resumeRepeatAcrossFamily = ()=>{
+    const resumeForTask = (taskRef)=>{
+      if (!taskRef || taskRef.mode !== "interval") return;
+      if (typeof setIntervalRepeatPaused === "function"){
+        setIntervalRepeatPaused(taskRef, false);
+      }else{
+        taskRef.repeatPaused = false;
+      }
+    };
+    if (typeof visitTaskFamily === "function"){
+      visitTaskFamily(instance, resumeForTask);
+      return;
+    }
+    resumeForTask(instance);
+  };
 
   const liveHoursRaw = getCurrentMachineHours();
   const liveHours = (liveHoursRaw != null && Number.isFinite(Number(liveHoursRaw)))
@@ -698,6 +714,7 @@ function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refresh
     targetDate.setHours(0,0,0,0);
     targetISO = ymd(targetDate);
     clearRemovedDateAcrossFamily(targetISO);
+    resumeRepeatAcrossFamily();
     instance.calendarDateISO = targetISO;
     const isPastOrToday = targetDate.getTime() <= today.getTime();
     const hoursAtTarget = hoursSnapshotOnOrBefore(targetISO);

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -662,6 +662,23 @@ function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refresh
   const today = new Date(); today.setHours(0,0,0,0);
   const todayISO = ymd(today);
 
+  const clearRemovedDateAcrossFamily = (dateKey)=>{
+    const normalized = typeof normalizeDateKey === "function" ? normalizeDateKey(dateKey) : dateKey;
+    if (!normalized || typeof clearRemovedOccurrences !== "function") return;
+    const clearForTask = (taskRef)=>{
+      if (!taskRef || taskRef.mode !== "interval") return;
+      clearRemovedOccurrences(taskRef, (value)=> {
+        const key = typeof normalizeDateKey === "function" ? normalizeDateKey(value) : value;
+        return key === normalized;
+      });
+    };
+    if (typeof visitTaskFamily === "function"){
+      visitTaskFamily(instance, clearForTask);
+      return;
+    }
+    clearForTask(instance);
+  };
+
   const liveHoursRaw = getCurrentMachineHours();
   const liveHours = (liveHoursRaw != null && Number.isFinite(Number(liveHoursRaw)))
     ? Number(liveHoursRaw)
@@ -680,6 +697,7 @@ function scheduleExistingIntervalTask(task, { dateISO = null, note = "", refresh
   if (targetDate instanceof Date && !Number.isNaN(targetDate.getTime())){
     targetDate.setHours(0,0,0,0);
     targetISO = ymd(targetDate);
+    clearRemovedDateAcrossFamily(targetISO);
     instance.calendarDateISO = targetISO;
     const isPastOrToday = targetDate.getTime() <= today.getTime();
     const hoursAtTarget = hoursSnapshotOnOrBefore(targetISO);

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -4828,7 +4828,14 @@ function renderDashboard(){
       if (!btn || !btn.dataset) return;
       const taskId = btn.dataset.taskId ? String(btn.dataset.taskId) : (btn.dataset.calTask ? String(btn.dataset.calTask) : "");
       const dueISO = btn.dataset.dueIso ? String(btn.dataset.dueIso) : "";
-      const parsedDue = dueISO && typeof parseDateLocal === "function" ? parseDateLocal(dueISO) : (dueISO ? new Date(dueISO) : null);
+      const parseCalendarDate = (dateISO)=>{
+        if (!dateISO) return null;
+        const parsed = typeof parseDateLocal === "function" ? parseDateLocal(dateISO) : new Date(dateISO);
+        if (!(parsed instanceof Date) || Number.isNaN(parsed.getTime())) return null;
+        parsed.setHours(0,0,0,0);
+        return parsed;
+      };
+      const parsedDue = parseCalendarDate(dueISO);
       if (parsedDue instanceof Date && !Number.isNaN(parsedDue.getTime())){
         parsedDue.setHours(0,0,0,0);
         const today = new Date();
@@ -4843,7 +4850,35 @@ function renderDashboard(){
       }
       if (typeof renderCalendar === "function") renderCalendar();
       const months = document.getElementById("months");
-      const cell = dueISO ? months?.querySelector(`[data-date-iso="${dueISO}"]`) : null;
+      const taskChip = taskId ? months?.querySelector(`[data-cal-task="${taskId}"]`) : null;
+      const taskCell = taskChip?.closest?.("[data-date-iso]") || null;
+      const taskCellISO = taskCell?.dataset?.dateIso ? String(taskCell.dataset.dateIso) : "";
+      const resolvedISO = taskCellISO || dueISO;
+      let cell = resolvedISO ? months?.querySelector(`[data-date-iso="${resolvedISO}"]`) : null;
+
+      if (!cell && taskId){
+        const fallbackChip = months?.querySelector(`[data-cal-task="${taskId}"]`);
+        if (fallbackChip?.closest){
+          cell = fallbackChip.closest("[data-date-iso]");
+        }
+      }
+
+      if (cell){
+        const resolvedDate = parseCalendarDate(resolvedISO);
+        if (resolvedDate){
+          const today = new Date();
+          today.setHours(0,0,0,0);
+          const diffMonths = (resolvedDate.getFullYear() - today.getFullYear()) * 12 + (resolvedDate.getMonth() - today.getMonth());
+          const clamped = Math.min(12, Math.max(-12, Math.round(diffMonths)));
+          if (window.__calendarMonthOffset !== clamped){
+            window.__calendarMonthOffset = clamped;
+            if (typeof renderCalendar === "function") renderCalendar();
+            const refreshedMonths = document.getElementById("months");
+            cell = resolvedISO ? refreshedMonths?.querySelector(`[data-date-iso="${resolvedISO}"]`) : cell;
+          }
+        }
+      }
+
       if (cell){
         cell.scrollIntoView({ behavior: "smooth", block: "center" });
         highlightCalendarDayCell(cell);


### PR DESCRIPTION
### Motivation
- Clicking a task in the "Next Due" widget sometimes navigated to an empty calendar cell because the widget used the projected `data-due-iso` instead of the date where the task chip was actually rendered. This change aims to navigate to the visible occurrence the user will see in the calendar.

### Description
- Updated the Next Due click handler in `js/renderers.js` to add a `parseCalendarDate` helper that safely normalizes date strings. 
- Prefer the calendar chip’s enclosing `[data-date-iso]` (the actual rendered occurrence) by locating `[data-cal-task]` first and using its cell ISO when present, falling back to the projected `data-due-iso` when necessary. 
- Recalculate and clamp `__calendarMonthOffset` using the resolved in-calendar date and re-render the calendar if the offset must change before scrolling. 
- After resolving the correct cell, scroll it into view, highlight it, and open the task bubble anchored to the actual rendered chip.

### Testing
- Ran `node --check js/renderers.js` to validate syntax, which completed successfully. 
- Confirmed `vercel.json` already matches the required static config (`{ "cleanUrls": true }`) so no changes were made to it.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e63aa1291c8325917afa43b45e42a4)