### PR TITLE
Add maintenance data-center table to cost analysis

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10568,6 +10568,11 @@ function setupForecastBreakdownModal(){
 function renderCosts(){
   const content = document.getElementById("content");
   if (!content) return;
+  const previousModal = document.getElementById("costDataCenterModal");
+  if (previousModal && previousModal.parentElement === document.body){
+    previousModal.remove();
+    document.body.classList.remove("cost-data-center-open");
+  }
 
   const escapeHtml = (str)=> String(str ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
 
@@ -10652,6 +10657,9 @@ function renderCosts(){
     const openBtn = content.querySelector("[data-open-data-center]");
     const modal = content.querySelector("[data-data-center-modal]");
     const closeBtns = Array.from(content.querySelectorAll("[data-close-data-center]"));
+    if (modal instanceof HTMLElement){
+      document.body.appendChild(modal);
+    }
     const closeDataCenter = ()=>{
       if (!(modal instanceof HTMLElement)) return;
       modal.setAttribute("hidden", "");
@@ -10675,11 +10683,14 @@ function renderCosts(){
         if (!(btn instanceof HTMLElement)) return;
         btn.addEventListener("click", closeDataCenter);
       });
-      modal.addEventListener("keydown", (event)=>{
-        if (event.key === "Escape" && !modal.hasAttribute("hidden")){
-          closeDataCenter();
-        }
-      });
+      if (!modal.dataset.wired){
+        modal.dataset.wired = "1";
+        modal.addEventListener("keydown", (event)=>{
+          if (event.key === "Escape" && !modal.hasAttribute("hidden")){
+            closeDataCenter();
+          }
+        });
+      }
     }
 
     const rows = Array.from(content.querySelectorAll("[data-maintenance-open-task]"));

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10704,15 +10704,25 @@ function renderCosts(){
     rows.forEach(btn => {
       if (!(btn instanceof HTMLElement)) return;
       btn.addEventListener("click", ()=>{
+        const modeId = String(btn.getAttribute("data-link-mode-id") || "");
+        const explicitSelect = modeId ? document.getElementById(modeId) : null;
         const row = btn.closest("tr");
-        const select = row ? row.querySelector("[data-maintenance-link-mode]") : null;
-        const destination = (select instanceof HTMLSelectElement ? select.value : "calendar").toLowerCase();
+        const fallbackSelect = row ? row.querySelector("[data-maintenance-link-mode]") : null;
+        const select = (explicitSelect instanceof HTMLSelectElement) ? explicitSelect : fallbackSelect;
+        const destination = String((select instanceof HTMLSelectElement ? select.value : "calendar") || "calendar").toLowerCase();
         const taskId = String(btn.getAttribute("data-task-id") || "");
         const dateISO = String(btn.getAttribute("data-date-iso") || "");
         if (destination === "settings"){
-          location.hash = `#/settings?taskId=${encodeURIComponent(taskId)}`;
+          closeDataCenter();
+          if (taskId){
+            window.pendingMaintenanceFocus = { taskIds: [taskId] };
+          }
+          location.hash = taskId
+            ? `#/settings?taskId=${encodeURIComponent(taskId)}`
+            : "#/settings";
           return;
         }
+        closeDataCenter();
         focusCalendarAtOccurrence(taskId, dateISO);
       });
     });

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -7710,7 +7710,9 @@ function renderSettings(){
         window.pendingMaintenanceFocus = { taskIds: [taskId] };
       }
     }
-  } catch (_err){}
+  } catch (err){
+    console.error("Failed to parse maintenance focus from URL hash:", err);
+  }
 
   // --- one-time hydration for legacy/remote tasks (per-list) ---
   // Previously this only ran if BOTH lists were empty. That prevented legacy
@@ -10697,7 +10699,7 @@ function renderCosts(){
       }
     }
 
-    const rows = Array.from(content.querySelectorAll("[data-maintenance-open-task]"));
+    const rows = Array.from((modal instanceof HTMLElement ? modal : content).querySelectorAll("[data-maintenance-open-task]"));
     if (!rows.length) return;
     rows.forEach(btn => {
       if (!(btn instanceof HTMLElement)) return;
@@ -14349,7 +14351,8 @@ function computeCostModel(){
     });
   });
   taskDateGroups.forEach((dateList, taskId) => {
-    const uniqueDates = Array.from(new Set((Array.isArray(dateList) ? dateList : []).filter(Boolean))).sort((a,b)=> b.localeCompare(a));
+    const normalizedDates = Array.isArray(dateList) ? dateList.filter(Boolean) : [];
+    const uniqueDates = [...new Set(normalizedDates)].sort((a, b) => b.localeCompare(a));
     const qty = uniqueDates.length;
     uniqueDates.forEach((dateISO, index) => {
       const row = maintenanceDataTableRows.find(item => item.taskId === taskId && item.dateISO === dateISO);

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10700,6 +10700,61 @@ function renderCosts(){
     }
 
     const searchInput = modal instanceof HTMLElement ? modal.querySelector("[data-maintenance-search]") : null;
+    const suggestionsBox = modal instanceof HTMLElement ? modal.querySelector("[data-maintenance-search-suggestions]") : null;
+    const suggestionState = { items: [] };
+    const computeSuggestions = (term, rows)=>{
+      const normalizedTerm = String(term || "").trim().toLowerCase();
+      if (!normalizedTerm) return [];
+      const counts = new Map();
+      rows.forEach(row => {
+        if (!(row instanceof HTMLElement)) return;
+        const taskName = String(row.getAttribute("data-task-name") || "").trim();
+        if (!taskName) return;
+        const key = taskName.toLowerCase();
+        counts.set(key, { taskName, count: (counts.get(key)?.count || 0) + 1 });
+      });
+      const ranked = Array.from(counts.values())
+        .map(item => {
+          const lower = item.taskName.toLowerCase();
+          const starts = lower.startsWith(normalizedTerm) ? 2 : 0;
+          const contains = !starts && lower.includes(normalizedTerm) ? 1 : 0;
+          return { ...item, score: starts + contains };
+        })
+        .filter(item => item.score > 0)
+        .sort((a, b) => {
+          if (b.score !== a.score) return b.score - a.score;
+          if (b.count !== a.count) return b.count - a.count;
+          return a.taskName.localeCompare(b.taskName);
+        })
+        .slice(0, 3);
+      return ranked.map(item => item.taskName);
+    };
+    const renderSuggestions = ()=>{
+      if (!(suggestionsBox instanceof HTMLElement) || !(searchInput instanceof HTMLInputElement) || !(modal instanceof HTMLElement)) return;
+      const tableRows = Array.from(modal.querySelectorAll("[data-maintenance-row]"));
+      suggestionState.items = computeSuggestions(searchInput.value, tableRows);
+      if (!suggestionState.items.length){
+        suggestionsBox.hidden = true;
+        suggestionsBox.innerHTML = "";
+        return;
+      }
+      suggestionsBox.innerHTML = suggestionState.items.map((label, idx)=> `
+        <button type="button" class="cost-data-center-suggestion" data-suggestion-index="${idx}">${escapeHtml(label)}</button>
+      `).join("");
+      suggestionsBox.hidden = false;
+      Array.from(suggestionsBox.querySelectorAll("[data-suggestion-index]")).forEach(btn => {
+        if (!(btn instanceof HTMLElement)) return;
+        btn.addEventListener("click", ()=>{
+          const index = Number(btn.getAttribute("data-suggestion-index"));
+          const selected = suggestionState.items[index];
+          if (!selected || !(searchInput instanceof HTMLInputElement)) return;
+          searchInput.value = selected;
+          applySearchFilter();
+          renderSuggestions();
+          try { searchInput.focus({ preventScroll: true }); } catch (_err){ searchInput.focus(); }
+        });
+      });
+    };
     const applySearchFilter = ()=>{
       if (!(modal instanceof HTMLElement)) return;
       const term = String(searchInput instanceof HTMLInputElement ? searchInput.value : "").trim().toLowerCase();
@@ -10712,8 +10767,23 @@ function renderCosts(){
       });
     };
     if (searchInput instanceof HTMLInputElement){
-      searchInput.addEventListener("input", applySearchFilter);
+      searchInput.addEventListener("input", ()=>{
+        applySearchFilter();
+        renderSuggestions();
+      });
+      searchInput.addEventListener("keydown", (event)=>{
+        if (event.key === "Tab" && suggestionState.items.length){
+          event.preventDefault();
+          const selected = suggestionState.items[0];
+          if (selected){
+            searchInput.value = selected;
+            applySearchFilter();
+            renderSuggestions();
+          }
+        }
+      });
       applySearchFilter();
+      renderSuggestions();
     }
 
     const rows = Array.from((modal instanceof HTMLElement ? modal : content).querySelectorAll("[data-maintenance-open-task]"));

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10569,6 +10569,7 @@ function renderCosts(){
   const content = document.getElementById("content");
   if (!content) return;
   const previousModal = document.getElementById("costDataCenterModal");
+  const wasDataCenterOpen = Boolean(previousModal && !previousModal.hasAttribute("hidden"));
   if (previousModal && previousModal.parentElement === document.body){
     previousModal.remove();
     document.body.classList.remove("cost-data-center-open");
@@ -10616,7 +10617,7 @@ function renderCosts(){
   setupCostTimeframeModal(model);
   setupJobCategoryWindow(model);
   setupWeeklyReportWindow(model);
-  setupMaintenanceDataCenterActions();
+  setupMaintenanceDataCenterActions({ openImmediately: wasDataCenterOpen });
 
   function focusCalendarAtOccurrence(taskId, dateISO){
     const dueISO = String(dateISO || "");
@@ -10653,7 +10654,7 @@ function renderCosts(){
     }
   }
 
-  function setupMaintenanceDataCenterActions(){
+  function setupMaintenanceDataCenterActions(options = {}){
     const openBtn = content.querySelector("[data-open-data-center]");
     const modal = content.querySelector("[data-data-center-modal]");
     const closeBtns = Array.from(content.querySelectorAll("[data-close-data-center]"));
@@ -10690,6 +10691,9 @@ function renderCosts(){
             closeDataCenter();
           }
         });
+      }
+      if (options && options.openImmediately){
+        openDataCenter();
       }
     }
 

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -14429,12 +14429,28 @@ function computeCostModel(){
     });
   });
   const categoryById = new Map();
+  const categoryParentById = new Map();
   if (Array.isArray(window.settingsFolders)){
     window.settingsFolders.forEach(folder => {
       if (!folder || folder.id == null) return;
       categoryById.set(String(folder.id), String(folder.name || "Category"));
+      categoryParentById.set(String(folder.id), folder.parent != null ? String(folder.parent) : null);
     });
   }
+  const resolveCategoryPath = (categoryId)=>{
+    const key = String(categoryId || "");
+    if (!key) return "";
+    const visited = new Set();
+    const names = [];
+    let current = key;
+    while (current && !visited.has(current)){
+      visited.add(current);
+      const name = categoryById.get(current);
+      if (name) names.unshift(name);
+      current = categoryParentById.get(current) || null;
+    }
+    return names.join(" › ");
+  };
   const maintenanceDataTableRows = [];
   const taskDateGroups = new Map();
   taskEventsByDate.forEach((tasksOnDate, dateISO) => {
@@ -14448,8 +14464,13 @@ function computeCostModel(){
       if (!taskDateGroups.has(groupKey)) taskDateGroups.set(groupKey, []);
       taskDateGroups.get(groupKey).push(key);
       const task = taskById.get(originalId) || taskById.get(String(taskMeta.id || "")) || null;
-      const categoryId = task?.cat != null ? String(task.cat) : "";
-      const categoryLabel = categoryId ? (categoryById.get(categoryId) || categoryId) : "";
+      const taskModeRaw = String(task?.mode || taskMeta?.mode || "interval").toLowerCase();
+      const taskMode = taskModeRaw === "asreq" ? "asreq" : "interval";
+      const modeLabel = taskMode === "asreq" ? "As Required" : "Per Interval";
+      const rawCategoryId = task?.cat != null ? String(task.cat) : "";
+      const categoryPath = rawCategoryId ? (resolveCategoryPath(rawCategoryId) || rawCategoryId) : "";
+      const categoryId = `${taskMode}:${rawCategoryId || "uncategorized"}`;
+      const categoryLabel = categoryPath ? `${modeLabel} • ${categoryPath}` : `${modeLabel} • Uncategorized`;
       const maintenanceHours = Number(task?.downtimeHours);
       const maintenanceHrs = Number.isFinite(maintenanceHours) && maintenanceHours > 0 ? maintenanceHours : 1;
       const partCost = Number(taskMeta?.unitPrice);
@@ -14473,7 +14494,8 @@ function computeCostModel(){
         cuttingHoursSince: hoursSince,
         settingsLink: `#/settings?taskId=${encodeURIComponent(originalId)}`,
         categoryId,
-        categoryLabel
+        categoryLabel,
+        taskMode
       });
     });
   });

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10717,9 +10717,7 @@ function renderCosts(){
           if (taskId){
             window.pendingMaintenanceFocus = { taskIds: [taskId] };
           }
-          location.hash = taskId
-            ? `#/settings?taskId=${encodeURIComponent(taskId)}`
-            : "#/settings";
+          location.hash = "#/settings";
           return;
         }
         closeDataCenter();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10611,6 +10611,62 @@ function renderCosts(){
   setupCostTimeframeModal(model);
   setupJobCategoryWindow(model);
   setupWeeklyReportWindow(model);
+  setupMaintenanceDataCenterActions();
+
+  function focusCalendarAtOccurrence(taskId, dateISO){
+    const dueISO = String(dateISO || "");
+    const parsedDue = dueISO && typeof parseDateLocal === "function"
+      ? parseDateLocal(dueISO)
+      : (dueISO ? new Date(dueISO) : null);
+    if (parsedDue instanceof Date && !Number.isNaN(parsedDue.getTime())){
+      parsedDue.setHours(0,0,0,0);
+      const today = new Date();
+      today.setHours(0,0,0,0);
+      const diffMonths = (parsedDue.getFullYear() - today.getFullYear()) * 12 + (parsedDue.getMonth() - today.getMonth());
+      window.__calendarMonthOffset = Math.min(12, Math.max(-12, Math.round(diffMonths)));
+    }
+    if (typeof hideBubble === "function") hideBubble();
+    location.hash = "#/";
+    const runFocus = ()=>{
+      if (typeof renderCalendar === "function") renderCalendar();
+      const months = document.getElementById("months");
+      const cell = dueISO ? months?.querySelector(`[data-date-iso="${dueISO}"]`) : null;
+      if (!cell) return false;
+      cell.scrollIntoView({ behavior: "smooth", block: "center" });
+      if (typeof highlightCalendarDayCell === "function"){
+        highlightCalendarDayCell(cell);
+      }
+      const anchor = taskId ? (cell.querySelector(`[data-cal-task="${String(taskId)}"]`) || cell) : cell;
+      if (taskId && typeof showTaskBubble === "function"){
+        showTaskBubble(String(taskId), anchor, { dateISO: dueISO });
+      }
+      return true;
+    };
+    if (!runFocus()){
+      setTimeout(runFocus, 120);
+      setTimeout(runFocus, 320);
+    }
+  }
+
+  function setupMaintenanceDataCenterActions(){
+    const rows = Array.from(content.querySelectorAll("[data-maintenance-open-task]"));
+    if (!rows.length) return;
+    rows.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", ()=>{
+        const row = btn.closest("tr");
+        const select = row ? row.querySelector("[data-maintenance-link-mode]") : null;
+        const destination = (select instanceof HTMLSelectElement ? select.value : "calendar").toLowerCase();
+        const taskId = String(btn.getAttribute("data-task-id") || "");
+        const dateISO = String(btn.getAttribute("data-date-iso") || "");
+        if (destination === "settings"){
+          location.hash = `#/settings?taskId=${encodeURIComponent(taskId)}`;
+          return;
+        }
+        focusCalendarAtOccurrence(taskId, dateISO);
+      });
+    });
+  }
 
   function setupCostTimeframeModal(currentModel){
     if (typeof window.__cleanupCostTimeframeModal === "function"){
@@ -14251,6 +14307,7 @@ function computeCostModel(){
       const row = maintenanceDataTableRows.find(item => item.taskId === taskId && item.dateISO === dateISO);
       if (!row) return;
       row.qty = qty;
+      row.counter = Math.max(1, qty - index);
       if (index < uniqueDates.length - 1){
         const prev = parseDateLocal(uniqueDates[index + 1]);
         const current = parseDateLocal(dateISO);
@@ -14267,6 +14324,7 @@ function computeCostModel(){
   maintenanceDataTableRows.sort((a,b)=> String(b.dateISO || "").localeCompare(String(a.dateISO || "")));
   const maintenanceDataTable = maintenanceDataTableRows.map((row, idx) => ({
     id: `${row.taskId}_${row.dateISO}_${idx}`,
+    taskId: row.taskId,
     taskName: row.taskName,
     maintenanceHrsLabel: formatHoursValue(row.maintenanceHrs) || "0",
     partCostLabel: formatterCurrency(row.partCost, { decimals: row.partCost < 1000 ? 2 : 0 }),
@@ -14277,7 +14335,8 @@ function computeCostModel(){
     daysSinceLastTaskLabel: Number.isFinite(row.daysSinceLastTask) ? String(row.daysSinceLastTask) : "—",
     cuttingHoursSinceLabel: Number.isFinite(row.cuttingHoursSince) ? formatHoursValue(row.cuttingHoursSince) : "—",
     settingsLink: row.settingsLink,
-    qtyLabel: Number.isFinite(row.qty) ? String(row.qty) : "1"
+    qtyLabel: Number.isFinite(row.qty) ? String(row.qty) : "1",
+    counterLabel: Number.isFinite(row.counter) ? `#${row.counter}` : "#1"
   }));
 
   return {

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10700,6 +10700,8 @@ function renderCosts(){
     }
 
     const searchInput = modal instanceof HTMLElement ? modal.querySelector("[data-maintenance-search]") : null;
+    const categoryFilter = modal instanceof HTMLElement ? modal.querySelector("[data-maintenance-filter-category]") : null;
+    const taskFilter = modal instanceof HTMLElement ? modal.querySelector("[data-maintenance-filter-task]") : null;
     const suggestionsBox = modal instanceof HTMLElement ? modal.querySelector("[data-maintenance-search-suggestions]") : null;
     const suggestionState = { items: [] };
     const computeSuggestions = (term, rows)=>{
@@ -10758,11 +10760,18 @@ function renderCosts(){
     const applySearchFilter = ()=>{
       if (!(modal instanceof HTMLElement)) return;
       const term = String(searchInput instanceof HTMLInputElement ? searchInput.value : "").trim().toLowerCase();
+      const categoryValue = String(categoryFilter instanceof HTMLSelectElement ? categoryFilter.value : "").trim();
+      const taskValue = String(taskFilter instanceof HTMLSelectElement ? taskFilter.value : "").trim().toLowerCase();
       const tableRows = Array.from(modal.querySelectorAll("[data-maintenance-row]"));
       tableRows.forEach(row => {
         if (!(row instanceof HTMLElement)) return;
         const haystack = String(row.getAttribute("data-search-text") || "").toLowerCase();
-        const matches = !term || haystack.includes(term);
+        const rowCategory = String(row.getAttribute("data-category-id") || "");
+        const rowTask = String(row.getAttribute("data-task-key") || "").toLowerCase();
+        const matchesSearch = !term || haystack.includes(term);
+        const matchesCategory = !categoryValue || rowCategory === categoryValue;
+        const matchesTask = !taskValue || rowTask === taskValue;
+        const matches = matchesSearch && matchesCategory && matchesTask;
         row.hidden = !matches;
       });
     };
@@ -10784,6 +10793,18 @@ function renderCosts(){
       });
       applySearchFilter();
       renderSuggestions();
+    }
+    if (categoryFilter instanceof HTMLSelectElement){
+      categoryFilter.addEventListener("change", ()=>{
+        applySearchFilter();
+        renderSuggestions();
+      });
+    }
+    if (taskFilter instanceof HTMLSelectElement){
+      taskFilter.addEventListener("change", ()=>{
+        applySearchFilter();
+        renderSuggestions();
+      });
     }
 
     const rows = Array.from((modal instanceof HTMLElement ? modal : content).querySelectorAll("[data-maintenance-open-task]"));
@@ -14407,6 +14428,13 @@ function computeCostModel(){
       taskById.set(String(task.id), task);
     });
   });
+  const categoryById = new Map();
+  if (Array.isArray(window.settingsFolders)){
+    window.settingsFolders.forEach(folder => {
+      if (!folder || folder.id == null) return;
+      categoryById.set(String(folder.id), String(folder.name || "Category"));
+    });
+  }
   const maintenanceDataTableRows = [];
   const taskDateGroups = new Map();
   taskEventsByDate.forEach((tasksOnDate, dateISO) => {
@@ -14420,6 +14448,8 @@ function computeCostModel(){
       if (!taskDateGroups.has(groupKey)) taskDateGroups.set(groupKey, []);
       taskDateGroups.get(groupKey).push(key);
       const task = taskById.get(originalId) || taskById.get(String(taskMeta.id || "")) || null;
+      const categoryId = task?.cat != null ? String(task.cat) : "";
+      const categoryLabel = categoryId ? (categoryById.get(categoryId) || categoryId) : "";
       const maintenanceHours = Number(task?.downtimeHours);
       const maintenanceHrs = Number.isFinite(maintenanceHours) && maintenanceHours > 0 ? maintenanceHours : 1;
       const partCost = Number(taskMeta?.unitPrice);
@@ -14441,7 +14471,9 @@ function computeCostModel(){
         totalCost,
         dateISO: key,
         cuttingHoursSince: hoursSince,
-        settingsLink: `#/settings?taskId=${encodeURIComponent(originalId)}`
+        settingsLink: `#/settings?taskId=${encodeURIComponent(originalId)}`,
+        categoryId,
+        categoryLabel
       });
     });
   });
@@ -14479,6 +14511,8 @@ function computeCostModel(){
     daysSinceLabel: Number.isFinite(row.daysSinceTask) ? String(row.daysSinceTask) : "—",
     cuttingHoursSinceLabel: Number.isFinite(row.cuttingHoursSince) ? formatHoursValue(row.cuttingHoursSince) : "—",
     settingsLink: row.settingsLink,
+    categoryId: row.categoryId || "",
+    categoryLabel: row.categoryLabel || "",
     qtyLabel: Number.isFinite(row.qty) ? String(row.qty) : "1",
     counterLabel: Number.isFinite(row.counter) ? `#${row.counter}` : "#1"
   }));

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10699,6 +10699,23 @@ function renderCosts(){
       }
     }
 
+    const searchInput = modal instanceof HTMLElement ? modal.querySelector("[data-maintenance-search]") : null;
+    const applySearchFilter = ()=>{
+      if (!(modal instanceof HTMLElement)) return;
+      const term = String(searchInput instanceof HTMLInputElement ? searchInput.value : "").trim().toLowerCase();
+      const tableRows = Array.from(modal.querySelectorAll("[data-maintenance-row]"));
+      tableRows.forEach(row => {
+        if (!(row instanceof HTMLElement)) return;
+        const haystack = String(row.getAttribute("data-search-text") || "").toLowerCase();
+        const matches = !term || haystack.includes(term);
+        row.hidden = !matches;
+      });
+    };
+    if (searchInput instanceof HTMLInputElement){
+      searchInput.addEventListener("input", applySearchFilter);
+      applySearchFilter();
+    }
+
     const rows = Array.from((modal instanceof HTMLElement ? modal : content).querySelectorAll("[data-maintenance-open-task]"));
     if (!rows.length) return;
     rows.forEach(btn => {

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -14376,7 +14376,15 @@ function computeCostModel(){
           row.daysSinceLastTask = null;
         }
       }else{
-        row.daysSinceLastTask = null;
+        const current = parseDateLocal(dateISO);
+        const today = new Date();
+        today.setHours(0,0,0,0);
+        if (current instanceof Date && !Number.isNaN(current.getTime())){
+          current.setHours(0,0,0,0);
+          row.daysSinceLastTask = Math.max(0, Math.round((today.getTime() - current.getTime()) / JOB_DAY_MS));
+        }else{
+          row.daysSinceLastTask = null;
+        }
       }
     });
   });

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -7699,6 +7699,18 @@ function renderSettings(){
     if (!validTaskIds.has(id)) openTaskState.delete(id);
   }
   if (typeof window._maintOrderCounter === "undefined") window._maintOrderCounter = 0;
+  try {
+    const hash = String(window.location?.hash || "");
+    const queryIndex = hash.indexOf("?");
+    if (queryIndex >= 0){
+      const query = hash.slice(queryIndex + 1);
+      const params = new URLSearchParams(query);
+      const taskId = (params.get("taskId") || "").trim();
+      if (taskId){
+        window.pendingMaintenanceFocus = { taskIds: [taskId] };
+      }
+    }
+  } catch (_err){}
 
   // --- one-time hydration for legacy/remote tasks (per-list) ---
   // Previously this only ran if BOTH lists were empty. That prevented legacy
@@ -14187,6 +14199,87 @@ function computeCostModel(){
     emptyMessage: orderRows.length ? "" : "Approve or deny order requests to build the spend log."
   };
 
+  const taskById = new Map();
+  [Array.isArray(intervalTasksAll) ? intervalTasksAll : [], Array.isArray(asReqTasksAll) ? asReqTasksAll : []].forEach(list => {
+    list.forEach(task => {
+      if (!task || task.id == null) return;
+      taskById.set(String(task.id), task);
+    });
+  });
+  const maintenanceDataTableRows = [];
+  const taskDateGroups = new Map();
+  taskEventsByDate.forEach((tasksOnDate, dateISO) => {
+    const key = toHistoryDateKey(dateISO);
+    if (!key || !Array.isArray(tasksOnDate)) return;
+    tasksOnDate.forEach(taskMeta => {
+      if (!taskMeta) return;
+      const originalId = taskMeta.originalId != null ? String(taskMeta.originalId) : (taskMeta.id != null ? String(taskMeta.id) : null);
+      if (!originalId) return;
+      const groupKey = originalId;
+      if (!taskDateGroups.has(groupKey)) taskDateGroups.set(groupKey, []);
+      taskDateGroups.get(groupKey).push(key);
+      const task = taskById.get(originalId) || taskById.get(String(taskMeta.id || "")) || null;
+      const maintenanceHours = Number(task?.downtimeHours);
+      const maintenanceHrs = Number.isFinite(maintenanceHours) && maintenanceHours > 0 ? maintenanceHours : 1;
+      const partCost = Number(taskMeta?.unitPrice);
+      const partCostValue = Number.isFinite(partCost) && partCost > 0 ? partCost : 0;
+      const chargeRate = MAINTENANCE_LABOR_RATE_PER_HOUR;
+      const laborCost = maintenanceHrs * chargeRate;
+      const totalCost = laborCost + partCostValue;
+      const snapshotHours = typeof hoursSnapshotOnOrBefore === "function" ? hoursSnapshotOnOrBefore(key) : null;
+      const hoursSince = (Number.isFinite(Number(currentHours)) && Number.isFinite(Number(snapshotHours)))
+        ? Math.max(0, Number(currentHours) - Number(snapshotHours))
+        : null;
+      maintenanceDataTableRows.push({
+        taskId: originalId,
+        taskName: taskMeta.name || task?.name || "Maintenance task",
+        maintenanceHrs,
+        partCost: partCostValue,
+        chargeRate,
+        laborCost,
+        totalCost,
+        dateISO: key,
+        cuttingHoursSince: hoursSince,
+        settingsLink: `#/settings?taskId=${encodeURIComponent(originalId)}`
+      });
+    });
+  });
+  taskDateGroups.forEach((dateList, taskId) => {
+    const uniqueDates = Array.from(new Set((Array.isArray(dateList) ? dateList : []).filter(Boolean))).sort((a,b)=> b.localeCompare(a));
+    const qty = uniqueDates.length;
+    uniqueDates.forEach((dateISO, index) => {
+      const row = maintenanceDataTableRows.find(item => item.taskId === taskId && item.dateISO === dateISO);
+      if (!row) return;
+      row.qty = qty;
+      if (index < uniqueDates.length - 1){
+        const prev = parseDateLocal(uniqueDates[index + 1]);
+        const current = parseDateLocal(dateISO);
+        if (prev instanceof Date && current instanceof Date && !Number.isNaN(prev.getTime()) && !Number.isNaN(current.getTime())){
+          row.daysSinceLastTask = Math.max(0, Math.round((current.getTime() - prev.getTime()) / JOB_DAY_MS));
+        }else{
+          row.daysSinceLastTask = null;
+        }
+      }else{
+        row.daysSinceLastTask = null;
+      }
+    });
+  });
+  maintenanceDataTableRows.sort((a,b)=> String(b.dateISO || "").localeCompare(String(a.dateISO || "")));
+  const maintenanceDataTable = maintenanceDataTableRows.map((row, idx) => ({
+    id: `${row.taskId}_${row.dateISO}_${idx}`,
+    taskName: row.taskName,
+    maintenanceHrsLabel: formatHoursValue(row.maintenanceHrs) || "0",
+    partCostLabel: formatterCurrency(row.partCost, { decimals: row.partCost < 1000 ? 2 : 0 }),
+    chargeRateLabel: formatterCurrency(row.chargeRate, { decimals: 2 }),
+    laborCostLabel: formatterCurrency(row.laborCost, { decimals: row.laborCost < 1000 ? 2 : 0 }),
+    totalCostLabel: formatterCurrency(row.totalCost, { decimals: row.totalCost < 1000 ? 2 : 0 }),
+    dateISO: row.dateISO,
+    daysSinceLastTaskLabel: Number.isFinite(row.daysSinceLastTask) ? String(row.daysSinceLastTask) : "—",
+    cuttingHoursSinceLabel: Number.isFinite(row.cuttingHoursSince) ? formatHoursValue(row.cuttingHoursSince) : "—",
+    settingsLink: row.settingsLink,
+    qtyLabel: Number.isFinite(row.qty) ? String(row.qty) : "1"
+  }));
+
   return {
     summaryCards,
     timeframeRows,
@@ -14202,6 +14295,7 @@ function computeCostModel(){
     chartNote,
     chartInfo,
     orderRequestSummary,
+    maintenanceDataTable,
     chartColors: COST_CHART_COLORS,
     maintenanceSeries,
     jobSeries,

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -14367,24 +14367,14 @@ function computeCostModel(){
       if (!row) return;
       row.qty = qty;
       row.counter = Math.max(1, qty - index);
-      if (index < uniqueDates.length - 1){
-        const prev = parseDateLocal(uniqueDates[index + 1]);
-        const current = parseDateLocal(dateISO);
-        if (prev instanceof Date && current instanceof Date && !Number.isNaN(prev.getTime()) && !Number.isNaN(current.getTime())){
-          row.daysSinceLastTask = Math.max(0, Math.round((current.getTime() - prev.getTime()) / JOB_DAY_MS));
-        }else{
-          row.daysSinceLastTask = null;
-        }
+      const current = parseDateLocal(dateISO);
+      const today = new Date();
+      today.setHours(0,0,0,0);
+      if (current instanceof Date && !Number.isNaN(current.getTime())){
+        current.setHours(0,0,0,0);
+        row.daysSinceTask = Math.max(0, Math.round((today.getTime() - current.getTime()) / JOB_DAY_MS));
       }else{
-        const current = parseDateLocal(dateISO);
-        const today = new Date();
-        today.setHours(0,0,0,0);
-        if (current instanceof Date && !Number.isNaN(current.getTime())){
-          current.setHours(0,0,0,0);
-          row.daysSinceLastTask = Math.max(0, Math.round((today.getTime() - current.getTime()) / JOB_DAY_MS));
-        }else{
-          row.daysSinceLastTask = null;
-        }
+        row.daysSinceTask = null;
       }
     });
   });
@@ -14399,7 +14389,7 @@ function computeCostModel(){
     laborCostLabel: formatterCurrency(row.laborCost, { decimals: row.laborCost < 1000 ? 2 : 0 }),
     totalCostLabel: formatterCurrency(row.totalCost, { decimals: row.totalCost < 1000 ? 2 : 0 }),
     dateISO: row.dateISO,
-    daysSinceLastTaskLabel: Number.isFinite(row.daysSinceLastTask) ? String(row.daysSinceLastTask) : "—",
+    daysSinceLabel: Number.isFinite(row.daysSinceTask) ? String(row.daysSinceTask) : "—",
     cuttingHoursSinceLabel: Number.isFinite(row.cuttingHoursSince) ? formatHoursValue(row.cuttingHoursSince) : "—",
     settingsLink: row.settingsLink,
     qtyLabel: Number.isFinite(row.qty) ? String(row.qty) : "1",

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10649,6 +10649,39 @@ function renderCosts(){
   }
 
   function setupMaintenanceDataCenterActions(){
+    const openBtn = content.querySelector("[data-open-data-center]");
+    const modal = content.querySelector("[data-data-center-modal]");
+    const closeBtns = Array.from(content.querySelectorAll("[data-close-data-center]"));
+    const closeDataCenter = ()=>{
+      if (!(modal instanceof HTMLElement)) return;
+      modal.setAttribute("hidden", "");
+      modal.setAttribute("aria-hidden", "true");
+      document.body.classList.remove("cost-data-center-open");
+    };
+    const openDataCenter = ()=>{
+      if (!(modal instanceof HTMLElement)) return;
+      modal.removeAttribute("hidden");
+      modal.setAttribute("aria-hidden", "false");
+      document.body.classList.add("cost-data-center-open");
+      try { modal.focus({ preventScroll: true }); } catch (_err){ modal.focus(); }
+      const panel = modal.querySelector(".cost-data-center-panel");
+      if (panel instanceof HTMLElement){
+        panel.scrollTop = 0;
+      }
+    };
+    if (openBtn instanceof HTMLElement && modal instanceof HTMLElement){
+      openBtn.addEventListener("click", openDataCenter);
+      closeBtns.forEach(btn => {
+        if (!(btn instanceof HTMLElement)) return;
+        btn.addEventListener("click", closeDataCenter);
+      });
+      modal.addEventListener("keydown", (event)=>{
+        if (event.key === "Escape" && !modal.hasAttribute("hidden")){
+          closeDataCenter();
+        }
+      });
+    }
+
     const rows = Array.from(content.querySelectorAll("[data-maintenance-open-task]"));
     if (!rows.length) return;
     rows.forEach(btn => {

--- a/js/views.js
+++ b/js/views.js
@@ -1980,6 +1980,7 @@ function viewCosts(model){
               <div class="cost-data-center-search">
                 <label for="costDataCenterSearch">Search table</label>
                 <input id="costDataCenterSearch" type="search" placeholder="Search task, date, counter, or link target" data-maintenance-search>
+                <div class="cost-data-center-search-suggestions" data-maintenance-search-suggestions hidden></div>
               </div>
               ${maintenanceDataTable.length ? `
             <table class="cost-table" style="margin-top:10px">
@@ -2001,7 +2002,7 @@ function viewCosts(model){
               </thead>
               <tbody>
                 ${maintenanceDataTable.map(row => `
-                  <tr data-maintenance-row data-search-text="${esc(`${row.counterLabel || ""} ${row.taskName || ""} ${row.dateISO || ""} ${row.qtyLabel || ""}`.toLowerCase())}">
+                  <tr data-maintenance-row data-task-name="${esc(row.taskName || "")}" data-search-text="${esc(`${row.counterLabel || ""} ${row.taskName || ""} ${row.dateISO || ""} ${row.qtyLabel || ""}`.toLowerCase())}">
                     <td>${esc(row.counterLabel || "#1")}</td>
                     <td>${esc(row.taskName || "Maintenance task")}</td>
                     <td>${esc(row.maintenanceHrsLabel || "0")}</td>

--- a/js/views.js
+++ b/js/views.js
@@ -1214,6 +1214,20 @@ function viewCosts(model){
   const orderSummary = data.orderRequestSummary || {};
   const orderRows = Array.isArray(orderSummary.rows) ? orderSummary.rows : [];
   const maintenanceDataTable = Array.isArray(data.maintenanceDataTable) ? data.maintenanceDataTable : [];
+  const maintenanceCategoryOptions = Array.from(new Set(
+    maintenanceDataTable
+      .map(row => ({ id: String(row?.categoryId || ""), label: String(row?.categoryLabel || "") }))
+      .filter(entry => entry.id && entry.label)
+      .map(entry => `${entry.id}|||${entry.label}`)
+  )).map(entry => {
+    const [id, label] = entry.split("|||");
+    return { id, label };
+  }).sort((a, b) => a.label.localeCompare(b.label));
+  const maintenanceTaskOptions = Array.from(new Set(
+    maintenanceDataTable
+      .map(row => String(row?.taskName || "").trim())
+      .filter(Boolean)
+  )).sort((a, b) => a.localeCompare(b));
   const overviewInsight = data.overviewInsight || "Totals blend the latest maintenance allocations, consumable burn rates, downtime burdens, and job margin data so you always see current cost exposure.";
   const ordersInsight = data.ordersInsight || "Tracks every waterjet part request from submission through approval so finance can confirm spend and spot stalled orders.";
   const timeframeInsight = data.timeframeInsight || "Usage windows combine logged machine hours with interval pricing to estimate what each upcoming maintenance window will cost.";
@@ -1980,6 +1994,16 @@ function viewCosts(model){
               <div class="cost-data-center-search">
                 <label for="costDataCenterSearch">Search table</label>
                 <input id="costDataCenterSearch" type="search" placeholder="Search task, date, counter, or link target" data-maintenance-search>
+                <label for="costDataCenterCategoryFilter">Filter by category</label>
+                <select id="costDataCenterCategoryFilter" data-maintenance-filter-category>
+                  <option value="">All categories</option>
+                  ${maintenanceCategoryOptions.map(opt => `<option value="${esc(opt.id)}">${esc(opt.label)}</option>`).join("")}
+                </select>
+                <label for="costDataCenterTaskFilter">Filter by task</label>
+                <select id="costDataCenterTaskFilter" data-maintenance-filter-task>
+                  <option value="">All tasks</option>
+                  ${maintenanceTaskOptions.map(name => `<option value="${esc(name.toLowerCase())}">${esc(name)}</option>`).join("")}
+                </select>
                 <div class="cost-data-center-search-suggestions" data-maintenance-search-suggestions hidden></div>
               </div>
               ${maintenanceDataTable.length ? `
@@ -2002,7 +2026,7 @@ function viewCosts(model){
               </thead>
               <tbody>
                 ${maintenanceDataTable.map(row => `
-                  <tr data-maintenance-row data-task-name="${esc(row.taskName || "")}" data-search-text="${esc(`${row.counterLabel || ""} ${row.taskName || ""} ${row.dateISO || ""} ${row.qtyLabel || ""}`.toLowerCase())}">
+                  <tr data-maintenance-row data-category-id="${esc(String(row.categoryId || ""))}" data-task-key="${esc(String(row.taskName || "").toLowerCase())}" data-task-name="${esc(row.taskName || "")}" data-search-text="${esc(`${row.counterLabel || ""} ${row.taskName || ""} ${row.dateISO || ""} ${row.qtyLabel || ""}`.toLowerCase())}">
                     <td>${esc(row.counterLabel || "#1")}</td>
                     <td>${esc(row.taskName || "Maintenance task")}</td>
                     <td>${esc(row.maintenanceHrsLabel || "0")}</td>

--- a/js/views.js
+++ b/js/views.js
@@ -1967,12 +1967,17 @@ function viewCosts(model){
 
       <div class="dashboard-window" data-cost-window="dataCenter">
         <div class="block">
-          <details class="cost-data-center" data-cost-data-center>
-            <summary>
-              <h3>Maintenance Data Center Table</h3>
-              <span class="small muted">Click to ${maintenanceDataTable.length ? "expand" : "view"}.</span>
-            </summary>
-            ${maintenanceDataTable.length ? `
+          <h3>Maintenance Data Center Table</h3>
+          <div class="small muted" style="margin-bottom:8px;">Open as a full-size popup for review and auditing.</div>
+          <button type="button" class="secondary" data-open-data-center ${maintenanceDataTable.length ? "" : "disabled"}>Open Data Center</button>
+          <div class="cost-data-center-modal" data-data-center-modal hidden aria-hidden="true" tabindex="-1">
+            <div class="cost-data-center-backdrop" data-close-data-center></div>
+            <div class="cost-data-center-panel" role="dialog" aria-modal="true" aria-labelledby="dataCenterTitle">
+              <div class="cost-data-center-header">
+                <h3 id="dataCenterTitle">Maintenance Data Center Table</h3>
+                <button type="button" class="secondary" data-close-data-center>Close</button>
+              </div>
+              ${maintenanceDataTable.length ? `
             <table class="cost-table" style="margin-top:10px">
               <thead>
                 <tr>
@@ -2021,7 +2026,8 @@ function viewCosts(model){
               </tbody>
             </table>
             ` : `<p class="small muted">No completed maintenance occurrences yet.</p>`}
-          </details>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/js/views.js
+++ b/js/views.js
@@ -1213,6 +1213,7 @@ function viewCosts(model){
   const chartInfo = data.chartInfo || "Maintenance cost line spreads interval pricing and approved as-required spend across logged machine hours; cutting jobs line tracks the rolling average gain or loss per completed job to spotlight margin drift.";
   const orderSummary = data.orderRequestSummary || {};
   const orderRows = Array.isArray(orderSummary.rows) ? orderSummary.rows : [];
+  const maintenanceDataTable = Array.isArray(data.maintenanceDataTable) ? data.maintenanceDataTable : [];
   const overviewInsight = data.overviewInsight || "Totals blend the latest maintenance allocations, consumable burn rates, downtime burdens, and job margin data so you always see current cost exposure.";
   const ordersInsight = data.ordersInsight || "Tracks every waterjet part request from submission through approval so finance can confirm spend and spot stalled orders.";
   const timeframeInsight = data.timeframeInsight || "Usage windows combine logged machine hours with interval pricing to estimate what each upcoming maintenance window will cost.";
@@ -1961,6 +1962,48 @@ function viewCosts(model){
               </div>
             </div>
           </div>
+        </div>
+      </div>
+
+      <div class="dashboard-window" data-cost-window="dataCenter">
+        <div class="block">
+          <h3>Maintenance Data Center Table</h3>
+          ${maintenanceDataTable.length ? `
+            <table class="cost-table">
+              <thead>
+                <tr>
+                  <th>Task</th>
+                  <th>Maint. hrs</th>
+                  <th>Part cost</th>
+                  <th>Rate/hr</th>
+                  <th>Labor cost</th>
+                  <th>Total cost</th>
+                  <th>Date</th>
+                  <th>Days since last</th>
+                  <th>Cut hrs since</th>
+                  <th>Qty</th>
+                  <th>Settings link</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${maintenanceDataTable.map(row => `
+                  <tr>
+                    <td>${esc(row.taskName || "Maintenance task")}</td>
+                    <td>${esc(row.maintenanceHrsLabel || "0")}</td>
+                    <td>${esc(row.partCostLabel || "$0.00")}</td>
+                    <td>${esc(row.chargeRateLabel || "$0.00")}</td>
+                    <td>${esc(row.laborCostLabel || "$0.00")}</td>
+                    <td>${esc(row.totalCostLabel || "$0.00")}</td>
+                    <td>${esc(row.dateISO || "—")}</td>
+                    <td>${esc(row.daysSinceLastTaskLabel || "—")}</td>
+                    <td>${esc(row.cuttingHoursSinceLabel || "—")}</td>
+                    <td>${esc(row.qtyLabel || "1")}</td>
+                    <td><a href="${esc(row.settingsLink || "#/settings")}" data-maintenance-link>Open task</a></td>
+                  </tr>
+                `).join("")}
+              </tbody>
+            </table>
+          ` : `<p class="small muted">No completed maintenance occurrences yet.</p>`}
         </div>
       </div>
 

--- a/js/views.js
+++ b/js/views.js
@@ -1967,11 +1967,16 @@ function viewCosts(model){
 
       <div class="dashboard-window" data-cost-window="dataCenter">
         <div class="block">
-          <h3>Maintenance Data Center Table</h3>
-          ${maintenanceDataTable.length ? `
-            <table class="cost-table">
+          <details class="cost-data-center" data-cost-data-center>
+            <summary>
+              <h3>Maintenance Data Center Table</h3>
+              <span class="small muted">Click to ${maintenanceDataTable.length ? "expand" : "view"}.</span>
+            </summary>
+            ${maintenanceDataTable.length ? `
+            <table class="cost-table" style="margin-top:10px">
               <thead>
                 <tr>
+                  <th>Counter</th>
                   <th>Task</th>
                   <th>Maint. hrs</th>
                   <th>Part cost</th>
@@ -1982,12 +1987,13 @@ function viewCosts(model){
                   <th>Days since last</th>
                   <th>Cut hrs since</th>
                   <th>Qty</th>
-                  <th>Settings link</th>
+                  <th>Task link</th>
                 </tr>
               </thead>
               <tbody>
                 ${maintenanceDataTable.map(row => `
                   <tr>
+                    <td>${esc(row.counterLabel || "#1")}</td>
                     <td>${esc(row.taskName || "Maintenance task")}</td>
                     <td>${esc(row.maintenanceHrsLabel || "0")}</td>
                     <td>${esc(row.partCostLabel || "$0.00")}</td>
@@ -1998,12 +2004,24 @@ function viewCosts(model){
                     <td>${esc(row.daysSinceLastTaskLabel || "—")}</td>
                     <td>${esc(row.cuttingHoursSinceLabel || "—")}</td>
                     <td>${esc(row.qtyLabel || "1")}</td>
-                    <td><a href="${esc(row.settingsLink || "#/settings")}" data-maintenance-link>Open task</a></td>
+                    <td>
+                      <label class="sr-only" for="maintenanceLinkMode_${esc(row.id || "")}">Destination</label>
+                      <select id="maintenanceLinkMode_${esc(row.id || "")}" data-maintenance-link-mode>
+                        <option value="calendar">Calendar</option>
+                        <option value="settings">Maintenance Settings</option>
+                      </select>
+                      <button type="button"
+                        data-maintenance-open-task
+                        data-task-id="${esc(row.taskId || "")}"
+                        data-date-iso="${esc(row.dateISO || "")}"
+                        data-settings-link="${esc(row.settingsLink || "#/settings")}">Open task</button>
+                    </td>
                   </tr>
                 `).join("")}
               </tbody>
             </table>
-          ` : `<p class="small muted">No completed maintenance occurrences yet.</p>`}
+            ` : `<p class="small muted">No completed maintenance occurrences yet.</p>`}
+          </details>
         </div>
       </div>
 

--- a/js/views.js
+++ b/js/views.js
@@ -1989,7 +1989,7 @@ function viewCosts(model){
                   <th>Labor cost</th>
                   <th>Total cost</th>
                   <th>Date</th>
-                  <th>Days since last</th>
+                  <th>Days since</th>
                   <th>Cut hrs since</th>
                   <th>Qty</th>
                   <th>Task link</th>
@@ -2006,7 +2006,7 @@ function viewCosts(model){
                     <td>${esc(row.laborCostLabel || "$0.00")}</td>
                     <td>${esc(row.totalCostLabel || "$0.00")}</td>
                     <td>${esc(row.dateISO || "—")}</td>
-                    <td>${esc(row.daysSinceLastTaskLabel || "—")}</td>
+                    <td>${esc(row.daysSinceLabel || "—")}</td>
                     <td>${esc(row.cuttingHoursSinceLabel || "—")}</td>
                     <td>${esc(row.qtyLabel || "1")}</td>
                     <td>

--- a/js/views.js
+++ b/js/views.js
@@ -1977,6 +1977,10 @@ function viewCosts(model){
                 <h3 id="dataCenterTitle">Maintenance Data Center Table</h3>
                 <button type="button" class="secondary" data-close-data-center>Close</button>
               </div>
+              <div class="cost-data-center-search">
+                <label for="costDataCenterSearch">Search table</label>
+                <input id="costDataCenterSearch" type="search" placeholder="Search task, date, counter, or link target" data-maintenance-search>
+              </div>
               ${maintenanceDataTable.length ? `
             <table class="cost-table" style="margin-top:10px">
               <thead>
@@ -1997,7 +2001,7 @@ function viewCosts(model){
               </thead>
               <tbody>
                 ${maintenanceDataTable.map(row => `
-                  <tr>
+                  <tr data-maintenance-row data-search-text="${esc(`${row.counterLabel || ""} ${row.taskName || ""} ${row.dateISO || ""} ${row.qtyLabel || ""}`.toLowerCase())}">
                     <td>${esc(row.counterLabel || "#1")}</td>
                     <td>${esc(row.taskName || "Maintenance task")}</td>
                     <td>${esc(row.maintenanceHrsLabel || "0")}</td>

--- a/js/views.js
+++ b/js/views.js
@@ -2019,6 +2019,7 @@ function viewCosts(model){
                         data-maintenance-open-task
                         data-task-id="${esc(row.taskId || "")}"
                         data-date-iso="${esc(row.dateISO || "")}"
+                        data-link-mode-id="maintenanceLinkMode_${esc(row.id || "")}"
                         data-settings-link="${esc(row.settingsLink || "#/settings")}">Open task</button>
                     </td>
                   </tr>

--- a/js/views.js
+++ b/js/views.js
@@ -1970,7 +1970,7 @@ function viewCosts(model){
           <h3>Maintenance Data Center Table</h3>
           <div class="small muted" style="margin-bottom:8px;">Open as a full-size popup for review and auditing.</div>
           <button type="button" class="secondary" data-open-data-center ${maintenanceDataTable.length ? "" : "disabled"}>Open Data Center</button>
-          <div class="cost-data-center-modal" data-data-center-modal hidden aria-hidden="true" tabindex="-1">
+          <div id="costDataCenterModal" class="cost-data-center-modal" data-data-center-modal hidden aria-hidden="true" tabindex="-1">
             <div class="cost-data-center-backdrop" data-close-data-center></div>
             <div class="cost-data-center-panel" role="dialog" aria-modal="true" aria-labelledby="dataCenterTitle">
               <div class="cost-data-center-header">

--- a/style.css
+++ b/style.css
@@ -500,6 +500,21 @@ body.pump-notes-open { overflow:hidden; }
 .cost-timeframe-row:focus-visible{ outline:2px solid var(--brand-blue-400, #2563eb); outline-offset:2px; }
 .cost-timeframe-section .small.muted{ margin-top:0; }
 body.cost-timeframe-modal-open{ overflow:hidden; }
+.cost-data-center-modal{ position:fixed; inset:0; z-index:1550; display:flex; align-items:center; justify-content:center; padding:24px; }
+.cost-data-center-modal[hidden]{ display:none; }
+.cost-data-center-backdrop{ position:absolute; inset:0; background:rgba(15,23,42,0.5); }
+.cost-data-center-panel{
+  position:relative;
+  width:min(1400px,96vw);
+  max-height:88vh;
+  overflow:auto;
+  background:#fff;
+  border-radius:12px;
+  box-shadow:0 20px 46px rgba(2,8,20,.35);
+  padding:16px;
+}
+.cost-data-center-header{ display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
+body.cost-data-center-open{ overflow:hidden; }
 @media (max-width: 640px){
   .cost-timeframe-card-body{ padding:24px 18px 28px; }
   .cost-timeframe-table th,.cost-timeframe-table td{ padding:8px 10px; }

--- a/style.css
+++ b/style.css
@@ -500,13 +500,13 @@ body.pump-notes-open { overflow:hidden; }
 .cost-timeframe-row:focus-visible{ outline:2px solid var(--brand-blue-400, #2563eb); outline-offset:2px; }
 .cost-timeframe-section .small.muted{ margin-top:0; }
 body.cost-timeframe-modal-open{ overflow:hidden; }
-.cost-data-center-modal{ position:fixed; inset:0; z-index:1550; display:flex; align-items:center; justify-content:center; padding:24px; }
+.cost-data-center-modal{ position:fixed; inset:0; z-index:99999; display:flex; align-items:center; justify-content:center; padding:24px; }
 .cost-data-center-modal[hidden]{ display:none; }
 .cost-data-center-backdrop{ position:absolute; inset:0; background:rgba(15,23,42,0.5); }
 .cost-data-center-panel{
   position:relative;
-  width:min(1400px,96vw);
-  max-height:88vh;
+  width:min(1600px,98vw);
+  max-height:92vh;
   overflow:auto;
   background:#fff;
   border-radius:12px;

--- a/style.css
+++ b/style.css
@@ -518,6 +518,9 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
 .cost-data-center-search{ display:flex; flex-direction:column; gap:6px; margin-bottom:10px; max-width:360px; }
 .cost-data-center-search label{ font-weight:600; font-size:14px; }
 .cost-data-center-search input{ border:1px solid #9aa6bb; border-radius:6px; padding:8px 10px; font-size:14px; color:#000; background:#fff; }
+.cost-data-center-search-suggestions{ display:flex; flex-direction:column; gap:4px; border:1px solid #b9c4d6; border-radius:6px; background:#fff; padding:4px; }
+.cost-data-center-suggestion{ text-align:left; border:0; background:#f4f7ff; color:#000; padding:6px 8px; border-radius:4px; cursor:pointer; font-size:13px; }
+.cost-data-center-suggestion:hover{ background:#e7eeff; }
 .cost-data-center-panel h3,
 .cost-data-center-panel .small,
 .cost-data-center-panel .muted,

--- a/style.css
+++ b/style.css
@@ -512,8 +512,20 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
   border-radius:12px;
   box-shadow:0 20px 46px rgba(2,8,20,.35);
   padding:16px;
+  color:#000;
 }
 .cost-data-center-header{ display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
+.cost-data-center-panel h3,
+.cost-data-center-panel .small,
+.cost-data-center-panel .muted,
+.cost-data-center-panel .cost-table,
+.cost-data-center-panel .cost-table th,
+.cost-data-center-panel .cost-table td,
+.cost-data-center-panel label,
+.cost-data-center-panel select,
+.cost-data-center-panel button{
+  color:#000;
+}
 body.cost-data-center-open{ overflow:hidden; }
 @media (max-width: 640px){
   .cost-timeframe-card-body{ padding:24px 18px 28px; }

--- a/style.css
+++ b/style.css
@@ -515,6 +515,9 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
   color:#000;
 }
 .cost-data-center-header{ display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
+.cost-data-center-search{ display:flex; flex-direction:column; gap:6px; margin-bottom:10px; max-width:360px; }
+.cost-data-center-search label{ font-weight:600; font-size:14px; }
+.cost-data-center-search input{ border:1px solid #9aa6bb; border-radius:6px; padding:8px 10px; font-size:14px; color:#000; background:#fff; }
 .cost-data-center-panel h3,
 .cost-data-center-panel .small,
 .cost-data-center-panel .muted,


### PR DESCRIPTION
### Motivation
- Provide a single, auditable data table (the "data center") that exposes every completed maintenance occurrence used by the cost analysis so downstream charts/tables can be traced back to a canonical source.
- Make it easy to jump from data rows into Maintenance Settings for inspection and edits via a deep-link.

### Description
- Added a new "Maintenance Data Center Table" window to the Cost Analysis view that lists occurrence-level rows with task name, maintenance hrs, part cost, labor rate, labor cost, total cost, occurrence date (newest first), days-since-previous, cutting-hours-since, quantity, and a settings link. (`js/views.js`)
- Built server-side/UI model wiring inside the cost computation to assemble `maintenanceDataTable` from the existing calendar/occurrence history and cost-linking logic so the table is derived from the same source as the cost model. (`js/renderers.js`, inside `computeCostModel()`)
- Added URL-hash query handling in `renderSettings()` so links like `#/settings?taskId=<id>` set a pending focus that automatically opens and highlights the referenced maintenance task in Maintenance Settings. (`js/renderers.js`) 
- Small compatibility fixes: use the existing task sets when mapping occurrences; sorting and human-friendly labels are produced with existing helpers (no schema changes or deletions of saved Firebase data).

### Testing
- Ran JavaScript syntax checks: `node --check js/views.js` (succeeded) and `node --check js/renderers.js` (succeeded).
- Ran repository binary check: `python scripts/check_binaries.py` (succeeded).
- No automated UI tests available in this environment; changes are additive and preserve existing persisted data.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64906d87883259cd91e5f27403b61)