### PR TITLE
Add receipt tracker popup to Cost Analysis weekly reports

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1607,6 +1607,7 @@ if (!Array.isArray(window.garnetCleanings)) window.garnetCleanings = [];
 if (!Array.isArray(window.dailyCutHours)) window.dailyCutHours = [];
 if (!Array.isArray(window.opportunityRollups)) window.opportunityRollups = [];
 if (!Array.isArray(window.weeklyCostReports)) window.weeklyCostReports = [];
+if (!Array.isArray(window.receiptTrackerWeeks)) window.receiptTrackerWeeks = [];
 if (!Array.isArray(window.jobFolders)) window.jobFolders = defaultJobFolders();
 if (typeof window.orderRequestTab !== "string") window.orderRequestTab = "active";
 
@@ -1629,6 +1630,7 @@ let garnetCleanings = window.garnetCleanings;
 let dailyCutHours = window.dailyCutHours;
 let jobFolders = window.jobFolders;
 let weeklyCostReports = window.weeklyCostReports;
+let receiptTrackerWeeks = window.receiptTrackerWeeks;
 
 function normalizeJobPriorityOrder(list){
   if (!Array.isArray(list)) return list;
@@ -1879,6 +1881,7 @@ window.defaultAsReqTasks = defaultAsReqTasks;
     copyArr("completedCuttingJobs");
     copyArr("dailyCutHours");
     copyArr("orderRequests");
+    copyArr("receiptTrackerWeeks");
     copyArr("garnetCleanings");
     copyArr("totalHistory");
     copyObj("appConfig");
@@ -1904,6 +1907,7 @@ window.defaultAsReqTasks = defaultAsReqTasks;
     if (!Array.isArray(sanitized.dailyCutHours) && Array.isArray(window.dailyCutHours)) sanitized.dailyCutHours = window.dailyCutHours.slice();
     if (!Array.isArray(sanitized.inventory) && Array.isArray(window.inventory)) sanitized.inventory = window.inventory.slice();
     if (!Array.isArray(sanitized.orderRequests) && Array.isArray(window.orderRequests)) sanitized.orderRequests = window.orderRequests.slice();
+    if (!Array.isArray(sanitized.receiptTrackerWeeks) && Array.isArray(window.receiptTrackerWeeks)) sanitized.receiptTrackerWeeks = window.receiptTrackerWeeks.slice();
     if (!Array.isArray(sanitized.garnetCleanings) && Array.isArray(window.garnetCleanings)) sanitized.garnetCleanings = window.garnetCleanings.slice();
     if (!Array.isArray(sanitized.totalHistory) && Array.isArray(window.totalHistory)) sanitized.totalHistory = window.totalHistory.slice();
     if (!Array.isArray(sanitized.deletedItems) && Array.isArray(window.deletedItems)) sanitized.deletedItems = window.deletedItems.slice();
@@ -1924,6 +1928,7 @@ window.defaultAsReqTasks = defaultAsReqTasks;
     window.appConfig = appConfig;
     refreshDerivedDailyHours();
     if (!Array.isArray(window.orderRequests)) window.orderRequests = [];
+    if (!Array.isArray(window.receiptTrackerWeeks)) window.receiptTrackerWeeks = [];
     if (!Array.isArray(window.garnetCleanings)) window.garnetCleanings = [];
     if (!Array.isArray(window.totalHistory)) window.totalHistory = [];
     if (!window.settingsFolders || !Array.isArray(window.settingsFolders)) window.settingsFolders = typeof defaultSettingsFolders === "function" ? defaultSettingsFolders() : [];
@@ -1958,6 +1963,7 @@ function stateHasMeaningfulData(data){
     "completedCuttingJobs",
     "dailyCutHours",
     "orderRequests",
+    "receiptTrackerWeeks",
     "totalHistory",
     "garnetCleanings",
     "deletedItems",
@@ -2077,6 +2083,9 @@ function snapshotState(){
     cuttingJobs: stripJobFileDataUrls(cuttingJobs),
     completedCuttingJobs: stripJobFileDataUrls(completedCuttingJobs),
     orderRequests,
+    receiptTrackerWeeks: Array.isArray(window.receiptTrackerWeeks)
+      ? window.receiptTrackerWeeks.map(entry => ({ ...entry }))
+      : [],
     orderRequestTab,
     garnetCleanings,
     dailyCutHours: Array.isArray(dailyCutHours)
@@ -2778,6 +2787,7 @@ function adoptState(doc){
   dailyCutHours = normalizeDailyCutHours(Array.isArray(data.dailyCutHours) ? data.dailyCutHours : []);
   opportunityRollups = Array.isArray(data.opportunityRollups) ? data.opportunityRollups : [];
   weeklyCostReports = Array.isArray(data.weeklyCostReports) ? data.weeklyCostReports.map(entry => ({ ...entry })) : [];
+  receiptTrackerWeeks = Array.isArray(data.receiptTrackerWeeks) ? data.receiptTrackerWeeks.map(entry => ({ ...entry })) : [];
 
   window.totalHistory = totalHistory;
   window.tasksInterval = tasksInterval;
@@ -2790,6 +2800,7 @@ function adoptState(doc){
   window.dailyCutHours = dailyCutHours;
   window.opportunityRollups = opportunityRollups;
   window.weeklyCostReports = weeklyCostReports;
+  window.receiptTrackerWeeks = receiptTrackerWeeks;
   deletedItems = normalizeDeletedItems(Array.isArray(data.deletedItems) ? data.deletedItems : deletedItems);
   window.deletedItems = deletedItems;
   purgeExpiredDeletedItems();
@@ -3075,6 +3086,7 @@ async function loadFromCloud(){
         cuttingJobs: Array.isArray(window.cuttingJobs) ? window.cuttingJobs.slice() : [],
         completedCuttingJobs: Array.isArray(window.completedCuttingJobs) ? window.completedCuttingJobs.slice() : [],
         orderRequests: Array.isArray(window.orderRequests) && window.orderRequests.length ? window.orderRequests.slice() : [typeof createOrderRequest === "function" ? createOrderRequest() : { id:"req_"+Date.now(), items:[] }],
+        receiptTrackerWeeks: Array.isArray(window.receiptTrackerWeeks) ? window.receiptTrackerWeeks.slice() : [],
         orderRequestTab: typeof window.orderRequestTab === "string" ? window.orderRequestTab : "active",
         dailyCutHours: Array.isArray(window.dailyCutHours) ? window.dailyCutHours.slice() : [],
         opportunityRollups: Array.isArray(window.opportunityRollups) ? window.opportunityRollups.slice() : [],
@@ -3308,6 +3320,7 @@ const pumpDefaults = { baselineRPM:null, baselineDateISO:null, entries:[], notes
     cuttingJobs: [],
     completedCuttingJobs: [],
     orderRequests: [createOrderRequest()],
+    receiptTrackerWeeks: [],
     orderRequestTab: "active",
     dailyCutHours: [],
     opportunityRollups: [],

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10967,8 +10967,9 @@ function renderCosts(){
       cost: Number(item?.cost) || 0,
       qty: Number(item?.qty) || 0,
       partNumber: String(item?.partNumber || ""),
-      shipping: Number(item?.shipping) || 0
-    })).filter(row => row.date || row.purchased || row.cost || row.qty || row.partNumber || row.shipping);
+      shipping: Number(item?.shipping) || 0,
+      tax: Number(item?.tax) || 0
+    })).filter(row => row.date || row.purchased || row.cost || row.qty || row.partNumber || row.shipping || row.tax);
     const getWeekEntry = (key)=>{
       const existing = window.receiptTrackerWeeks.find(entry => String(entry?.key || "") === key);
       if (existing) return existing;
@@ -10977,7 +10978,7 @@ function renderCosts(){
       window.receiptTrackerWeeks.push(created);
       return created;
     };
-    const computeRowTotal = (row)=> ((Number(row?.cost) || 0) * (Number(row?.qty) || 0)) + (Number(row?.shipping) || 0);
+    const computeRowTotal = (row)=> ((Number(row?.cost) || 0) * (Number(row?.qty) || 0)) + (Number(row?.shipping) || 0) + (Number(row?.tax) || 0);
     const buildRangeRows = (months)=>{
       const end = new Date();
       const start = months === "all" ? null : new Date(end.getFullYear(), end.getMonth() - Number(months), end.getDate());
@@ -11040,7 +11041,8 @@ function renderCosts(){
           cost: Number(tr.querySelector('[data-col=\"cost\"]')?.value) || 0,
           qty: Number(tr.querySelector('[data-col=\"qty\"]')?.value) || 0,
           partNumber: String(tr.querySelector('[data-col=\"partNumber\"]')?.value || "").trim(),
-          shipping: Number(tr.querySelector('[data-col=\"shipping\"]')?.value) || 0
+          shipping: Number(tr.querySelector('[data-col=\"shipping\"]')?.value) || 0,
+          tax: Number(tr.querySelector('[data-col=\"tax\"]')?.value) || 0
         }));
         entry.rows = normalizeRows(rows);
         persistReceiptState();
@@ -11057,6 +11059,7 @@ function renderCosts(){
           <td><input type="number" min="0" step="0.01" data-col="qty" placeholder="0"></td>
           <td><input type="text" data-col="partNumber" placeholder="Part #"></td>
           <td><input type="number" min="0" step="0.01" data-col="shipping" placeholder="0.00"></td>
+          <td><input type="number" min="0" step="0.01" data-col="tax" placeholder="0.00"></td>
           <td data-col="total">${formatUsd(0)}</td>`;
         weekRowsBody.appendChild(tr);
         if (focusFirst){
@@ -11071,7 +11074,8 @@ function renderCosts(){
           const row = {
             cost: Number(tr.querySelector('[data-col=\"cost\"]')?.value) || 0,
             qty: Number(tr.querySelector('[data-col=\"qty\"]')?.value) || 0,
-            shipping: Number(tr.querySelector('[data-col=\"shipping\"]')?.value) || 0
+            shipping: Number(tr.querySelector('[data-col=\"shipping\"]')?.value) || 0,
+            tax: Number(tr.querySelector('[data-col=\"tax\"]')?.value) || 0
           };
           const total = computeRowTotal(row);
           subtotal += total;
@@ -11095,6 +11099,7 @@ function renderCosts(){
             <td><input type="number" min="0" step="0.01" data-col="qty" value="${escapeHtml(String(row.qty || 0))}"></td>
             <td><input type="text" data-col="partNumber" value="${escapeHtml(row.partNumber || "")}"></td>
             <td><input type="number" min="0" step="0.01" data-col="shipping" value="${escapeHtml(String(row.shipping || 0))}"></td>
+            <td><input type="number" min="0" step="0.01" data-col="tax" value="${escapeHtml(String(row.tax || 0))}"></td>
             <td data-col="total">${formatUsd(computeRowTotal(row))}</td>
           </tr>`).join("");
         appendEmptyRow();
@@ -11111,9 +11116,10 @@ function renderCosts(){
             <td>${escapeHtml(String(row.qty || 0))}</td>
             <td>${escapeHtml(row.partNumber || "—")}</td>
             <td>${formatUsd(row.shipping || 0)}</td>
+            <td>${formatUsd(row.tax || 0)}</td>
             <td>${formatUsd(row.total || 0)}</td>
             <td></td>
-          </tr>`).join("") : '<tr><td colspan="7" class="cost-table-placeholder">No receipt rows in this range.</td></tr>';
+          </tr>`).join("") : '<tr><td colspan="8" class="cost-table-placeholder">No receipt rows in this range.</td></tr>';
         if (rangeSubtotal) rangeSubtotal.textContent = formatUsd(subtotal);
       };
       const bindRowEvents = ()=>{
@@ -11125,7 +11131,7 @@ function renderCosts(){
           event.preventDefault();
           const row = input.closest("tr[data-receipt-row]");
           if (!row) return;
-          const columns = ["date", "purchased", "cost", "qty", "partNumber", "shipping"];
+          const columns = ["date", "purchased", "cost", "qty", "partNumber", "shipping", "tax"];
           const col = input.getAttribute("data-col") || "";
           const idx = columns.indexOf(col);
           if (idx < 0) return;
@@ -11173,9 +11179,9 @@ function renderCosts(){
           const rows = normalizeRows(entry.rows);
           const subtotal = rows.reduce((sum, row) => sum + computeRowTotal(row), 0);
           const payload = [
-            ["Date", "Purchased", "Cost", "Qty", "Part number", "Shipping", "Total"],
-            ...rows.map(row => [row.date, row.purchased, row.cost, row.qty, row.partNumber, row.shipping, computeRowTotal(row)]),
-            ["", "", "", "", "", "Subtotal", subtotal]
+            ["Date", "Purchased", "Cost", "Qty", "Part number", "Shipping", "Tax", "Total"],
+            ...rows.map(row => [row.date, row.purchased, row.cost, row.qty, row.partNumber, row.shipping, row.tax, computeRowTotal(row)]),
+            ["", "", "", "", "", "", "Subtotal", subtotal]
           ];
           downloadCsv(`receipt-week-${entry.key}.csv`, payload);
         });
@@ -11185,9 +11191,9 @@ function renderCosts(){
           const rows = buildRangeRows(activeRange);
           const subtotal = rows.reduce((sum, row) => sum + row.total, 0);
           const payload = [
-            ["Date", "Purchased", "Qty", "Part number", "Shipping", "Total"],
-            ...rows.map(row => [row.date, row.purchased, row.qty, row.partNumber, row.shipping, row.total]),
-            ["", "", "", "", "Subtotal", subtotal]
+            ["Date", "Purchased", "Qty", "Part number", "Shipping", "Tax", "Total"],
+            ...rows.map(row => [row.date, row.purchased, row.qty, row.partNumber, row.shipping, row.tax, row.total]),
+            ["", "", "", "", "", "Subtotal", subtotal]
           ];
           downloadCsv(`receipt-range-${activeRange}.csv`, payload);
         });

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10556,6 +10556,10 @@ function setupForecastBreakdownModal(){
 function renderCosts(){
   const content = document.getElementById("content");
   if (!content) return;
+  const existingReceiptModal = document.getElementById("costReceiptModal");
+  if (existingReceiptModal instanceof HTMLElement){
+    window.costPurchaseHistoryModalOpen = !existingReceiptModal.hasAttribute("hidden");
+  }
 
   const escapeHtml = (str)=> String(str ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
 
@@ -11202,15 +11206,20 @@ function renderCosts(){
         modal.hidden = false;
         modal.setAttribute("aria-hidden", "false");
         document.body.classList.add("cost-receipt-modal-open");
+        window.costPurchaseHistoryModalOpen = true;
       };
       const closeModal = ()=>{
         saveWeekRowsFromDom();
         modal.hidden = true;
         modal.setAttribute("aria-hidden", "true");
         document.body.classList.remove("cost-receipt-modal-open");
+        window.costPurchaseHistoryModalOpen = false;
       };
       receiptOpenBtn.addEventListener("click", openModal);
       closeControls.forEach(control => control.addEventListener("click", closeModal));
+      if (window.costPurchaseHistoryModalOpen){
+        openModal();
+      }
     }
 
     const canvas = panel.querySelector("#weeklyCostChart");

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10931,6 +10931,282 @@ function renderCosts(){
       });
     }
 
+    const formatUsd = (value)=> new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(Number.isFinite(Number(value)) ? Number(value) : 0);
+    const toIsoDate = (value)=> String(value || "").slice(0, 10);
+    const parseIsoDate = (iso)=>{
+      const raw = String(iso || "");
+      if (!raw) return null;
+      const dt = new Date(`${raw}T00:00:00`);
+      return Number.isNaN(dt.getTime()) ? null : dt;
+    };
+    const weekStartFromIndex = (year, week)=>{
+      const jan4 = new Date(Date.UTC(year, 0, 4));
+      const jan4Day = jan4.getUTCDay() || 7;
+      const monday = new Date(jan4);
+      monday.setUTCDate(jan4.getUTCDate() - jan4Day + 1 + ((week - 1) * 7));
+      return monday;
+    };
+    const weekKey = (year, week)=> `${year}-W${String(week).padStart(2, "0")}`;
+    const now = new Date();
+    const year = now.getUTCFullYear();
+    const weekOptions = Array.from({ length: 52 }, (_, i)=>{
+      const week = i + 1;
+      const start = weekStartFromIndex(year, week);
+      const end = new Date(start); end.setUTCDate(start.getUTCDate() + 6);
+      return { key: weekKey(year, week), year, week, startISO: start.toISOString().slice(0, 10), endISO: end.toISOString().slice(0, 10) };
+    });
+    if (!Array.isArray(window.receiptTrackerWeeks)) window.receiptTrackerWeeks = [];
+    const persistReceiptState = ()=>{
+      if (typeof saveCloudDebounced === "function"){
+        try { saveCloudDebounced(); } catch (_err){}
+      }
+    };
+    const normalizeRows = (rows)=> (Array.isArray(rows) ? rows : []).map(item => ({
+      date: toIsoDate(item?.date),
+      purchased: String(item?.purchased || ""),
+      cost: Number(item?.cost) || 0,
+      qty: Number(item?.qty) || 0,
+      partNumber: String(item?.partNumber || ""),
+      shipping: Number(item?.shipping) || 0
+    })).filter(row => row.date || row.purchased || row.cost || row.qty || row.partNumber || row.shipping);
+    const getWeekEntry = (key)=>{
+      const existing = window.receiptTrackerWeeks.find(entry => String(entry?.key || "") === key);
+      if (existing) return existing;
+      const meta = weekOptions.find(item => item.key === key);
+      const created = { key, year: meta?.year || year, week: meta?.week || 1, startISO: meta?.startISO || "", endISO: meta?.endISO || "", rows: [] };
+      window.receiptTrackerWeeks.push(created);
+      return created;
+    };
+    const computeRowTotal = (row)=> ((Number(row?.cost) || 0) * (Number(row?.qty) || 0)) + (Number(row?.shipping) || 0);
+    const buildRangeRows = (months)=>{
+      const end = new Date();
+      const start = months === "all" ? null : new Date(end.getFullYear(), end.getMonth() - Number(months), end.getDate());
+      const rows = [];
+      (window.receiptTrackerWeeks || []).forEach(week => {
+        normalizeRows(week?.rows).forEach(row => {
+          const date = parseIsoDate(row.date);
+          if (!date) return;
+          if (start && date < start) return;
+          if (date > end) return;
+          rows.push({ ...row, total: computeRowTotal(row) });
+        });
+      });
+      rows.sort((a,b)=> String(a.date).localeCompare(String(b.date)));
+      return rows;
+    };
+    const downloadCsv = (name, rows)=>{
+      const csv = rows.map(cols => cols.map(val => `"${String(val ?? "").replace(/"/g, "\"\"")}"`).join(",")).join("\n");
+      const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+      const link = document.createElement("a");
+      const url = URL.createObjectURL(blob);
+      link.href = url;
+      link.download = name;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    };
+
+    const receiptOpenBtn = panel.querySelector("[data-cost-receipt-open]");
+    const modal = document.getElementById("costReceiptModal");
+    if (receiptOpenBtn instanceof HTMLElement && modal instanceof HTMLElement){
+      const weekSelect = modal.querySelector("[data-receipt-week-select]");
+      const weekRangeLabel = modal.querySelector("[data-receipt-week-range]");
+      const weekRowsBody = modal.querySelector("[data-receipt-week-rows]");
+      const weekSubtotal = modal.querySelector("[data-receipt-week-subtotal]");
+      const rangeSelect = modal.querySelector("[data-receipt-range-select]");
+      const rangeRowsBody = modal.querySelector("[data-receipt-range-rows]");
+      const rangeSubtotal = modal.querySelector("[data-receipt-range-subtotal]");
+      const closeControls = Array.from(modal.querySelectorAll("[data-receipt-close]"));
+      const exportWeekBtn = modal.querySelector("[data-receipt-export-week]");
+      const exportRangeBtn = modal.querySelector("[data-receipt-export-range]");
+      let activeWeekKey = String((window.receiptTrackerWeekSelected || weekOptions[0]?.key || ""));
+      let activeRange = String(window.receiptTrackerRangeSelected || "1");
+      window.receiptTrackerWeekSelected = activeWeekKey;
+      window.receiptTrackerRangeSelected = activeRange;
+
+      const renderWeekOptions = ()=>{
+        if (!(weekSelect instanceof HTMLSelectElement)) return;
+        weekSelect.innerHTML = weekOptions.map(opt => `<option value="${escapeHtml(opt.key)}">Week ${escapeHtml(String(opt.week))} (${escapeHtml(opt.startISO)} to ${escapeHtml(opt.endISO)})</option>`).join("");
+        if (!weekOptions.some(item => item.key === activeWeekKey)) activeWeekKey = weekOptions[0]?.key || "";
+        weekSelect.value = activeWeekKey;
+      };
+      const saveWeekRowsFromDom = ()=>{
+        const entry = getWeekEntry(activeWeekKey);
+        if (!(weekRowsBody instanceof HTMLElement)) return entry;
+        const rows = Array.from(weekRowsBody.querySelectorAll("tr[data-receipt-row]")).map(tr => ({
+          date: toIsoDate(tr.querySelector('[data-col=\"date\"]')?.value || ""),
+          purchased: String(tr.querySelector('[data-col=\"purchased\"]')?.value || "").trim(),
+          cost: Number(tr.querySelector('[data-col=\"cost\"]')?.value) || 0,
+          qty: Number(tr.querySelector('[data-col=\"qty\"]')?.value) || 0,
+          partNumber: String(tr.querySelector('[data-col=\"partNumber\"]')?.value || "").trim(),
+          shipping: Number(tr.querySelector('[data-col=\"shipping\"]')?.value) || 0
+        }));
+        entry.rows = normalizeRows(rows);
+        persistReceiptState();
+        return entry;
+      };
+      const appendEmptyRow = (focusFirst = false)=>{
+        if (!(weekRowsBody instanceof HTMLElement)) return;
+        const tr = document.createElement("tr");
+        tr.setAttribute("data-receipt-row", "1");
+        tr.innerHTML = `
+          <td><input type="date" data-col="date"></td>
+          <td><input type="text" data-col="purchased" placeholder="Item"></td>
+          <td><input type="number" min="0" step="0.01" data-col="cost" placeholder="0.00"></td>
+          <td><input type="number" min="0" step="0.01" data-col="qty" placeholder="0"></td>
+          <td><input type="text" data-col="partNumber" placeholder="Part #"></td>
+          <td><input type="number" min="0" step="0.01" data-col="shipping" placeholder="0.00"></td>
+          <td data-col="total">${formatUsd(0)}</td>`;
+        weekRowsBody.appendChild(tr);
+        if (focusFirst){
+          const first = tr.querySelector("[data-col='date']");
+          if (first instanceof HTMLElement) first.focus();
+        }
+      };
+      const recomputeWeekTotals = ()=>{
+        if (!(weekRowsBody instanceof HTMLElement)) return;
+        let subtotal = 0;
+        Array.from(weekRowsBody.querySelectorAll("tr[data-receipt-row]")).forEach(tr => {
+          const row = {
+            cost: Number(tr.querySelector('[data-col=\"cost\"]')?.value) || 0,
+            qty: Number(tr.querySelector('[data-col=\"qty\"]')?.value) || 0,
+            shipping: Number(tr.querySelector('[data-col=\"shipping\"]')?.value) || 0
+          };
+          const total = computeRowTotal(row);
+          subtotal += total;
+          const totalCell = tr.querySelector('[data-col=\"total\"]');
+          if (totalCell) totalCell.textContent = formatUsd(total);
+        });
+        if (weekSubtotal) weekSubtotal.textContent = formatUsd(subtotal);
+      };
+      const renderWeekRows = ()=>{
+        const entry = getWeekEntry(activeWeekKey);
+        const rows = normalizeRows(entry.rows);
+        if (weekRangeLabel){
+          weekRangeLabel.textContent = entry.startISO && entry.endISO ? `Date range: ${entry.startISO} to ${entry.endISO}` : "Date range unavailable";
+        }
+        if (!(weekRowsBody instanceof HTMLElement)) return;
+        weekRowsBody.innerHTML = rows.map(row => `
+          <tr data-receipt-row="1">
+            <td><input type="date" data-col="date" value="${escapeHtml(toIsoDate(row.date))}"></td>
+            <td><input type="text" data-col="purchased" value="${escapeHtml(row.purchased || "")}"></td>
+            <td><input type="number" min="0" step="0.01" data-col="cost" value="${escapeHtml(String(row.cost || 0))}"></td>
+            <td><input type="number" min="0" step="0.01" data-col="qty" value="${escapeHtml(String(row.qty || 0))}"></td>
+            <td><input type="text" data-col="partNumber" value="${escapeHtml(row.partNumber || "")}"></td>
+            <td><input type="number" min="0" step="0.01" data-col="shipping" value="${escapeHtml(String(row.shipping || 0))}"></td>
+            <td data-col="total">${formatUsd(computeRowTotal(row))}</td>
+          </tr>`).join("");
+        appendEmptyRow();
+        recomputeWeekTotals();
+      };
+      const renderRangeTable = ()=>{
+        if (!(rangeRowsBody instanceof HTMLElement)) return;
+        const rows = buildRangeRows(activeRange);
+        const subtotal = rows.reduce((sum, row) => sum + row.total, 0);
+        rangeRowsBody.innerHTML = rows.length ? rows.map(row => `
+          <tr>
+            <td>${escapeHtml(row.date || "—")}</td>
+            <td>${escapeHtml(row.purchased || "—")}</td>
+            <td>${escapeHtml(String(row.qty || 0))}</td>
+            <td>${escapeHtml(row.partNumber || "—")}</td>
+            <td>${formatUsd(row.shipping || 0)}</td>
+            <td>${formatUsd(row.total || 0)}</td>
+            <td></td>
+          </tr>`).join("") : '<tr><td colspan="7" class="cost-table-placeholder">No receipt rows in this range.</td></tr>';
+        if (rangeSubtotal) rangeSubtotal.textContent = formatUsd(subtotal);
+      };
+      const bindRowEvents = ()=>{
+        if (!(weekRowsBody instanceof HTMLElement)) return;
+        weekRowsBody.addEventListener("keydown", event => {
+          if (event.key !== "Enter") return;
+          const input = event.target;
+          if (!(input instanceof HTMLInputElement)) return;
+          event.preventDefault();
+          const row = input.closest("tr[data-receipt-row]");
+          if (!row) return;
+          const columns = ["date", "purchased", "cost", "qty", "partNumber", "shipping"];
+          const col = input.getAttribute("data-col") || "";
+          const idx = columns.indexOf(col);
+          if (idx < 0) return;
+          if (idx === columns.length - 1){
+            appendEmptyRow(true);
+          } else {
+            const next = row.querySelector(`[data-col="${columns[idx + 1]}"]`);
+            if (next instanceof HTMLElement) next.focus();
+          }
+          recomputeWeekTotals();
+          saveWeekRowsFromDom();
+          renderRangeTable();
+        });
+        weekRowsBody.addEventListener("input", ()=>{
+          recomputeWeekTotals();
+          saveWeekRowsFromDom();
+          renderRangeTable();
+        });
+      };
+      bindRowEvents();
+      renderWeekOptions();
+      renderWeekRows();
+      renderRangeTable();
+      if (rangeSelect instanceof HTMLSelectElement){
+        rangeSelect.value = activeRange;
+        rangeSelect.addEventListener("change", ()=>{
+          activeRange = rangeSelect.value || "1";
+          window.receiptTrackerRangeSelected = activeRange;
+          renderRangeTable();
+          persistReceiptState();
+        });
+      }
+      if (weekSelect instanceof HTMLSelectElement){
+        weekSelect.addEventListener("change", ()=>{
+          saveWeekRowsFromDom();
+          activeWeekKey = weekSelect.value;
+          window.receiptTrackerWeekSelected = activeWeekKey;
+          renderWeekRows();
+          renderRangeTable();
+        });
+      }
+      if (exportWeekBtn instanceof HTMLElement){
+        exportWeekBtn.addEventListener("click", ()=>{
+          const entry = saveWeekRowsFromDom();
+          const rows = normalizeRows(entry.rows);
+          const subtotal = rows.reduce((sum, row) => sum + computeRowTotal(row), 0);
+          const payload = [
+            ["Date", "Purchased", "Cost", "Qty", "Part number", "Shipping", "Total"],
+            ...rows.map(row => [row.date, row.purchased, row.cost, row.qty, row.partNumber, row.shipping, computeRowTotal(row)]),
+            ["", "", "", "", "", "Subtotal", subtotal]
+          ];
+          downloadCsv(`receipt-week-${entry.key}.csv`, payload);
+        });
+      }
+      if (exportRangeBtn instanceof HTMLElement){
+        exportRangeBtn.addEventListener("click", ()=>{
+          const rows = buildRangeRows(activeRange);
+          const subtotal = rows.reduce((sum, row) => sum + row.total, 0);
+          const payload = [
+            ["Date", "Purchased", "Qty", "Part number", "Shipping", "Total"],
+            ...rows.map(row => [row.date, row.purchased, row.qty, row.partNumber, row.shipping, row.total]),
+            ["", "", "", "", "Subtotal", subtotal]
+          ];
+          downloadCsv(`receipt-range-${activeRange}.csv`, payload);
+        });
+      }
+      const openModal = ()=>{
+        modal.hidden = false;
+        modal.setAttribute("aria-hidden", "false");
+        document.body.classList.add("cost-receipt-modal-open");
+      };
+      const closeModal = ()=>{
+        saveWeekRowsFromDom();
+        modal.hidden = true;
+        modal.setAttribute("aria-hidden", "true");
+        document.body.classList.remove("cost-receipt-modal-open");
+      };
+      receiptOpenBtn.addEventListener("click", openModal);
+      closeControls.forEach(control => control.addEventListener("click", closeModal));
+    }
+
     const canvas = panel.querySelector("#weeklyCostChart");
     const reportForChart = reports.find(item => String(item?.weekStartISO || "") === normalized) || null;
     if (canvas instanceof HTMLCanvasElement){

--- a/js/views.js
+++ b/js/views.js
@@ -1784,15 +1784,15 @@ function viewCosts(model){
     </div>
 
     <div class="cost-receipt-modal" id="costReceiptModal" role="dialog" aria-modal="true" aria-labelledby="costReceiptTitle" aria-hidden="true" hidden>
-      <div class="cost-receipt-backdrop" data-receipt-close tabindex="-1" aria-label="Close receipt tracker"></div>
+      <div class="cost-receipt-backdrop" tabindex="-1" aria-hidden="true"></div>
       <div class="cost-receipt-card" role="document">
-        <button type="button" class="cost-receipt-close" data-receipt-close aria-label="Close receipt tracker"><span aria-hidden="true">×</span></button>
+        <button type="button" class="cost-receipt-close" data-receipt-close aria-label="Close purchase history"><span aria-hidden="true">×</span></button>
         <div class="cost-receipt-card-body">
-          <h3 id="costReceiptTitle">Receipt tracker</h3>
+          <h3 id="costReceiptTitle">Purchase History</h3>
           <div class="cost-receipt-controls">
             <label>
               <span>Week of year</span>
-              <select data-receipt-week-select aria-label="Select receipt tracker week"></select>
+              <select data-receipt-week-select aria-label="Select purchase history week"></select>
             </label>
             <button type="button" class="btn secondary" data-receipt-export-week>Export week (CSV)</button>
             <button type="button" class="btn secondary" data-receipt-export-range>Export range (CSV)</button>
@@ -2036,7 +2036,7 @@ function viewCosts(model){
                 ${weeklyOptions}
               </select>
             </label>
-            <button type="button" class="btn secondary" data-cost-receipt-open>Receipt tracker</button>
+            <button type="button" class="btn secondary" data-cost-receipt-open>Purchase History</button>
             <button type="button" class="btn secondary" data-cost-weekly-export ${selectedWeeklyReport ? "" : "disabled"}>Export week (Excel)</button>
           </div>
           <div class="cost-weekly-summary">

--- a/js/views.js
+++ b/js/views.js
@@ -1783,6 +1783,52 @@ function viewCosts(model){
       </div>
     </div>
 
+    <div class="cost-receipt-modal" id="costReceiptModal" role="dialog" aria-modal="true" aria-labelledby="costReceiptTitle" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-receipt-close tabindex="-1" aria-label="Close receipt tracker"></div>
+      <div class="cost-receipt-card" role="document">
+        <button type="button" class="cost-receipt-close" data-receipt-close aria-label="Close receipt tracker"><span aria-hidden="true">×</span></button>
+        <div class="cost-receipt-card-body">
+          <h3 id="costReceiptTitle">Receipt tracker</h3>
+          <div class="cost-receipt-controls">
+            <label>
+              <span>Week of year</span>
+              <select data-receipt-week-select aria-label="Select receipt tracker week"></select>
+            </label>
+            <button type="button" class="btn secondary" data-receipt-export-week>Export week (CSV)</button>
+            <button type="button" class="btn secondary" data-receipt-export-range>Export range (CSV)</button>
+          </div>
+          <p class="small muted" data-receipt-week-range>—</p>
+          <div class="cost-weekly-table-wrap">
+            <table class="cost-table cost-receipt-week-table">
+              <thead><tr><th>Date</th><th>Purchased</th><th>Cost</th><th>Qty</th><th>Part number</th><th>Shipping</th><th>Total</th></tr></thead>
+              <tbody data-receipt-week-rows></tbody>
+              <tfoot><tr><th colspan="6">Subtotal</th><th data-receipt-week-subtotal>$0.00</th></tr></tfoot>
+            </table>
+          </div>
+          <div class="cost-receipt-summary-controls">
+            <label>
+              <span>Range</span>
+              <select data-receipt-range-select aria-label="Select receipt summary range">
+                <option value="1">1 month</option>
+                <option value="2">2 months</option>
+                <option value="3">3 months</option>
+                <option value="6">6 months</option>
+                <option value="12">1 year</option>
+                <option value="all">All time</option>
+              </select>
+            </label>
+          </div>
+          <div class="cost-weekly-table-wrap">
+            <table class="cost-table cost-receipt-summary-table">
+              <thead><tr><th>Date</th><th>Purchased</th><th>Qty</th><th>Part number</th><th>Shipping</th><th>Total</th><th>Sub total</th></tr></thead>
+              <tbody data-receipt-range-rows></tbody>
+              <tfoot><tr><th colspan="6">Subtotal</th><th data-receipt-range-subtotal>$0.00</th></tr></tfoot>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="dashboard-layout cost-layout" id="costLayout">
       <div class="dashboard-window" data-cost-window="overview">
         <div class="block cost-overview-block">
@@ -1990,6 +2036,7 @@ function viewCosts(model){
                 ${weeklyOptions}
               </select>
             </label>
+            <button type="button" class="btn secondary" data-cost-receipt-open>Receipt tracker</button>
             <button type="button" class="btn secondary" data-cost-weekly-export ${selectedWeeklyReport ? "" : "disabled"}>Export week (Excel)</button>
           </div>
           <div class="cost-weekly-summary">

--- a/js/views.js
+++ b/js/views.js
@@ -1800,9 +1800,9 @@ function viewCosts(model){
           <p class="small muted" data-receipt-week-range>—</p>
           <div class="cost-weekly-table-wrap">
             <table class="cost-table cost-receipt-week-table">
-              <thead><tr><th>Date</th><th>Purchased</th><th>Cost</th><th>Qty</th><th>Part number</th><th>Shipping</th><th>Total</th></tr></thead>
+              <thead><tr><th>Date</th><th>Purchased</th><th>Cost</th><th>Qty</th><th>Part number</th><th>Shipping</th><th>Tax</th><th>Total</th></tr></thead>
               <tbody data-receipt-week-rows></tbody>
-              <tfoot><tr><th colspan="6">Subtotal</th><th data-receipt-week-subtotal>$0.00</th></tr></tfoot>
+              <tfoot><tr><th colspan="7">Subtotal</th><th data-receipt-week-subtotal>$0.00</th></tr></tfoot>
             </table>
           </div>
           <div class="cost-receipt-summary-controls">
@@ -1820,9 +1820,9 @@ function viewCosts(model){
           </div>
           <div class="cost-weekly-table-wrap">
             <table class="cost-table cost-receipt-summary-table">
-              <thead><tr><th>Date</th><th>Purchased</th><th>Qty</th><th>Part number</th><th>Shipping</th><th>Total</th><th>Sub total</th></tr></thead>
+              <thead><tr><th>Date</th><th>Purchased</th><th>Qty</th><th>Part number</th><th>Shipping</th><th>Tax</th><th>Total</th><th>Sub total</th></tr></thead>
               <tbody data-receipt-range-rows></tbody>
-              <tfoot><tr><th colspan="6">Subtotal</th><th data-receipt-range-subtotal>$0.00</th></tr></tfoot>
+              <tfoot><tr><th colspan="7">Subtotal</th><th data-receipt-range-subtotal>$0.00</th></tr></tfoot>
             </table>
           </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -500,6 +500,19 @@ body.pump-notes-open { overflow:hidden; }
 .cost-timeframe-row:focus-visible{ outline:2px solid var(--brand-blue-400, #2563eb); outline-offset:2px; }
 .cost-timeframe-section .small.muted{ margin-top:0; }
 body.cost-timeframe-modal-open{ overflow:hidden; }
+
+.cost-receipt-modal{ position:fixed; inset:0; z-index:1600; display:flex; align-items:center; justify-content:center; padding:24px 20px; }
+.cost-receipt-modal[hidden]{ display:none; }
+.cost-receipt-backdrop{ position:absolute; inset:0; background:rgba(15,23,42,0.55); }
+.cost-receipt-card{ position:relative; width:min(1100px, 100%); max-height:92vh; background:#fff; border-radius:18px; box-shadow:0 32px 72px rgba(15,23,42,0.28); overflow:hidden; }
+.cost-receipt-card-body{ position:relative; z-index:2; padding:24px; overflow:auto; max-height:92vh; }
+.cost-receipt-close{ position:absolute; top:10px; right:12px; border:none; background:none; font-size:28px; cursor:pointer; color:#1e2b45; z-index:3; }
+.cost-receipt-controls,.cost-receipt-summary-controls{ display:flex; gap:10px; flex-wrap:wrap; align-items:flex-end; margin-bottom:10px; }
+.cost-receipt-controls label,.cost-receipt-summary-controls label{ display:flex; flex-direction:column; gap:4px; font-weight:600; color:#1e2b45; }
+.cost-receipt-controls select,.cost-receipt-summary-controls select{ min-width:240px; padding:6px 8px; border:1px solid #c8d0e0; border-radius:6px; }
+.cost-receipt-week-table input{ width:100%; box-sizing:border-box; padding:6px 8px; border:1px solid #cfd7e6; border-radius:6px; font:inherit; }
+.cost-receipt-week-table td[data-col="total"],.cost-receipt-week-table tfoot th,.cost-receipt-summary-table tfoot th{ font-weight:700; }
+body.cost-receipt-modal-open{ overflow:hidden; }
 @media (max-width: 640px){
   .cost-timeframe-card-body{ padding:24px 18px 28px; }
   .cost-timeframe-table th,.cost-timeframe-table td{ padding:8px 10px; }


### PR DESCRIPTION
### Motivation
- Provide a lightweight receipt/receipt-tracker UI to capture real purchase cost per week and produce automated rollups over selectable time ranges, matching the requested receipt/weekly tables and exports.
- Let users edit week-by-week rows in-place with keyboard flow (Enter advances cells and auto-adds rows) and have a single subtotal per week and for range rollups.
- Persist receipt data so it is included in workspace snapshots and saved to Firebase alongside existing app state.

### Description
- Added a receipt tracker modal UI and open button in the Cost Analysis weekly window by updating `js/views.js` to include the modal markup and a `Receipt tracker` launcher button. 
- Implemented receipt tracker behavior in `js/renderers.js` with 52-week selector/date ranges, editable week tables (`date`, `purchased`, `cost`, `qty`, `partNumber`, `shipping`, `total`), auto-calculated totals/subtotals, range rollups (1/2/3/6/12 months + all time), CSV export for week and range, Enter-key navigation, auto-row creation, and autosave hooks. 
- Wired persistent state under the new key `receiptTrackerWeeks` in `js/core.js` so entries are included in `snapshotState`, `adoptState`, initial seeds and cloud saves via `saveCloudDebounced()`. 
- Added styling for the modal and table inputs in `style.css` and verified `vercel.json` remains the required `{ "cleanUrls": true }`.

### Testing
- Ran JavaScript syntax checks with `node --check js/core.js && node --check js/views.js && node --check js/renderers.js` and they completed successfully. 
- Confirmed `vercel.json` contains the exact required content (`{ "cleanUrls": true }`). 
- No automated browser/UI integration tests were executed in this run; interactive behavior was implemented and unit/smoke checks were limited to the static code checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7989efa6c832592c94f4551831d05)