### PR TITLE
Add Maintenance Data Center modal and data tables to Costs dashboard

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10832,22 +10832,18 @@ function renderCosts(){
 
     const cuttingSearchInput = modal instanceof HTMLElement ? modal.querySelector("[data-cutting-search]") : null;
     const cuttingCategoryFilter = modal instanceof HTMLElement ? modal.querySelector("[data-cutting-filter-category]") : null;
-    const cuttingTaskFilter = modal instanceof HTMLElement ? modal.querySelector("[data-cutting-filter-job]") : null;
     const applyCuttingFilter = ()=>{
       if (!(modal instanceof HTMLElement)) return;
       const term = String(cuttingSearchInput instanceof HTMLInputElement ? cuttingSearchInput.value : "").trim().toLowerCase();
       const categoryValue = String(cuttingCategoryFilter instanceof HTMLSelectElement ? cuttingCategoryFilter.value : "").trim();
-      const taskValue = String(cuttingTaskFilter instanceof HTMLSelectElement ? cuttingTaskFilter.value : "").trim().toLowerCase();
       const rows = Array.from(modal.querySelectorAll("[data-cutting-row]"));
       rows.forEach(row => {
         if (!(row instanceof HTMLElement)) return;
         const haystack = String(row.getAttribute("data-cutting-search-text") || "").toLowerCase();
         const rowCategory = String(row.getAttribute("data-cutting-category-id") || "");
-        const rowJob = String(row.getAttribute("data-cutting-job-key") || "").toLowerCase();
         const matchesSearch = !term || haystack.includes(term);
         const matchesCategory = !categoryValue || rowCategory === categoryValue;
-        const matchesTask = !taskValue || rowJob === taskValue;
-        row.hidden = !(matchesSearch && matchesCategory && matchesTask);
+        row.hidden = !(matchesSearch && matchesCategory);
       });
     };
     if (cuttingSearchInput instanceof HTMLInputElement){
@@ -10857,9 +10853,17 @@ function renderCosts(){
     if (cuttingCategoryFilter instanceof HTMLSelectElement){
       cuttingCategoryFilter.addEventListener("change", applyCuttingFilter);
     }
-    if (cuttingTaskFilter instanceof HTMLSelectElement){
-      cuttingTaskFilter.addEventListener("change", applyCuttingFilter);
-    }
+    Array.from((modal instanceof HTMLElement ? modal : content).querySelectorAll("[data-cutting-open-job]")).forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", ()=>{
+        const jobId = String(btn.getAttribute("data-job-id") || "");
+        closeDataCenter();
+        if (jobId){
+          window.pendingJobFocus = { type: "jobRow", id: jobId };
+        }
+        location.hash = "#/jobs";
+      });
+    });
 
     const rows = Array.from((modal instanceof HTMLElement ? modal : content).querySelectorAll("[data-maintenance-open-task]"));
     if (!rows.length) return;
@@ -14475,6 +14479,7 @@ function computeCostModel(){
     emptyMessage: orderRows.length ? "" : "Approve or deny order requests to build the spend log."
   };
 
+  const cuttingCategoryCounters = new Map();
   const cuttingJobsDataTable = (Array.isArray(completedCuttingJobs) ? completedCuttingJobs : []).map((job, index) => {
     const categoryId = job?.cat != null ? String(job.cat) : "";
     const categoryLabel = categoryId ? resolveCategoryName(categoryId) : "Uncategorized";
@@ -14485,6 +14490,8 @@ function computeCostModel(){
       Number(job?.estimateHours)
     ];
     const hours = actualHoursCandidates.find(val => Number.isFinite(val) && val >= 0) ?? 0;
+    const categoryCutCount = (cuttingCategoryCounters.get(categoryId || "__uncategorized__") || 0) + 1;
+    cuttingCategoryCounters.set(categoryId || "__uncategorized__", categoryCutCount);
     const chargeRateRaw = Number(job?.chargeRate);
     const costRateRaw = Number(job?.costRate);
     const chargeRate = Number.isFinite(chargeRateRaw) && chargeRateRaw >= 0 ? chargeRateRaw : JOB_RATE_PER_HOUR;
@@ -14497,7 +14504,7 @@ function computeCostModel(){
       name: job?.name || `Completed job ${index + 1}`,
       categoryId,
       categoryLabel,
-      hoursLabel: formatHoursValue(hours) || "0",
+      hoursLabel: Number.isFinite(hours) ? String(hours) : "0",
       chargeRateLabel: formatterCurrency(chargeRate, { decimals: 2 }),
       costRateLabel: formatterCurrency(costRate, { decimals: 2 }),
       materialType: String(job?.material || "—"),
@@ -14508,7 +14515,9 @@ function computeCostModel(){
       completedDateLabel: completedISO ? String(completedISO).slice(0, 10) : "—",
       projectNumber: String(job?.projectNumber || "—"),
       notes: String(job?.notes || "").trim() || "—",
-      priorityLabel: Number.isFinite(Number(job?.priority)) ? String(Math.max(1, Math.floor(Number(job.priority)))) : "—"
+      priorityLabel: Number.isFinite(Number(job?.priority)) ? String(Math.max(1, Math.floor(Number(job.priority)))) : "—",
+      cumulativeCutNumberLabel: `#${index + 1}`,
+      categoryCutNumberLabel: `#${categoryCutCount}`
     };
   });
 
@@ -15178,6 +15187,19 @@ function renderJobs(){
             addButton.focus();
           }
           addButton.scrollIntoView({ block: "nearest", inline: "nearest", behavior: "smooth" });
+        }
+      });
+    } else if (pendingJobFocus.type === "jobRow" && pendingJobFocus.id != null){
+      requestAnimationFrame(()=>{
+        const targetRow = content.querySelector(`[data-job-row="${pendingJobFocus.id}"]`);
+        if (targetRow instanceof HTMLElement){
+          targetRow.classList.add("job-row-priority-animate");
+          try {
+            targetRow.scrollIntoView({ behavior: "smooth", block: "center" });
+          } catch (_err){
+            try { targetRow.scrollIntoView(); } catch(__){}
+          }
+          setTimeout(()=> targetRow.classList.remove("job-row-priority-animate"), 1800);
         }
       });
     }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10656,6 +10656,41 @@ function renderCosts(){
     }
   }
 
+  function focusCalendarForCuttingJob(jobId, dateISO){
+    const dueISO = String(dateISO || "");
+    const parsedDue = dueISO && typeof parseDateLocal === "function"
+      ? parseDateLocal(dueISO)
+      : (dueISO ? new Date(dueISO) : null);
+    if (parsedDue instanceof Date && !Number.isNaN(parsedDue.getTime())){
+      parsedDue.setHours(0,0,0,0);
+      const today = new Date();
+      today.setHours(0,0,0,0);
+      const diffMonths = (parsedDue.getFullYear() - today.getFullYear()) * 12 + (parsedDue.getMonth() - today.getMonth());
+      window.__calendarMonthOffset = Math.min(12, Math.max(-12, Math.round(diffMonths)));
+    }
+    if (typeof hideBubble === "function") hideBubble();
+    location.hash = "#/";
+    const runFocus = ()=>{
+      if (typeof renderCalendar === "function") renderCalendar();
+      const months = document.getElementById("months");
+      const cell = dueISO ? months?.querySelector(`[data-date-iso="${dueISO}"]`) : null;
+      if (!cell) return false;
+      cell.scrollIntoView({ behavior: "smooth", block: "center" });
+      if (typeof highlightCalendarDayCell === "function"){
+        highlightCalendarDayCell(cell);
+      }
+      const anchor = jobId ? (cell.querySelector(`[data-cal-job="${String(jobId)}"]`) || cell) : cell;
+      if (jobId && typeof showJobBubble === "function"){
+        showJobBubble(String(jobId), anchor);
+      }
+      return true;
+    };
+    if (!runFocus()){
+      setTimeout(runFocus, 120);
+      setTimeout(runFocus, 320);
+    }
+  }
+
   function setupMaintenanceDataCenterActions(options = {}){
     const openBtn = content.querySelector("[data-open-data-center]");
     const modal = content.querySelector("[data-data-center-modal]");
@@ -10663,6 +10698,9 @@ function renderCosts(){
     const tabButtons = modal instanceof HTMLElement ? Array.from(modal.querySelectorAll("[data-dc-tab]")) : [];
     const panels = modal instanceof HTMLElement ? Array.from(modal.querySelectorAll("[data-dc-panel]")) : [];
     const setActiveTab = (tabKey)=>{
+      if (typeof window !== "undefined"){
+        window.dataCenterActiveTab = tabKey;
+      }
       tabButtons.forEach(btn => {
         if (!(btn instanceof HTMLElement)) return;
         const isActive = String(btn.getAttribute("data-dc-tab") || "") === tabKey;
@@ -10682,7 +10720,10 @@ function renderCosts(){
         setActiveTab(key);
       });
     });
-    setActiveTab("maintenance");
+    const rememberedTab = (typeof window !== "undefined" && typeof window.dataCenterActiveTab === "string")
+      ? window.dataCenterActiveTab
+      : "maintenance";
+    setActiveTab(rememberedTab === "cutting" ? "cutting" : "maintenance");
     if (modal instanceof HTMLElement){
       document.body.appendChild(modal);
     }
@@ -10857,7 +10898,15 @@ function renderCosts(){
       if (!(btn instanceof HTMLElement)) return;
       btn.addEventListener("click", ()=>{
         const jobId = String(btn.getAttribute("data-job-id") || "");
+        const dateISO = String(btn.getAttribute("data-date-iso") || "");
+        const modeId = String(btn.getAttribute("data-link-mode-id") || "");
+        const modeEl = modeId ? document.getElementById(modeId) : null;
+        const destination = String(modeEl instanceof HTMLSelectElement ? modeEl.value : "jobs").toLowerCase();
         closeDataCenter();
+        if (destination === "calendar"){
+          focusCalendarForCuttingJob(jobId, dateISO);
+          return;
+        }
         if (jobId){
           window.pendingJobFocus = { type: "jobRow", id: jobId };
         }
@@ -15193,13 +15242,13 @@ function renderJobs(){
       requestAnimationFrame(()=>{
         const targetRow = content.querySelector(`[data-job-row="${pendingJobFocus.id}"]`);
         if (targetRow instanceof HTMLElement){
-          targetRow.classList.add("job-row-priority-animate");
+          targetRow.classList.add("job-row-link-highlight");
           try {
             targetRow.scrollIntoView({ behavior: "smooth", block: "center" });
           } catch (_err){
             try { targetRow.scrollIntoView(); } catch(__){}
           }
-          setTimeout(()=> targetRow.classList.remove("job-row-priority-animate"), 1800);
+          setTimeout(()=> targetRow.classList.remove("job-row-link-highlight"), 2000);
         }
       });
     }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -14528,8 +14528,19 @@ function computeCostModel(){
     emptyMessage: orderRows.length ? "" : "Approve or deny order requests to build the spend log."
   };
 
-  const cuttingCategoryCounters = new Map();
-  const cuttingJobsDataTable = (Array.isArray(completedCuttingJobs) ? completedCuttingJobs : []).map((job, index) => {
+  const completedJobsForDataCenter = (Array.isArray(completedCuttingJobs) ? completedCuttingJobs.slice() : [])
+    .sort((a, b) => {
+      const aDate = String(a?.completedAtISO || a?.dueISO || a?.startISO || "");
+      const bDate = String(b?.completedAtISO || b?.dueISO || b?.startISO || "");
+      return bDate.localeCompare(aDate);
+    });
+  const cuttingCategoryRemaining = new Map();
+  completedJobsForDataCenter.forEach(job => {
+    const key = job?.cat != null ? String(job.cat) : "__uncategorized__";
+    cuttingCategoryRemaining.set(key, (cuttingCategoryRemaining.get(key) || 0) + 1);
+  });
+  const totalCompletedJobs = completedJobsForDataCenter.length;
+  const cuttingJobsDataTable = completedJobsForDataCenter.map((job, index) => {
     const categoryId = job?.cat != null ? String(job.cat) : "";
     const categoryLabel = categoryId ? resolveCategoryName(categoryId) : "Uncategorized";
     const actualHoursCandidates = [
@@ -14539,8 +14550,9 @@ function computeCostModel(){
       Number(job?.estimateHours)
     ];
     const hours = actualHoursCandidates.find(val => Number.isFinite(val) && val >= 0) ?? 0;
-    const categoryCutCount = (cuttingCategoryCounters.get(categoryId || "__uncategorized__") || 0) + 1;
-    cuttingCategoryCounters.set(categoryId || "__uncategorized__", categoryCutCount);
+    const categoryKey = categoryId || "__uncategorized__";
+    const categoryCutCount = cuttingCategoryRemaining.get(categoryKey) || 1;
+    cuttingCategoryRemaining.set(categoryKey, Math.max(0, categoryCutCount - 1));
     const chargeRateRaw = Number(job?.chargeRate);
     const costRateRaw = Number(job?.costRate);
     const chargeRate = Number.isFinite(chargeRateRaw) && chargeRateRaw >= 0 ? chargeRateRaw : JOB_RATE_PER_HOUR;
@@ -14565,7 +14577,7 @@ function computeCostModel(){
       projectNumber: String(job?.projectNumber || "—"),
       notes: String(job?.notes || "").trim() || "—",
       priorityLabel: Number.isFinite(Number(job?.priority)) ? String(Math.max(1, Math.floor(Number(job.priority)))) : "—",
-      cumulativeCutNumberLabel: `#${index + 1}`,
+      cumulativeCutNumberLabel: `#${Math.max(1, totalCompletedJobs - index)}`,
       categoryCutNumberLabel: `#${categoryCutCount}`
     };
   });
@@ -15240,7 +15252,7 @@ function renderJobs(){
       });
     } else if (pendingJobFocus.type === "jobRow" && pendingJobFocus.id != null){
       requestAnimationFrame(()=>{
-        const targetRow = content.querySelector(`[data-job-row="${pendingJobFocus.id}"]`);
+        const targetRow = content.querySelector(`[data-job-row="${pendingJobFocus.id}"], [data-history-row="${pendingJobFocus.id}"]`);
         if (targetRow instanceof HTMLElement){
           targetRow.classList.add("job-row-link-highlight");
           try {

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -14543,11 +14543,22 @@ function computeCostModel(){
   const cuttingJobsDataTable = completedJobsForDataCenter.map((job, index) => {
     const categoryId = job?.cat != null ? String(job.cat) : "";
     const categoryLabel = categoryId ? resolveCategoryName(categoryId) : "Uncategorized";
+    const manualLogs = Array.isArray(job?.manualLogs) ? job.manualLogs : [];
+    const latestManualLog = manualLogs
+      .filter(entry => Number.isFinite(Number(entry?.completedHours)))
+      .sort((a, b) => String(a?.dateISO || "").localeCompare(String(b?.dateISO || "")))
+      .pop() || null;
+    const efficiencyActualHours = Number(job?.efficiency?.actualHours);
+    const computedEfficiency = typeof computeJobEfficiency === "function" ? computeJobEfficiency(job) : null;
+    const computedActualHours = Number(computedEfficiency?.actualHours);
     const actualHoursCandidates = [
       Number(job?.actualHours),
       Number(job?.durationHours),
       Number(job?.completedHours),
-      Number(job?.estimateHours)
+      Number(job?.estimateHours),
+      Number(latestManualLog?.completedHours),
+      efficiencyActualHours,
+      computedActualHours
     ];
     const hours = actualHoursCandidates.find(val => Number.isFinite(val) && val >= 0) ?? 0;
     const categoryKey = categoryId || "__uncategorized__";

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -14560,7 +14560,9 @@ function computeCostModel(){
       efficiencyActualHours,
       computedActualHours
     ];
-    const hours = actualHoursCandidates.find(val => Number.isFinite(val) && val >= 0) ?? 0;
+    const positiveHours = actualHoursCandidates.find(val => Number.isFinite(val) && val > 0);
+    const fallbackHours = actualHoursCandidates.find(val => Number.isFinite(val) && val >= 0);
+    const hours = Number.isFinite(positiveHours) ? positiveHours : (Number.isFinite(fallbackHours) ? fallbackHours : 0);
     const categoryKey = categoryId || "__uncategorized__";
     const categoryCutCount = cuttingCategoryRemaining.get(categoryKey) || 1;
     cuttingCategoryRemaining.set(categoryKey, Math.max(0, categoryCutCount - 1));

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -7699,6 +7699,20 @@ function renderSettings(){
     if (!validTaskIds.has(id)) openTaskState.delete(id);
   }
   if (typeof window._maintOrderCounter === "undefined") window._maintOrderCounter = 0;
+  try {
+    const hash = String(window.location?.hash || "");
+    const queryIndex = hash.indexOf("?");
+    if (queryIndex >= 0){
+      const query = hash.slice(queryIndex + 1);
+      const params = new URLSearchParams(query);
+      const taskId = (params.get("taskId") || "").trim();
+      if (taskId){
+        window.pendingMaintenanceFocus = { taskIds: [taskId] };
+      }
+    }
+  } catch (err){
+    console.error("Failed to parse maintenance focus from URL hash:", err);
+  }
 
   // --- one-time hydration for legacy/remote tasks (per-list) ---
   // Previously this only ran if BOTH lists were empty. That prevented legacy
@@ -10556,6 +10570,12 @@ function setupForecastBreakdownModal(){
 function renderCosts(){
   const content = document.getElementById("content");
   if (!content) return;
+  const previousModal = document.getElementById("costDataCenterModal");
+  const wasDataCenterOpen = Boolean(previousModal && !previousModal.hasAttribute("hidden"));
+  if (previousModal && previousModal.parentElement === document.body){
+    previousModal.remove();
+    document.body.classList.remove("cost-data-center-open");
+  }
 
   const escapeHtml = (str)=> String(str ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
 
@@ -10599,6 +10619,274 @@ function renderCosts(){
   setupCostTimeframeModal(model);
   setupJobCategoryWindow(model);
   setupWeeklyReportWindow(model);
+  setupMaintenanceDataCenterActions({ openImmediately: wasDataCenterOpen });
+
+  function focusCalendarAtOccurrence(taskId, dateISO){
+    const dueISO = String(dateISO || "");
+    const parsedDue = dueISO && typeof parseDateLocal === "function"
+      ? parseDateLocal(dueISO)
+      : (dueISO ? new Date(dueISO) : null);
+    if (parsedDue instanceof Date && !Number.isNaN(parsedDue.getTime())){
+      parsedDue.setHours(0,0,0,0);
+      const today = new Date();
+      today.setHours(0,0,0,0);
+      const diffMonths = (parsedDue.getFullYear() - today.getFullYear()) * 12 + (parsedDue.getMonth() - today.getMonth());
+      window.__calendarMonthOffset = Math.min(12, Math.max(-12, Math.round(diffMonths)));
+    }
+    if (typeof hideBubble === "function") hideBubble();
+    location.hash = "#/";
+    const runFocus = ()=>{
+      if (typeof renderCalendar === "function") renderCalendar();
+      const months = document.getElementById("months");
+      const cell = dueISO ? months?.querySelector(`[data-date-iso="${dueISO}"]`) : null;
+      if (!cell) return false;
+      cell.scrollIntoView({ behavior: "smooth", block: "center" });
+      if (typeof highlightCalendarDayCell === "function"){
+        highlightCalendarDayCell(cell);
+      }
+      const anchor = taskId ? (cell.querySelector(`[data-cal-task="${String(taskId)}"]`) || cell) : cell;
+      if (taskId && typeof showTaskBubble === "function"){
+        showTaskBubble(String(taskId), anchor, { dateISO: dueISO });
+      }
+      return true;
+    };
+    if (!runFocus()){
+      setTimeout(runFocus, 120);
+      setTimeout(runFocus, 320);
+    }
+  }
+
+  function setupMaintenanceDataCenterActions(options = {}){
+    const openBtn = content.querySelector("[data-open-data-center]");
+    const modal = content.querySelector("[data-data-center-modal]");
+    const closeBtns = Array.from(content.querySelectorAll("[data-close-data-center]"));
+    const tabButtons = modal instanceof HTMLElement ? Array.from(modal.querySelectorAll("[data-dc-tab]")) : [];
+    const panels = modal instanceof HTMLElement ? Array.from(modal.querySelectorAll("[data-dc-panel]")) : [];
+    const setActiveTab = (tabKey)=>{
+      tabButtons.forEach(btn => {
+        if (!(btn instanceof HTMLElement)) return;
+        const isActive = String(btn.getAttribute("data-dc-tab") || "") === tabKey;
+        btn.classList.toggle("is-active", isActive);
+        btn.setAttribute("aria-selected", isActive ? "true" : "false");
+      });
+      panels.forEach(panel => {
+        if (!(panel instanceof HTMLElement)) return;
+        const isActive = String(panel.getAttribute("data-dc-panel") || "") === tabKey;
+        panel.hidden = !isActive;
+      });
+    };
+    tabButtons.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", ()=>{
+        const key = String(btn.getAttribute("data-dc-tab") || "maintenance");
+        setActiveTab(key);
+      });
+    });
+    setActiveTab("maintenance");
+    if (modal instanceof HTMLElement){
+      document.body.appendChild(modal);
+    }
+    const closeDataCenter = ()=>{
+      if (!(modal instanceof HTMLElement)) return;
+      modal.setAttribute("hidden", "");
+      modal.setAttribute("aria-hidden", "true");
+      document.body.classList.remove("cost-data-center-open");
+    };
+    const openDataCenter = ()=>{
+      if (!(modal instanceof HTMLElement)) return;
+      modal.removeAttribute("hidden");
+      modal.setAttribute("aria-hidden", "false");
+      document.body.classList.add("cost-data-center-open");
+      try { modal.focus({ preventScroll: true }); } catch (_err){ modal.focus(); }
+      const panel = modal.querySelector(".cost-data-center-panel");
+      if (panel instanceof HTMLElement){
+        panel.scrollTop = 0;
+      }
+    };
+    if (openBtn instanceof HTMLElement && modal instanceof HTMLElement){
+      openBtn.addEventListener("click", openDataCenter);
+      closeBtns.forEach(btn => {
+        if (!(btn instanceof HTMLElement)) return;
+        btn.addEventListener("click", closeDataCenter);
+      });
+      if (!modal.dataset.wired){
+        modal.dataset.wired = "1";
+        modal.addEventListener("keydown", (event)=>{
+          if (event.key === "Escape" && !modal.hasAttribute("hidden")){
+            closeDataCenter();
+          }
+        });
+      }
+      if (options && options.openImmediately){
+        openDataCenter();
+      }
+    }
+
+    const searchInput = modal instanceof HTMLElement ? modal.querySelector("[data-maintenance-search]") : null;
+    const categoryFilter = modal instanceof HTMLElement ? modal.querySelector("[data-maintenance-filter-category]") : null;
+    const taskFilter = modal instanceof HTMLElement ? modal.querySelector("[data-maintenance-filter-task]") : null;
+    const suggestionsBox = modal instanceof HTMLElement ? modal.querySelector("[data-maintenance-search-suggestions]") : null;
+    const suggestionState = { items: [] };
+    const computeSuggestions = (term, rows)=>{
+      const normalizedTerm = String(term || "").trim().toLowerCase();
+      if (!normalizedTerm) return [];
+      const counts = new Map();
+      rows.forEach(row => {
+        if (!(row instanceof HTMLElement)) return;
+        const taskName = String(row.getAttribute("data-task-name") || "").trim();
+        if (!taskName) return;
+        const key = taskName.toLowerCase();
+        counts.set(key, { taskName, count: (counts.get(key)?.count || 0) + 1 });
+      });
+      const ranked = Array.from(counts.values())
+        .map(item => {
+          const lower = item.taskName.toLowerCase();
+          const starts = lower.startsWith(normalizedTerm) ? 2 : 0;
+          const contains = !starts && lower.includes(normalizedTerm) ? 1 : 0;
+          return { ...item, score: starts + contains };
+        })
+        .filter(item => item.score > 0)
+        .sort((a, b) => {
+          if (b.score !== a.score) return b.score - a.score;
+          if (b.count !== a.count) return b.count - a.count;
+          return a.taskName.localeCompare(b.taskName);
+        })
+        .slice(0, 3);
+      return ranked.map(item => item.taskName);
+    };
+    const renderSuggestions = ()=>{
+      if (!(suggestionsBox instanceof HTMLElement) || !(searchInput instanceof HTMLInputElement) || !(modal instanceof HTMLElement)) return;
+      const tableRows = Array.from(modal.querySelectorAll("[data-maintenance-row]"));
+      suggestionState.items = computeSuggestions(searchInput.value, tableRows);
+      if (!suggestionState.items.length){
+        suggestionsBox.hidden = true;
+        suggestionsBox.innerHTML = "";
+        return;
+      }
+      suggestionsBox.innerHTML = suggestionState.items.map((label, idx)=> `
+        <button type="button" class="cost-data-center-suggestion" data-suggestion-index="${idx}">${escapeHtml(label)}</button>
+      `).join("");
+      suggestionsBox.hidden = false;
+      Array.from(suggestionsBox.querySelectorAll("[data-suggestion-index]")).forEach(btn => {
+        if (!(btn instanceof HTMLElement)) return;
+        btn.addEventListener("click", ()=>{
+          const index = Number(btn.getAttribute("data-suggestion-index"));
+          const selected = suggestionState.items[index];
+          if (!selected || !(searchInput instanceof HTMLInputElement)) return;
+          searchInput.value = selected;
+          applySearchFilter();
+          renderSuggestions();
+          try { searchInput.focus({ preventScroll: true }); } catch (_err){ searchInput.focus(); }
+        });
+      });
+    };
+    const applySearchFilter = ()=>{
+      if (!(modal instanceof HTMLElement)) return;
+      const term = String(searchInput instanceof HTMLInputElement ? searchInput.value : "").trim().toLowerCase();
+      const categoryValue = String(categoryFilter instanceof HTMLSelectElement ? categoryFilter.value : "").trim();
+      const taskValue = String(taskFilter instanceof HTMLSelectElement ? taskFilter.value : "").trim().toLowerCase();
+      const tableRows = Array.from(modal.querySelectorAll("[data-maintenance-row]"));
+      tableRows.forEach(row => {
+        if (!(row instanceof HTMLElement)) return;
+        const haystack = String(row.getAttribute("data-search-text") || "").toLowerCase();
+        const rowCategory = String(row.getAttribute("data-category-id") || "");
+        const rowTask = String(row.getAttribute("data-task-key") || "").toLowerCase();
+        const matchesSearch = !term || haystack.includes(term);
+        const matchesCategory = !categoryValue || rowCategory === categoryValue;
+        const matchesTask = !taskValue || rowTask === taskValue;
+        const matches = matchesSearch && matchesCategory && matchesTask;
+        row.hidden = !matches;
+      });
+    };
+    if (searchInput instanceof HTMLInputElement){
+      searchInput.addEventListener("input", ()=>{
+        applySearchFilter();
+        renderSuggestions();
+      });
+      searchInput.addEventListener("keydown", (event)=>{
+        if (event.key === "Tab" && suggestionState.items.length){
+          event.preventDefault();
+          const selected = suggestionState.items[0];
+          if (selected){
+            searchInput.value = selected;
+            applySearchFilter();
+            renderSuggestions();
+          }
+        }
+      });
+      applySearchFilter();
+      renderSuggestions();
+    }
+    if (categoryFilter instanceof HTMLSelectElement){
+      categoryFilter.addEventListener("change", ()=>{
+        applySearchFilter();
+        renderSuggestions();
+      });
+    }
+    if (taskFilter instanceof HTMLSelectElement){
+      taskFilter.addEventListener("change", ()=>{
+        applySearchFilter();
+        renderSuggestions();
+      });
+    }
+
+    const cuttingSearchInput = modal instanceof HTMLElement ? modal.querySelector("[data-cutting-search]") : null;
+    const cuttingCategoryFilter = modal instanceof HTMLElement ? modal.querySelector("[data-cutting-filter-category]") : null;
+    const cuttingTaskFilter = modal instanceof HTMLElement ? modal.querySelector("[data-cutting-filter-job]") : null;
+    const applyCuttingFilter = ()=>{
+      if (!(modal instanceof HTMLElement)) return;
+      const term = String(cuttingSearchInput instanceof HTMLInputElement ? cuttingSearchInput.value : "").trim().toLowerCase();
+      const categoryValue = String(cuttingCategoryFilter instanceof HTMLSelectElement ? cuttingCategoryFilter.value : "").trim();
+      const taskValue = String(cuttingTaskFilter instanceof HTMLSelectElement ? cuttingTaskFilter.value : "").trim().toLowerCase();
+      const rows = Array.from(modal.querySelectorAll("[data-cutting-row]"));
+      rows.forEach(row => {
+        if (!(row instanceof HTMLElement)) return;
+        const haystack = String(row.getAttribute("data-cutting-search-text") || "").toLowerCase();
+        const rowCategory = String(row.getAttribute("data-cutting-category-id") || "");
+        const rowJob = String(row.getAttribute("data-cutting-job-key") || "").toLowerCase();
+        const matchesSearch = !term || haystack.includes(term);
+        const matchesCategory = !categoryValue || rowCategory === categoryValue;
+        const matchesTask = !taskValue || rowJob === taskValue;
+        row.hidden = !(matchesSearch && matchesCategory && matchesTask);
+      });
+    };
+    if (cuttingSearchInput instanceof HTMLInputElement){
+      cuttingSearchInput.addEventListener("input", applyCuttingFilter);
+      applyCuttingFilter();
+    }
+    if (cuttingCategoryFilter instanceof HTMLSelectElement){
+      cuttingCategoryFilter.addEventListener("change", applyCuttingFilter);
+    }
+    if (cuttingTaskFilter instanceof HTMLSelectElement){
+      cuttingTaskFilter.addEventListener("change", applyCuttingFilter);
+    }
+
+    const rows = Array.from((modal instanceof HTMLElement ? modal : content).querySelectorAll("[data-maintenance-open-task]"));
+    if (!rows.length) return;
+    rows.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", ()=>{
+        const modeId = String(btn.getAttribute("data-link-mode-id") || "");
+        const explicitSelect = modeId ? document.getElementById(modeId) : null;
+        const row = btn.closest("tr");
+        const fallbackSelect = row ? row.querySelector("[data-maintenance-link-mode]") : null;
+        const select = (explicitSelect instanceof HTMLSelectElement) ? explicitSelect : fallbackSelect;
+        const destination = String((select instanceof HTMLSelectElement ? select.value : "calendar") || "calendar").toLowerCase();
+        const taskId = String(btn.getAttribute("data-task-id") || "");
+        const dateISO = String(btn.getAttribute("data-date-iso") || "");
+        if (destination === "settings"){
+          closeDataCenter();
+          if (taskId){
+            window.pendingMaintenanceFocus = { taskIds: [taskId] };
+          }
+          location.hash = "#/settings";
+          return;
+        }
+        closeDataCenter();
+        focusCalendarAtOccurrence(taskId, dateISO);
+      });
+    });
+  }
 
   function setupCostTimeframeModal(currentModel){
     if (typeof window.__cleanupCostTimeframeModal === "function"){
@@ -14187,6 +14475,161 @@ function computeCostModel(){
     emptyMessage: orderRows.length ? "" : "Approve or deny order requests to build the spend log."
   };
 
+  const cuttingJobsDataTable = (Array.isArray(completedCuttingJobs) ? completedCuttingJobs : []).map((job, index) => {
+    const categoryId = job?.cat != null ? String(job.cat) : "";
+    const categoryLabel = categoryId ? resolveCategoryName(categoryId) : "Uncategorized";
+    const actualHoursCandidates = [
+      Number(job?.actualHours),
+      Number(job?.durationHours),
+      Number(job?.completedHours),
+      Number(job?.estimateHours)
+    ];
+    const hours = actualHoursCandidates.find(val => Number.isFinite(val) && val >= 0) ?? 0;
+    const chargeRateRaw = Number(job?.chargeRate);
+    const costRateRaw = Number(job?.costRate);
+    const chargeRate = Number.isFinite(chargeRateRaw) && chargeRateRaw >= 0 ? chargeRateRaw : JOB_RATE_PER_HOUR;
+    const costRate = Number.isFinite(costRateRaw) && costRateRaw >= 0 ? costRateRaw : JOB_BASE_COST_PER_HOUR;
+    const materialCost = Number(job?.materialCost);
+    const materialQty = Number(job?.materialQty);
+    const completedISO = typeof job?.completedAtISO === "string" && job.completedAtISO ? job.completedAtISO : "";
+    return {
+      id: job?.id != null ? String(job.id) : `completed_job_${index}`,
+      name: job?.name || `Completed job ${index + 1}`,
+      categoryId,
+      categoryLabel,
+      hoursLabel: formatHoursValue(hours) || "0",
+      chargeRateLabel: formatterCurrency(chargeRate, { decimals: 2 }),
+      costRateLabel: formatterCurrency(costRate, { decimals: 2 }),
+      materialType: String(job?.material || "—"),
+      materialCostLabel: Number.isFinite(materialCost) ? formatterCurrency(materialCost, { decimals: 2 }) : "—",
+      materialQtyLabel: Number.isFinite(materialQty) ? String(materialQty) : "—",
+      startDateLabel: job?.startISO || "—",
+      dueDateLabel: job?.dueISO || "—",
+      completedDateLabel: completedISO ? String(completedISO).slice(0, 10) : "—",
+      projectNumber: String(job?.projectNumber || "—"),
+      notes: String(job?.notes || "").trim() || "—",
+      priorityLabel: Number.isFinite(Number(job?.priority)) ? String(Math.max(1, Math.floor(Number(job.priority)))) : "—"
+    };
+  });
+
+  const taskById = new Map();
+  [Array.isArray(intervalTasksAll) ? intervalTasksAll : [], Array.isArray(asReqTasksAll) ? asReqTasksAll : []].forEach(list => {
+    list.forEach(task => {
+      if (!task || task.id == null) return;
+      taskById.set(String(task.id), task);
+    });
+  });
+  const categoryById = new Map();
+  const categoryParentById = new Map();
+  if (Array.isArray(window.settingsFolders)){
+    window.settingsFolders.forEach(folder => {
+      if (!folder || folder.id == null) return;
+      categoryById.set(String(folder.id), String(folder.name || "Category"));
+      categoryParentById.set(String(folder.id), folder.parent != null ? String(folder.parent) : null);
+    });
+  }
+  const resolveCategoryPath = (categoryId)=>{
+    const key = String(categoryId || "");
+    if (!key) return "";
+    const visited = new Set();
+    const names = [];
+    let current = key;
+    while (current && !visited.has(current)){
+      visited.add(current);
+      const name = categoryById.get(current);
+      if (name) names.unshift(name);
+      current = categoryParentById.get(current) || null;
+    }
+    return names.join(" › ");
+  };
+  const maintenanceDataTableRows = [];
+  const taskDateGroups = new Map();
+  taskEventsByDate.forEach((tasksOnDate, dateISO) => {
+    const key = toHistoryDateKey(dateISO);
+    if (!key || !Array.isArray(tasksOnDate)) return;
+    tasksOnDate.forEach(taskMeta => {
+      if (!taskMeta) return;
+      const originalId = taskMeta.originalId != null ? String(taskMeta.originalId) : (taskMeta.id != null ? String(taskMeta.id) : null);
+      if (!originalId) return;
+      const groupKey = originalId;
+      if (!taskDateGroups.has(groupKey)) taskDateGroups.set(groupKey, []);
+      taskDateGroups.get(groupKey).push(key);
+      const task = taskById.get(originalId) || taskById.get(String(taskMeta.id || "")) || null;
+      const taskModeRaw = String(task?.mode || taskMeta?.mode || "interval").toLowerCase();
+      const taskMode = taskModeRaw === "asreq" ? "asreq" : "interval";
+      const modeLabel = taskMode === "asreq" ? "As Required" : "Per Interval";
+      const rawCategoryId = task?.cat != null ? String(task.cat) : "";
+      const categoryPath = rawCategoryId ? (resolveCategoryPath(rawCategoryId) || rawCategoryId) : "";
+      const categoryId = `${taskMode}:${rawCategoryId || "uncategorized"}`;
+      const categoryLabel = categoryPath ? `${modeLabel} • ${categoryPath}` : `${modeLabel} • Uncategorized`;
+      const maintenanceHours = Number(task?.downtimeHours);
+      const maintenanceHrs = Number.isFinite(maintenanceHours) && maintenanceHours > 0 ? maintenanceHours : 1;
+      const partCost = Number(taskMeta?.unitPrice);
+      const partCostValue = Number.isFinite(partCost) && partCost > 0 ? partCost : 0;
+      const chargeRate = MAINTENANCE_LABOR_RATE_PER_HOUR;
+      const laborCost = maintenanceHrs * chargeRate;
+      const totalCost = laborCost + partCostValue;
+      const snapshotHours = typeof hoursSnapshotOnOrBefore === "function" ? hoursSnapshotOnOrBefore(key) : null;
+      const hoursSince = (Number.isFinite(Number(currentHours)) && Number.isFinite(Number(snapshotHours)))
+        ? Math.max(0, Number(currentHours) - Number(snapshotHours))
+        : null;
+      maintenanceDataTableRows.push({
+        taskId: originalId,
+        taskName: taskMeta.name || task?.name || "Maintenance task",
+        maintenanceHrs,
+        partCost: partCostValue,
+        chargeRate,
+        laborCost,
+        totalCost,
+        dateISO: key,
+        cuttingHoursSince: hoursSince,
+        settingsLink: `#/settings?taskId=${encodeURIComponent(originalId)}`,
+        categoryId,
+        categoryLabel,
+        taskMode
+      });
+    });
+  });
+  taskDateGroups.forEach((dateList, taskId) => {
+    const normalizedDates = Array.isArray(dateList) ? dateList.filter(Boolean) : [];
+    const uniqueDates = [...new Set(normalizedDates)].sort((a, b) => b.localeCompare(a));
+    const qty = uniqueDates.length;
+    uniqueDates.forEach((dateISO, index) => {
+      const row = maintenanceDataTableRows.find(item => item.taskId === taskId && item.dateISO === dateISO);
+      if (!row) return;
+      row.qty = qty;
+      row.counter = Math.max(1, qty - index);
+      const current = parseDateLocal(dateISO);
+      const today = new Date();
+      today.setHours(0,0,0,0);
+      if (current instanceof Date && !Number.isNaN(current.getTime())){
+        current.setHours(0,0,0,0);
+        row.daysSinceTask = Math.max(0, Math.round((today.getTime() - current.getTime()) / JOB_DAY_MS));
+      }else{
+        row.daysSinceTask = null;
+      }
+    });
+  });
+  maintenanceDataTableRows.sort((a,b)=> String(b.dateISO || "").localeCompare(String(a.dateISO || "")));
+  const maintenanceDataTable = maintenanceDataTableRows.map((row, idx) => ({
+    id: `${row.taskId}_${row.dateISO}_${idx}`,
+    taskId: row.taskId,
+    taskName: row.taskName,
+    maintenanceHrsLabel: formatHoursValue(row.maintenanceHrs) || "0",
+    partCostLabel: formatterCurrency(row.partCost, { decimals: row.partCost < 1000 ? 2 : 0 }),
+    chargeRateLabel: formatterCurrency(row.chargeRate, { decimals: 2 }),
+    laborCostLabel: formatterCurrency(row.laborCost, { decimals: row.laborCost < 1000 ? 2 : 0 }),
+    totalCostLabel: formatterCurrency(row.totalCost, { decimals: row.totalCost < 1000 ? 2 : 0 }),
+    dateISO: row.dateISO,
+    daysSinceLabel: Number.isFinite(row.daysSinceTask) ? String(row.daysSinceTask) : "—",
+    cuttingHoursSinceLabel: Number.isFinite(row.cuttingHoursSince) ? formatHoursValue(row.cuttingHoursSince) : "—",
+    settingsLink: row.settingsLink,
+    categoryId: row.categoryId || "",
+    categoryLabel: row.categoryLabel || "",
+    qtyLabel: Number.isFinite(row.qty) ? String(row.qty) : "1",
+    counterLabel: Number.isFinite(row.counter) ? `#${row.counter}` : "#1"
+  }));
+
   return {
     summaryCards,
     timeframeRows,
@@ -14202,6 +14645,8 @@ function computeCostModel(){
     chartNote,
     chartInfo,
     orderRequestSummary,
+    maintenanceDataTable,
+    cuttingJobsDataTable,
     chartColors: COST_CHART_COLORS,
     maintenanceSeries,
     jobSeries,

--- a/js/views.js
+++ b/js/views.js
@@ -1238,9 +1238,6 @@ function viewCosts(model){
     const [id, label] = entry.split("|||");
     return { id, label };
   }).sort((a, b) => a.label.localeCompare(b.label));
-  const cuttingJobTaskOptions = Array.from(new Set(
-    cuttingJobsDataTable.map(row => String(row?.name || "").trim()).filter(Boolean)
-  )).sort((a, b) => a.localeCompare(b));
   const overviewInsight = data.overviewInsight || "Totals blend the latest maintenance allocations, consumable burn rates, downtime burdens, and job margin data so you always see current cost exposure.";
   const ordersInsight = data.ordersInsight || "Tracks every waterjet part request from submission through approval so finance can confirm spend and spot stalled orders.";
   const timeframeInsight = data.timeframeInsight || "Usage windows combine logged machine hours with interval pricing to estimate what each upcoming maintenance window will cost.";
@@ -2084,17 +2081,14 @@ function viewCosts(model){
                     <option value="">All categories</option>
                     ${cuttingJobCategoryOptions.map(opt => `<option value="${esc(opt.id)}">${esc(opt.label)}</option>`).join("")}
                   </select>
-                  <label for="costDataCenterCuttingTaskFilter">Filter by job</label>
-                  <select id="costDataCenterCuttingTaskFilter" data-cutting-filter-job>
-                    <option value="">All jobs</option>
-                    ${cuttingJobTaskOptions.map(name => `<option value="${esc(name.toLowerCase())}">${esc(name)}</option>`).join("")}
-                  </select>
                 </div>
                 ${cuttingJobsDataTable.length ? `
                 <table class="cost-table" style="margin-top:10px">
                   <thead>
                     <tr>
                       <th>Job name</th>
+                      <th>Cumulative cut #</th>
+                      <th>Category cut #</th>
                       <th>Category</th>
                       <th>Hours</th>
                       <th>Charge rate/hr</th>
@@ -2108,12 +2102,15 @@ function viewCosts(model){
                       <th>Project #</th>
                       <th>Priority</th>
                       <th>Notes</th>
+                      <th>Job link</th>
                     </tr>
                   </thead>
                   <tbody>
                     ${cuttingJobsDataTable.map(row => `
                       <tr data-cutting-row data-cutting-category-id="${esc(String(row.categoryId || ""))}" data-cutting-job-key="${esc(String(row.name || "").toLowerCase())}" data-cutting-search-text="${esc(`${row.name || ""} ${row.categoryLabel || ""} ${row.materialType || ""} ${row.projectNumber || ""} ${row.completedDateLabel || ""}`.toLowerCase())}">
                         <td>${esc(row.name || "—")}</td>
+                        <td>${esc(row.cumulativeCutNumberLabel || "—")}</td>
+                        <td>${esc(row.categoryCutNumberLabel || "—")}</td>
                         <td>${esc(row.categoryLabel || "—")}</td>
                         <td>${esc(row.hoursLabel || "0")}</td>
                         <td>${esc(row.chargeRateLabel || "—")}</td>
@@ -2127,6 +2124,7 @@ function viewCosts(model){
                         <td>${esc(row.projectNumber || "—")}</td>
                         <td>${esc(row.priorityLabel || "—")}</td>
                         <td>${esc(row.notes || "—")}</td>
+                        <td><button type="button" data-cutting-open-job data-job-id="${esc(row.id || "")}">Open job</button></td>
                       </tr>
                     `).join("")}
                   </tbody>

--- a/js/views.js
+++ b/js/views.js
@@ -1213,6 +1213,34 @@ function viewCosts(model){
   const chartInfo = data.chartInfo || "Maintenance cost line spreads interval pricing and approved as-required spend across logged machine hours; cutting jobs line tracks the rolling average gain or loss per completed job to spotlight margin drift.";
   const orderSummary = data.orderRequestSummary || {};
   const orderRows = Array.isArray(orderSummary.rows) ? orderSummary.rows : [];
+  const maintenanceDataTable = Array.isArray(data.maintenanceDataTable) ? data.maintenanceDataTable : [];
+  const maintenanceCategoryOptions = Array.from(new Set(
+    maintenanceDataTable
+      .map(row => ({ id: String(row?.categoryId || ""), label: String(row?.categoryLabel || "") }))
+      .filter(entry => entry.id && entry.label)
+      .map(entry => `${entry.id}|||${entry.label}`)
+  )).map(entry => {
+    const [id, label] = entry.split("|||");
+    return { id, label };
+  }).sort((a, b) => a.label.localeCompare(b.label));
+  const maintenanceTaskOptions = Array.from(new Set(
+    maintenanceDataTable
+      .map(row => String(row?.taskName || "").trim())
+      .filter(Boolean)
+  )).sort((a, b) => a.localeCompare(b));
+  const cuttingJobsDataTable = Array.isArray(data.cuttingJobsDataTable) ? data.cuttingJobsDataTable : [];
+  const cuttingJobCategoryOptions = Array.from(new Set(
+    cuttingJobsDataTable
+      .map(row => ({ id: String(row?.categoryId || ""), label: String(row?.categoryLabel || "") }))
+      .filter(entry => entry.label)
+      .map(entry => `${entry.id}|||${entry.label}`)
+  )).map(entry => {
+    const [id, label] = entry.split("|||");
+    return { id, label };
+  }).sort((a, b) => a.label.localeCompare(b.label));
+  const cuttingJobTaskOptions = Array.from(new Set(
+    cuttingJobsDataTable.map(row => String(row?.name || "").trim()).filter(Boolean)
+  )).sort((a, b) => a.localeCompare(b));
   const overviewInsight = data.overviewInsight || "Totals blend the latest maintenance allocations, consumable burn rates, downtime burdens, and job margin data so you always see current cost exposure.";
   const ordersInsight = data.ordersInsight || "Tracks every waterjet part request from submission through approval so finance can confirm spend and spot stalled orders.";
   const timeframeInsight = data.timeframeInsight || "Usage windows combine logged machine hours with interval pricing to estimate what each upcoming maintenance window will cost.";
@@ -1958,6 +1986,152 @@ function viewCosts(model){
               </button>
               <div class="chart-info-bubble" id="costHistoryInsight" role="tooltip">
                 <p>${esc(historyInsight)}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="dashboard-window" data-cost-window="dataCenter">
+        <div class="block">
+          <h3>Maintenance Data Center Table</h3>
+          <div class="small muted" style="margin-bottom:8px;">Open as a full-size popup for review and auditing.</div>
+          <button type="button" class="secondary" data-open-data-center ${maintenanceDataTable.length ? "" : "disabled"}>Open Data Center</button>
+          <div id="costDataCenterModal" class="cost-data-center-modal" data-data-center-modal hidden aria-hidden="true" tabindex="-1">
+            <div class="cost-data-center-backdrop" data-close-data-center></div>
+            <div class="cost-data-center-panel" role="dialog" aria-modal="true" aria-labelledby="dataCenterTitle">
+              <div class="cost-data-center-header">
+                <h3 id="dataCenterTitle">Maintenance Data Center Table</h3>
+                <button type="button" class="secondary" data-close-data-center>Close</button>
+              </div>
+              <div class="cost-data-center-tabs" role="tablist" aria-label="Data center tables">
+                <button type="button" class="cost-data-center-tab is-active" data-dc-tab="maintenance" role="tab" aria-selected="true">Maintenance Tasks</button>
+                <button type="button" class="cost-data-center-tab" data-dc-tab="cutting" role="tab" aria-selected="false">Completed Cutting Jobs</button>
+              </div>
+              <div class="cost-data-center-panel-content" data-dc-panel="maintenance">
+              <div class="cost-data-center-search">
+                <label for="costDataCenterSearch">Search table</label>
+                <input id="costDataCenterSearch" type="search" placeholder="Search task, date, counter, or link target" data-maintenance-search>
+                <label for="costDataCenterCategoryFilter">Filter by category</label>
+                <select id="costDataCenterCategoryFilter" data-maintenance-filter-category>
+                  <option value="">All categories</option>
+                  ${maintenanceCategoryOptions.map(opt => `<option value="${esc(opt.id)}">${esc(opt.label)}</option>`).join("")}
+                </select>
+                <label for="costDataCenterTaskFilter">Filter by task</label>
+                <select id="costDataCenterTaskFilter" data-maintenance-filter-task>
+                  <option value="">All tasks</option>
+                  ${maintenanceTaskOptions.map(name => `<option value="${esc(name.toLowerCase())}">${esc(name)}</option>`).join("")}
+                </select>
+                <div class="cost-data-center-search-suggestions" data-maintenance-search-suggestions hidden></div>
+              </div>
+              ${maintenanceDataTable.length ? `
+            <table class="cost-table" style="margin-top:10px">
+              <thead>
+                <tr>
+                  <th>Counter</th>
+                  <th>Task</th>
+                  <th>Maint. hrs</th>
+                  <th>Part cost</th>
+                  <th>Rate/hr</th>
+                  <th>Labor cost</th>
+                  <th>Total cost</th>
+                  <th>Date</th>
+                  <th>Days since</th>
+                  <th>Cut hrs since</th>
+                  <th>Qty</th>
+                  <th>Task link</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${maintenanceDataTable.map(row => `
+                  <tr data-maintenance-row data-category-id="${esc(String(row.categoryId || ""))}" data-task-key="${esc(String(row.taskName || "").toLowerCase())}" data-task-name="${esc(row.taskName || "")}" data-search-text="${esc(`${row.counterLabel || ""} ${row.taskName || ""} ${row.dateISO || ""} ${row.qtyLabel || ""}`.toLowerCase())}">
+                    <td>${esc(row.counterLabel || "#1")}</td>
+                    <td>${esc(row.taskName || "Maintenance task")}</td>
+                    <td>${esc(row.maintenanceHrsLabel || "0")}</td>
+                    <td>${esc(row.partCostLabel || "$0.00")}</td>
+                    <td>${esc(row.chargeRateLabel || "$0.00")}</td>
+                    <td>${esc(row.laborCostLabel || "$0.00")}</td>
+                    <td>${esc(row.totalCostLabel || "$0.00")}</td>
+                    <td>${esc(row.dateISO || "—")}</td>
+                    <td>${esc(row.daysSinceLabel || "—")}</td>
+                    <td>${esc(row.cuttingHoursSinceLabel || "—")}</td>
+                    <td>${esc(row.qtyLabel || "1")}</td>
+                    <td>
+                      <label class="sr-only" for="maintenanceLinkMode_${esc(row.id || "")}">Destination</label>
+                      <select id="maintenanceLinkMode_${esc(row.id || "")}" data-maintenance-link-mode>
+                        <option value="calendar">Calendar</option>
+                        <option value="settings">Maintenance Settings</option>
+                      </select>
+                      <button type="button"
+                        data-maintenance-open-task
+                        data-task-id="${esc(row.taskId || "")}"
+                        data-date-iso="${esc(row.dateISO || "")}"
+                        data-link-mode-id="maintenanceLinkMode_${esc(row.id || "")}"
+                        data-settings-link="${esc(row.settingsLink || "#/settings")}">Open task</button>
+                    </td>
+                  </tr>
+                `).join("")}
+              </tbody>
+            </table>
+            ` : `<p class="small muted">No completed maintenance occurrences yet.</p>`}
+              </div>
+              <div class="cost-data-center-panel-content" data-dc-panel="cutting" hidden>
+                <div class="cost-data-center-search">
+                  <label for="costDataCenterCuttingSearch">Search completed jobs</label>
+                  <input id="costDataCenterCuttingSearch" type="search" placeholder="Search job name, date, material, or project #" data-cutting-search>
+                  <label for="costDataCenterCuttingCategoryFilter">Filter by category</label>
+                  <select id="costDataCenterCuttingCategoryFilter" data-cutting-filter-category>
+                    <option value="">All categories</option>
+                    ${cuttingJobCategoryOptions.map(opt => `<option value="${esc(opt.id)}">${esc(opt.label)}</option>`).join("")}
+                  </select>
+                  <label for="costDataCenterCuttingTaskFilter">Filter by job</label>
+                  <select id="costDataCenterCuttingTaskFilter" data-cutting-filter-job>
+                    <option value="">All jobs</option>
+                    ${cuttingJobTaskOptions.map(name => `<option value="${esc(name.toLowerCase())}">${esc(name)}</option>`).join("")}
+                  </select>
+                </div>
+                ${cuttingJobsDataTable.length ? `
+                <table class="cost-table" style="margin-top:10px">
+                  <thead>
+                    <tr>
+                      <th>Job name</th>
+                      <th>Category</th>
+                      <th>Hours</th>
+                      <th>Charge rate/hr</th>
+                      <th>Cost rate/hr</th>
+                      <th>Material type</th>
+                      <th>Material cost</th>
+                      <th>Material qty</th>
+                      <th>Start date</th>
+                      <th>Due date</th>
+                      <th>Completed date</th>
+                      <th>Project #</th>
+                      <th>Priority</th>
+                      <th>Notes</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    ${cuttingJobsDataTable.map(row => `
+                      <tr data-cutting-row data-cutting-category-id="${esc(String(row.categoryId || ""))}" data-cutting-job-key="${esc(String(row.name || "").toLowerCase())}" data-cutting-search-text="${esc(`${row.name || ""} ${row.categoryLabel || ""} ${row.materialType || ""} ${row.projectNumber || ""} ${row.completedDateLabel || ""}`.toLowerCase())}">
+                        <td>${esc(row.name || "—")}</td>
+                        <td>${esc(row.categoryLabel || "—")}</td>
+                        <td>${esc(row.hoursLabel || "0")}</td>
+                        <td>${esc(row.chargeRateLabel || "—")}</td>
+                        <td>${esc(row.costRateLabel || "—")}</td>
+                        <td>${esc(row.materialType || "—")}</td>
+                        <td>${esc(row.materialCostLabel || "—")}</td>
+                        <td>${esc(row.materialQtyLabel || "—")}</td>
+                        <td>${esc(row.startDateLabel || "—")}</td>
+                        <td>${esc(row.dueDateLabel || "—")}</td>
+                        <td>${esc(row.completedDateLabel || "—")}</td>
+                        <td>${esc(row.projectNumber || "—")}</td>
+                        <td>${esc(row.priorityLabel || "—")}</td>
+                        <td>${esc(row.notes || "—")}</td>
+                      </tr>
+                    `).join("")}
+                  </tbody>
+                </table>
+                ` : `<p class="small muted">No completed cutting jobs yet.</p>`}
               </div>
             </div>
           </div>

--- a/js/views.js
+++ b/js/views.js
@@ -2124,7 +2124,14 @@ function viewCosts(model){
                         <td>${esc(row.projectNumber || "—")}</td>
                         <td>${esc(row.priorityLabel || "—")}</td>
                         <td>${esc(row.notes || "—")}</td>
-                        <td><button type="button" data-cutting-open-job data-job-id="${esc(row.id || "")}">Open job</button></td>
+                        <td>
+                          <label class="sr-only" for="cuttingLinkMode_${esc(row.id || "")}">Cutting link destination</label>
+                          <select id="cuttingLinkMode_${esc(row.id || "")}" data-cutting-link-mode>
+                            <option value="jobs">Cutting jobs page</option>
+                            <option value="calendar">Calendar</option>
+                          </select>
+                          <button type="button" data-cutting-open-job data-job-id="${esc(row.id || "")}" data-date-iso="${esc(row.completedDateLabel || "")}" data-link-mode-id="cuttingLinkMode_${esc(row.id || "")}">Open job</button>
+                        </td>
                       </tr>
                     `).join("")}
                   </tbody>

--- a/style.css
+++ b/style.css
@@ -500,6 +500,43 @@ body.pump-notes-open { overflow:hidden; }
 .cost-timeframe-row:focus-visible{ outline:2px solid var(--brand-blue-400, #2563eb); outline-offset:2px; }
 .cost-timeframe-section .small.muted{ margin-top:0; }
 body.cost-timeframe-modal-open{ overflow:hidden; }
+.cost-data-center-modal{ position:fixed; inset:0; z-index:99999; display:flex; align-items:center; justify-content:center; padding:24px; }
+.cost-data-center-modal[hidden]{ display:none; }
+.cost-data-center-backdrop{ position:absolute; inset:0; background:rgba(15,23,42,0.5); }
+.cost-data-center-panel{
+  position:relative;
+  width:min(1600px,98vw);
+  max-height:92vh;
+  overflow:auto;
+  background:#fff;
+  border-radius:12px;
+  box-shadow:0 20px 46px rgba(2,8,20,.35);
+  padding:16px;
+  color:#000;
+}
+.cost-data-center-header{ display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
+.cost-data-center-tabs{ display:flex; gap:8px; margin-bottom:10px; }
+.cost-data-center-tab{ border:1px solid #a8b6ce; background:#eef3ff; color:#0b1a38; padding:7px 12px; border-radius:6px; cursor:pointer; font-weight:600; }
+.cost-data-center-tab.is-active{ background:#0a63c2; color:#fff; border-color:#0a63c2; }
+.cost-data-center-panel-content[hidden]{ display:none !important; }
+.cost-data-center-search{ display:flex; flex-direction:column; gap:6px; margin-bottom:10px; max-width:360px; }
+.cost-data-center-search label{ font-weight:600; font-size:14px; }
+.cost-data-center-search input{ border:1px solid #9aa6bb; border-radius:6px; padding:8px 10px; font-size:14px; color:#000; background:#fff; }
+.cost-data-center-search-suggestions{ display:flex; flex-direction:column; gap:4px; border:1px solid #b9c4d6; border-radius:6px; background:#fff; padding:4px; }
+.cost-data-center-suggestion{ text-align:left; border:0; background:#f4f7ff; color:#000; padding:6px 8px; border-radius:4px; cursor:pointer; font-size:13px; }
+.cost-data-center-suggestion:hover{ background:#e7eeff; }
+.cost-data-center-panel h3,
+.cost-data-center-panel .small,
+.cost-data-center-panel .muted,
+.cost-data-center-panel .cost-table,
+.cost-data-center-panel .cost-table th,
+.cost-data-center-panel .cost-table td,
+.cost-data-center-panel label,
+.cost-data-center-panel select,
+.cost-data-center-panel button{
+  color:#000;
+}
+body.cost-data-center-open{ overflow:hidden; }
 @media (max-width: 640px){
   .cost-timeframe-card-body{ padding:24px 18px 28px; }
   .cost-timeframe-table th,.cost-timeframe-table td{ padding:8px 10px; }

--- a/style.css
+++ b/style.css
@@ -2530,7 +2530,9 @@ body.modal-open .auth-bar {
   animation: job-priority-shift 0.5s ease;
 }
 .job-row-link-highlight > td{
-  animation: job-link-highlight 2s ease;
+  background-color: rgba(76, 164, 255, 0.28) !important;
+  box-shadow: inset 0 0 0 1px rgba(76, 164, 255, 0.38);
+  transition: background-color 2s ease, box-shadow 2s ease;
 }
 
 @keyframes job-priority-shift {
@@ -2547,17 +2549,6 @@ body.modal-open .auth-bar {
     box-shadow: inset 0 0 0 0 rgba(52, 120, 246, 0);
   }
 }
-@keyframes job-link-highlight {
-  0% {
-    background-color: rgba(76, 164, 255, 0.28);
-    box-shadow: inset 0 0 0 1px rgba(76, 164, 255, 0.38);
-  }
-  100% {
-    background-color: transparent;
-    box-shadow: inset 0 0 0 0 rgba(76, 164, 255, 0);
-  }
-}
-
 .job-title-chip-dot {
   width: 10px;
   height: 10px;

--- a/style.css
+++ b/style.css
@@ -2529,6 +2529,9 @@ body.modal-open .auth-bar {
 .job-row-priority-animate > td {
   animation: job-priority-shift 0.5s ease;
 }
+.job-row-link-highlight > td{
+  animation: job-link-highlight 2s ease;
+}
 
 @keyframes job-priority-shift {
   0% {
@@ -2542,6 +2545,16 @@ body.modal-open .auth-bar {
   100% {
     background-color: transparent;
     box-shadow: inset 0 0 0 0 rgba(52, 120, 246, 0);
+  }
+}
+@keyframes job-link-highlight {
+  0% {
+    background-color: rgba(76, 164, 255, 0.28);
+    box-shadow: inset 0 0 0 1px rgba(76, 164, 255, 0.38);
+  }
+  100% {
+    background-color: transparent;
+    box-shadow: inset 0 0 0 0 rgba(76, 164, 255, 0);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Provide a full-size, reviewable "Maintenance Data Center" for the Costs dashboard to inspect maintenance occurrences and completed cutting jobs, filter/search rows, and jump to calendar or settings for a selected task.

### Description
- Add a data-center modal UI to the Costs view and a toggle to open it, including tabbed panels for "Maintenance Tasks" and "Completed Cutting Jobs", filters, search, and suggestion support (`js/views.js`, `style.css`).
- Implement `setupMaintenanceDataCenterActions`, `focusCalendarAtOccurrence`, and lifecycle wiring inside the Costs renderer to mount the modal to `document.body`, preserve open state across renders, and handle open/close/tab/search/filter interactions (`js/renderers.js`).
- Populate two new data tables in the cost model: `maintenanceDataTable` (built from `taskEventsByDate` and task metadata) and `cuttingJobsDataTable` (from `completedCuttingJobs`), and expose them to the view (`js/renderers.js`).
- Add styles for the modal, tabs, search suggestions, and responsive behavior (`style.css`).
- Parse `taskId` from the URL hash query (e.g. `#/settings?taskId=...`) and set `window.pendingMaintenanceFocus` to allow opening the appropriate settings or calendar target after navigation (`js/renderers.js`).

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64906d87883259cd91e5f27403b61)