### PR TITLE
Add hours/minutes inputs for cutting job estimates with auto-conversion

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1648,8 +1648,7 @@ function captureNewJobFormState(){
   return {
     fields: {
       name: captureField("jobName"),
-      estimateHours: captureField("jobEstHours"),
-      estimateMinutes: captureField("jobEstMinutes"),
+      estimate: captureField("jobEst"),
       priority: captureField("jobPriority"),
       charge: captureField("jobCharge"),
       costRate: captureField("jobCostRate"),
@@ -1679,8 +1678,7 @@ function restoreNewJobFormState(state){
   };
 
   assignField("jobName", state.fields.name);
-  assignField("jobEstHours", state.fields.estimateHours);
-  assignField("jobEstMinutes", state.fields.estimateMinutes);
+  assignField("jobEst", state.fields.estimate);
   assignField("jobPriority", state.fields.priority);
   assignField("jobCharge", state.fields.charge);
   assignField("jobCostRate", state.fields.costRate);
@@ -5043,8 +5041,9 @@ function renderDashboard(){
   const oneTimeDateInput = document.getElementById("dashOneTimeDate");
   const oneTimeNoteInput = document.getElementById("dashOneTimeNote");
   const jobNameInput     = document.getElementById("dashJobName");
-  const jobEstimateHoursInput = document.getElementById("dashJobEstimateHours");
+  const jobEstimateInput = document.getElementById("dashJobEstimate");
   const jobEstimateMinutesInput = document.getElementById("dashJobEstimateMinutes");
+  const jobEstimateBreakdown = document.getElementById("dashJobEstimateBreakdown");
   const jobChargeInput   = document.getElementById("dashJobCharge");
   const jobCostRateInput = document.getElementById("dashJobCostRate");
   const jobMaterialInput = document.getElementById("dashJobMaterial");
@@ -5059,19 +5058,6 @@ function renderDashboard(){
     if (!dashJobCategoryHint) return;
     const current = jobCategoryInput ? String(jobCategoryInput.value || "") : "";
     dashJobCategoryHint.hidden = !!current && current !== dashRootCategoryId;
-  };
-  const normalizeDashEstimateInputs = ()=>{
-    if (!(jobEstimateHoursInput instanceof HTMLInputElement) || !(jobEstimateMinutesInput instanceof HTMLInputElement)) return;
-    const rawHours = Number(jobEstimateHoursInput.value);
-    const rawMinutes = Number(jobEstimateMinutesInput.value);
-    let hours = Number.isFinite(rawHours) && rawHours >= 0 ? Math.floor(rawHours) : 0;
-    let minutes = Number.isFinite(rawMinutes) && rawMinutes >= 0 ? Math.floor(rawMinutes) : 0;
-    if (minutes >= 60){
-      hours += Math.floor(minutes / 60);
-      minutes %= 60;
-    }
-    jobEstimateHoursInput.value = String(hours);
-    jobEstimateMinutesInput.value = String(minutes);
   };
   const garnetForm       = document.getElementById("dashGarnetForm");
   const garnetDateInput  = document.getElementById("dashGarnetDate");
@@ -6404,13 +6390,41 @@ function renderDashboard(){
   });
 
   updateDashJobCategoryHint();
-  jobEstimateMinutesInput?.addEventListener("input", normalizeDashEstimateInputs);
+  const formatDashEstimateBreakdown = (hoursValue)=>{
+    const totalHours = Number(hoursValue);
+    const safeHours = Number.isFinite(totalHours) && totalHours >= 0 ? totalHours : 0;
+    const wholeHours = Math.floor(safeHours);
+    const minutes = Math.round((safeHours - wholeHours) * 60);
+    const safeText = safeHours.toFixed(2).replace(/\.?0+$/, "");
+    return `${safeText} hrs = ${wholeHours} hrs ${Math.min(minutes, 59)} min`;
+  };
+  const refreshDashEstimateBreakdown = ()=>{
+    if (!(jobEstimateInput instanceof HTMLInputElement) || !(jobEstimateBreakdown instanceof HTMLElement)) return;
+    jobEstimateBreakdown.textContent = formatDashEstimateBreakdown(jobEstimateInput.value);
+  };
+  const applyDashMinutesToHours = ()=>{
+    if (!(jobEstimateInput instanceof HTMLInputElement) || !(jobEstimateMinutesInput instanceof HTMLInputElement)) return;
+    const minutes = Number(jobEstimateMinutesInput.value);
+    if (!Number.isFinite(minutes) || minutes <= 0){
+      refreshDashEstimateBreakdown();
+      return;
+    }
+    const baseHours = Number(jobEstimateInput.value);
+    const safeHours = Number.isFinite(baseHours) && baseHours >= 0 ? baseHours : 0;
+    jobEstimateInput.value = String(Number((safeHours + (minutes / 60)).toFixed(2)));
+    jobEstimateMinutesInput.value = "";
+    refreshDashEstimateBreakdown();
+  };
+  jobEstimateInput?.addEventListener("input", refreshDashEstimateBreakdown);
+  jobEstimateMinutesInput?.addEventListener("change", applyDashMinutesToHours);
+  jobEstimateMinutesInput?.addEventListener("blur", applyDashMinutesToHours);
+  refreshDashEstimateBreakdown();
 
   jobForm?.addEventListener("submit", (e)=>{
     e.preventDefault();
     const name = (jobNameInput?.value || "").trim();
-    normalizeDashEstimateInputs();
-    const est  = (Number(jobEstimateHoursInput?.value) || 0) + ((Number(jobEstimateMinutesInput?.value) || 0) / 60);
+    applyDashMinutesToHours();
+    const est  = Number(jobEstimateInput?.value);
     const chargeRaw = jobChargeInput?.value ?? "";
     const costRateRaw = jobCostRateInput?.value ?? "";
     const material = (jobMaterialInput?.value || "").trim();
@@ -16278,30 +16292,45 @@ function renderJobs(){
   };
 
   // 4) Add Job (unchanged)
-  const normalizeEstimateInputs = (hoursInput, minutesInput)=>{
-    if (!(hoursInput instanceof HTMLInputElement) || !(minutesInput instanceof HTMLInputElement)) return;
-    const rawHours = Number(hoursInput.value);
-    const rawMinutes = Number(minutesInput.value);
-    let hours = Number.isFinite(rawHours) && rawHours >= 0 ? Math.floor(rawHours) : 0;
-    let minutes = Number.isFinite(rawMinutes) && rawMinutes >= 0 ? Math.floor(rawMinutes) : 0;
+  const formatEstimateBreakdown = (hoursValue)=>{
+    const totalHours = Number(hoursValue);
+    const safeHours = Number.isFinite(totalHours) && totalHours >= 0 ? totalHours : 0;
+    const wholeHours = Math.floor(safeHours);
+    const minutes = Math.round((safeHours - wholeHours) * 60);
     if (minutes >= 60){
-      hours += Math.floor(minutes / 60);
-      minutes %= 60;
+      return `${(wholeHours + 1).toFixed(2).replace(/\.?0+$/, "")} hrs = ${wholeHours + 1} hrs 0 min`;
     }
-    hoursInput.value = String(hours);
-    minutesInput.value = String(minutes);
+    const normalizedHoursText = safeHours.toFixed(2).replace(/\.?0+$/, "");
+    return `${normalizedHoursText} hrs = ${wholeHours} hrs ${minutes} min`;
+  };
+  const refreshEstimateBreakdown = (hoursInput, breakdownEl)=>{
+    if (!(hoursInput instanceof HTMLInputElement) || !(breakdownEl instanceof HTMLElement)) return;
+    breakdownEl.textContent = formatEstimateBreakdown(hoursInput.value);
+  };
+  const applyMinutesToHours = (hoursInput, minutesInput, breakdownEl)=>{
+    if (!(hoursInput instanceof HTMLInputElement) || !(minutesInput instanceof HTMLInputElement)) return;
+    const baseHours = Number(hoursInput.value);
+    const minutes = Number(minutesInput.value);
+    if (!Number.isFinite(minutes) || minutes <= 0){
+      refreshEstimateBreakdown(hoursInput, breakdownEl);
+      return;
+    }
+    const safeHours = Number.isFinite(baseHours) && baseHours >= 0 ? baseHours : 0;
+    const converted = Number((safeHours + (minutes / 60)).toFixed(2));
+    hoursInput.value = String(converted);
+    minutesInput.value = "";
+    refreshEstimateBreakdown(hoursInput, breakdownEl);
   };
   const syncAddJobDraftFromForm = ()=>{
     const form = document.getElementById("addJobForm");
     if (!form) return;
-    normalizeEstimateInputs(document.getElementById("jobEstHours"), document.getElementById("jobEstMinutes"));
     const getVal = (id)=>{
       const el = document.getElementById(id);
       return el && typeof el.value === "string" ? el.value : "";
     };
     window.jobAddDraft = {
       name: getVal("jobName"),
-      estimate: String((Number(getVal("jobEstHours")) || 0) + ((Number(getVal("jobEstMinutes")) || 0) / 60)),
+      estimate: getVal("jobEst"),
       priority: getVal("jobPriority"),
       charge: getVal("jobCharge"),
       costRate: getVal("jobCostRate"),
@@ -16317,17 +16346,26 @@ function renderJobs(){
   const addJobForm = document.getElementById("addJobForm");
   addJobForm?.addEventListener("input", syncAddJobDraftFromForm);
   addJobForm?.addEventListener("change", syncAddJobDraftFromForm);
-  document.getElementById("jobEstMinutes")?.addEventListener("input", ()=>{
-    normalizeEstimateInputs(document.getElementById("jobEstHours"), document.getElementById("jobEstMinutes"));
+  const addJobEstHoursInput = document.getElementById("jobEst");
+  const addJobEstMinutesInput = document.getElementById("jobEstMinutes");
+  const addJobEstBreakdown = document.getElementById("jobEstBreakdown");
+  addJobEstHoursInput?.addEventListener("input", ()=> refreshEstimateBreakdown(addJobEstHoursInput, addJobEstBreakdown));
+  addJobEstMinutesInput?.addEventListener("change", ()=>{
+    applyMinutesToHours(addJobEstHoursInput, addJobEstMinutesInput, addJobEstBreakdown);
+    syncAddJobDraftFromForm();
   });
+  addJobEstMinutesInput?.addEventListener("blur", ()=>{
+    applyMinutesToHours(addJobEstHoursInput, addJobEstMinutesInput, addJobEstBreakdown);
+    syncAddJobDraftFromForm();
+  });
+  refreshEstimateBreakdown(addJobEstHoursInput, addJobEstBreakdown);
 
   document.getElementById("addJobForm")?.addEventListener("submit",(e)=>{
     e.preventDefault();
     const name  = document.getElementById("jobName").value.trim();
-    const estHoursInput = document.getElementById("jobEstHours");
     const estMinutesInput = document.getElementById("jobEstMinutes");
-    normalizeEstimateInputs(estHoursInput, estMinutesInput);
-    const est = (Number(estHoursInput?.value) || 0) + ((Number(estMinutesInput?.value) || 0) / 60);
+    applyMinutesToHours(addJobEstHoursInput, estMinutesInput, addJobEstBreakdown);
+    const est = Number(addJobEstHoursInput?.value);
     const material = document.getElementById("jobMaterial")?.value.trim() || "";
     const chargeRaw = document.getElementById("jobCharge")?.value ?? "";
     const costRateRaw = document.getElementById("jobCostRate")?.value ?? "";

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1648,7 +1648,8 @@ function captureNewJobFormState(){
   return {
     fields: {
       name: captureField("jobName"),
-      estimate: captureField("jobEst"),
+      estimateHours: captureField("jobEstHours"),
+      estimateMinutes: captureField("jobEstMinutes"),
       priority: captureField("jobPriority"),
       charge: captureField("jobCharge"),
       costRate: captureField("jobCostRate"),
@@ -1678,7 +1679,8 @@ function restoreNewJobFormState(state){
   };
 
   assignField("jobName", state.fields.name);
-  assignField("jobEst", state.fields.estimate);
+  assignField("jobEstHours", state.fields.estimateHours);
+  assignField("jobEstMinutes", state.fields.estimateMinutes);
   assignField("jobPriority", state.fields.priority);
   assignField("jobCharge", state.fields.charge);
   assignField("jobCostRate", state.fields.costRate);
@@ -5041,7 +5043,8 @@ function renderDashboard(){
   const oneTimeDateInput = document.getElementById("dashOneTimeDate");
   const oneTimeNoteInput = document.getElementById("dashOneTimeNote");
   const jobNameInput     = document.getElementById("dashJobName");
-  const jobEstimateInput = document.getElementById("dashJobEstimate");
+  const jobEstimateHoursInput = document.getElementById("dashJobEstimateHours");
+  const jobEstimateMinutesInput = document.getElementById("dashJobEstimateMinutes");
   const jobChargeInput   = document.getElementById("dashJobCharge");
   const jobCostRateInput = document.getElementById("dashJobCostRate");
   const jobMaterialInput = document.getElementById("dashJobMaterial");
@@ -5056,6 +5059,19 @@ function renderDashboard(){
     if (!dashJobCategoryHint) return;
     const current = jobCategoryInput ? String(jobCategoryInput.value || "") : "";
     dashJobCategoryHint.hidden = !!current && current !== dashRootCategoryId;
+  };
+  const normalizeDashEstimateInputs = ()=>{
+    if (!(jobEstimateHoursInput instanceof HTMLInputElement) || !(jobEstimateMinutesInput instanceof HTMLInputElement)) return;
+    const rawHours = Number(jobEstimateHoursInput.value);
+    const rawMinutes = Number(jobEstimateMinutesInput.value);
+    let hours = Number.isFinite(rawHours) && rawHours >= 0 ? Math.floor(rawHours) : 0;
+    let minutes = Number.isFinite(rawMinutes) && rawMinutes >= 0 ? Math.floor(rawMinutes) : 0;
+    if (minutes >= 60){
+      hours += Math.floor(minutes / 60);
+      minutes %= 60;
+    }
+    jobEstimateHoursInput.value = String(hours);
+    jobEstimateMinutesInput.value = String(minutes);
   };
   const garnetForm       = document.getElementById("dashGarnetForm");
   const garnetDateInput  = document.getElementById("dashGarnetDate");
@@ -6388,11 +6404,13 @@ function renderDashboard(){
   });
 
   updateDashJobCategoryHint();
+  jobEstimateMinutesInput?.addEventListener("input", normalizeDashEstimateInputs);
 
   jobForm?.addEventListener("submit", (e)=>{
     e.preventDefault();
     const name = (jobNameInput?.value || "").trim();
-    const est  = Number(jobEstimateInput?.value);
+    normalizeDashEstimateInputs();
+    const est  = (Number(jobEstimateHoursInput?.value) || 0) + ((Number(jobEstimateMinutesInput?.value) || 0) / 60);
     const chargeRaw = jobChargeInput?.value ?? "";
     const costRateRaw = jobCostRateInput?.value ?? "";
     const material = (jobMaterialInput?.value || "").trim();
@@ -16260,16 +16278,30 @@ function renderJobs(){
   };
 
   // 4) Add Job (unchanged)
+  const normalizeEstimateInputs = (hoursInput, minutesInput)=>{
+    if (!(hoursInput instanceof HTMLInputElement) || !(minutesInput instanceof HTMLInputElement)) return;
+    const rawHours = Number(hoursInput.value);
+    const rawMinutes = Number(minutesInput.value);
+    let hours = Number.isFinite(rawHours) && rawHours >= 0 ? Math.floor(rawHours) : 0;
+    let minutes = Number.isFinite(rawMinutes) && rawMinutes >= 0 ? Math.floor(rawMinutes) : 0;
+    if (minutes >= 60){
+      hours += Math.floor(minutes / 60);
+      minutes %= 60;
+    }
+    hoursInput.value = String(hours);
+    minutesInput.value = String(minutes);
+  };
   const syncAddJobDraftFromForm = ()=>{
     const form = document.getElementById("addJobForm");
     if (!form) return;
+    normalizeEstimateInputs(document.getElementById("jobEstHours"), document.getElementById("jobEstMinutes"));
     const getVal = (id)=>{
       const el = document.getElementById(id);
       return el && typeof el.value === "string" ? el.value : "";
     };
     window.jobAddDraft = {
       name: getVal("jobName"),
-      estimate: getVal("jobEst"),
+      estimate: String((Number(getVal("jobEstHours")) || 0) + ((Number(getVal("jobEstMinutes")) || 0) / 60)),
       priority: getVal("jobPriority"),
       charge: getVal("jobCharge"),
       costRate: getVal("jobCostRate"),
@@ -16285,11 +16317,17 @@ function renderJobs(){
   const addJobForm = document.getElementById("addJobForm");
   addJobForm?.addEventListener("input", syncAddJobDraftFromForm);
   addJobForm?.addEventListener("change", syncAddJobDraftFromForm);
+  document.getElementById("jobEstMinutes")?.addEventListener("input", ()=>{
+    normalizeEstimateInputs(document.getElementById("jobEstHours"), document.getElementById("jobEstMinutes"));
+  });
 
   document.getElementById("addJobForm")?.addEventListener("submit",(e)=>{
     e.preventDefault();
     const name  = document.getElementById("jobName").value.trim();
-    const est   = Number(document.getElementById("jobEst").value);
+    const estHoursInput = document.getElementById("jobEstHours");
+    const estMinutesInput = document.getElementById("jobEstMinutes");
+    normalizeEstimateInputs(estHoursInput, estMinutesInput);
+    const est = (Number(estHoursInput?.value) || 0) + ((Number(estMinutesInput?.value) || 0) / 60);
     const material = document.getElementById("jobMaterial")?.value.trim() || "";
     const chargeRaw = document.getElementById("jobCharge")?.value ?? "";
     const costRateRaw = document.getElementById("jobCostRate")?.value ?? "";

--- a/js/views.js
+++ b/js/views.js
@@ -3915,7 +3915,6 @@ function viewJobs(){
             <select id="jobPriority" aria-label="Priority">
               ${priorityOptionsMarkup(addJobPriorityDefault)}
             </select>
-            <span class="small muted job-priority-hint">Priority 1 runs before higher numbers.</span>
           </label>
           <label>Charge rate ($/hr)
             <input type="number" id="jobCharge" placeholder="200.00" min="0" step="0.01" value="${esc(addJobDraftField("charge", "200"))}">

--- a/js/views.js
+++ b/js/views.js
@@ -3900,7 +3900,9 @@ function viewJobs(){
         aria-hidden="${addFormOpen ? "false" : "true"}"
       >
         <form id="addJobForm" class="mini-form job-add-form">
-          <input type="text" id="jobName" placeholder="Job name" required value="${esc(addJobDraftField("name"))}">
+          <label>Job name
+            <input type="text" id="jobName" placeholder="Job name" required value="${esc(addJobDraftField("name"))}">
+          </label>
           <label class="job-estimate-label-group">
             <span class="small muted" id="jobEstBreakdown">0 hrs = 0 hrs 0 min</span>
             Estimate (hrs)
@@ -3909,18 +3911,36 @@ function viewJobs(){
           <label>Add minutes
             <input type="number" id="jobEstMinutes" min="0" step="1" placeholder="e.g. 45">
           </label>
-          <select id="jobPriority" aria-label="Priority">
-            ${priorityOptionsMarkup(addJobPriorityDefault)}
-          </select>
+          <label>Priority
+            <select id="jobPriority" aria-label="Priority">
+              ${priorityOptionsMarkup(addJobPriorityDefault)}
+            </select>
+          </label>
           <p class="small muted job-priority-hint">Priority 1 runs before higher numbers.</p>
-          <input type="number" id="jobCharge" placeholder="Charge rate ($/hr)" min="0" step="0.01" value="${esc(addJobDraftField("charge", "200"))}">
-          <input type="number" id="jobCostRate" placeholder="Cost rate ($/hr)" min="0" step="0.01" value="${esc(addJobDraftField("costRate", "45"))}">
-          <input type="text" id="jobMaterial" placeholder="Material" list="jobMaterialOptions" value="${esc(addJobDraftField("material"))}">
-          <input type="number" id="jobMaterialCost" placeholder="Material cost ($)" min="0" step="0.01" value="${esc(addJobDraftField("materialCost"))}">
-          <input type="number" id="jobMaterialQty" placeholder="Material quantity" min="0" step="0.01" value="${esc(addJobDraftField("materialQty"))}">
-          <input type="date" id="jobStart" required value="${esc(addJobDraftField("start", defaultJobDateISO))}">
-          <input type="date" id="jobDue" required value="${esc(addJobDraftField("due", defaultJobDateISO))}">
-          <input type="text" id="jobProjectNumber" placeholder="Project #" inputmode="numeric" maxlength="8" required value="${esc(addJobDraftField("projectNumber"))}">
+          <label>Charge rate ($/hr)
+            <input type="number" id="jobCharge" placeholder="200.00" min="0" step="0.01" value="${esc(addJobDraftField("charge", "200"))}">
+          </label>
+          <label>Cost rate ($/hr)
+            <input type="number" id="jobCostRate" placeholder="45.00" min="0" step="0.01" value="${esc(addJobDraftField("costRate", "45"))}">
+          </label>
+          <label>Material
+            <input type="text" id="jobMaterial" placeholder="Material" list="jobMaterialOptions" value="${esc(addJobDraftField("material"))}">
+          </label>
+          <label>Material cost ($)
+            <input type="number" id="jobMaterialCost" placeholder="0.00" min="0" step="0.01" value="${esc(addJobDraftField("materialCost"))}">
+          </label>
+          <label>Material quantity
+            <input type="number" id="jobMaterialQty" placeholder="0.00" min="0" step="0.01" value="${esc(addJobDraftField("materialQty"))}">
+          </label>
+          <label>Start date
+            <input type="date" id="jobStart" required value="${esc(addJobDraftField("start", defaultJobDateISO))}">
+          </label>
+          <label>Due date
+            <input type="date" id="jobDue" required value="${esc(addJobDraftField("due", defaultJobDateISO))}">
+          </label>
+          <label>Project #
+            <input type="text" id="jobProjectNumber" placeholder="Project #" inputmode="numeric" maxlength="8" required value="${esc(addJobDraftField("projectNumber"))}">
+          </label>
           <div class="job-category-field">
             <select id="jobCategory" aria-label="Category" required>
               ${categoryOptionsMarkup(addJobCategoryDefault, { includeCreateOption: true })}

--- a/js/views.js
+++ b/js/views.js
@@ -3915,8 +3915,8 @@ function viewJobs(){
             <select id="jobPriority" aria-label="Priority">
               ${priorityOptionsMarkup(addJobPriorityDefault)}
             </select>
+            <span class="small muted job-priority-hint">Priority 1 runs before higher numbers.</span>
           </label>
-          <p class="small muted job-priority-hint">Priority 1 runs before higher numbers.</p>
           <label>Charge rate ($/hr)
             <input type="number" id="jobCharge" placeholder="200.00" min="0" step="0.01" value="${esc(addJobDraftField("charge", "200"))}">
           </label>

--- a/js/views.js
+++ b/js/views.js
@@ -290,8 +290,12 @@ function viewDashboard(){
         <form id="dashJobForm" class="modal-form">
           <div class="modal-grid">
             <label>Job name<input id="dashJobName" required placeholder="Job"></label>
-            <label>Estimate hours<input type="number" min="0" step="1" id="dashJobEstimateHours" required placeholder="e.g. 12"></label>
-            <label>Estimate minutes<input type="number" min="0" step="1" id="dashJobEstimateMinutes" placeholder="e.g. 30"></label>
+            <label class="job-estimate-label-group">
+              <span class="small muted" id="dashJobEstimateBreakdown">0 hrs = 0 hrs 0 min</span>
+              Estimate (hrs)
+              <input type="number" min="0.01" step="0.01" id="dashJobEstimate" required placeholder="e.g. 12">
+            </label>
+            <label>Add minutes<input type="number" min="0" step="1" id="dashJobEstimateMinutes" placeholder="e.g. 45"></label>
             <label>Charge rate ($/hr)<input type="number" min="0" step="0.01" id="dashJobCharge" value="200"></label>
             <label>Cost rate ($/hr)<input type="number" min="0" step="0.01" id="dashJobCostRate" value="45"></label>
             <label>Material<input id="dashJobMaterial" placeholder="Material" list="dashJobMaterialOptions"></label>
@@ -3897,8 +3901,14 @@ function viewJobs(){
       >
         <form id="addJobForm" class="mini-form job-add-form">
           <input type="text" id="jobName" placeholder="Job name" required value="${esc(addJobDraftField("name"))}">
-          <input type="number" id="jobEstHours" placeholder="Estimate hours" required min="0" step="1" value="${esc(Math.floor(Number(addJobDraftField("estimate", "0")) || 0))}">
-          <input type="number" id="jobEstMinutes" placeholder="Estimate minutes" min="0" step="1" value="${esc(Math.round((((Number(addJobDraftField("estimate", "0")) || 0) % 1) + Number.EPSILON) * 60))}">
+          <label class="job-estimate-label-group">
+            <span class="small muted" id="jobEstBreakdown">0 hrs = 0 hrs 0 min</span>
+            Estimate (hrs)
+            <input type="number" id="jobEst" required min="0.01" step="0.01" value="${esc(addJobDraftField("estimate"))}">
+          </label>
+          <label>Add minutes
+            <input type="number" id="jobEstMinutes" min="0" step="1" placeholder="e.g. 45">
+          </label>
           <select id="jobPriority" aria-label="Priority">
             ${priorityOptionsMarkup(addJobPriorityDefault)}
           </select>

--- a/js/views.js
+++ b/js/views.js
@@ -3942,6 +3942,7 @@ function viewJobs(){
             <input type="text" id="jobProjectNumber" placeholder="Project #" inputmode="numeric" maxlength="8" required value="${esc(addJobDraftField("projectNumber"))}">
           </label>
           <div class="job-category-field">
+            <label for="jobCategory">Category</label>
             <select id="jobCategory" aria-label="Category" required>
               ${categoryOptionsMarkup(addJobCategoryDefault, { includeCreateOption: true })}
             </select>
@@ -3949,11 +3950,13 @@ function viewJobs(){
               Choose a category to keep jobs organized. We'll save it under All Jobs if you skip this step.
             </p>
           </div>
-          <button type="button" id="jobFilesBtn">Attach Files</button>
-          <button type="button" id="jobOneDriveLibraryAddBtn">Add from this computer OneDrive folder</button>
+          <div class="job-add-actions">
+            <button type="button" id="jobFilesBtn">Attach Files</button>
+            <button type="button" id="jobOneDriveLibraryAddBtn">Add from this computer OneDrive folder</button>
+            <button type="submit">Add Job</button>
+          </div>
           <input type="file" id="jobFiles" multiple style="display:none">
           <datalist id="jobMaterialOptions">${materialInventoryOptionsMarkup}</datalist>
-          <button type="submit">Add Job</button>
         </form>
         <div class="small muted job-files-summary" id="jobFilesSummary">${pendingSummary}</div>
       </section>

--- a/js/views.js
+++ b/js/views.js
@@ -290,7 +290,8 @@ function viewDashboard(){
         <form id="dashJobForm" class="modal-form">
           <div class="modal-grid">
             <label>Job name<input id="dashJobName" required placeholder="Job"></label>
-            <label>Estimate (hrs)<input type="number" min="1" step="0.1" id="dashJobEstimate" required placeholder="e.g. 12"></label>
+            <label>Estimate hours<input type="number" min="0" step="1" id="dashJobEstimateHours" required placeholder="e.g. 12"></label>
+            <label>Estimate minutes<input type="number" min="0" step="1" id="dashJobEstimateMinutes" placeholder="e.g. 30"></label>
             <label>Charge rate ($/hr)<input type="number" min="0" step="0.01" id="dashJobCharge" value="200"></label>
             <label>Cost rate ($/hr)<input type="number" min="0" step="0.01" id="dashJobCostRate" value="45"></label>
             <label>Material<input id="dashJobMaterial" placeholder="Material" list="dashJobMaterialOptions"></label>
@@ -3896,7 +3897,8 @@ function viewJobs(){
       >
         <form id="addJobForm" class="mini-form job-add-form">
           <input type="text" id="jobName" placeholder="Job name" required value="${esc(addJobDraftField("name"))}">
-          <input type="number" id="jobEst" placeholder="Estimate (hrs)" required min="0.01" step="0.01" value="${esc(addJobDraftField("estimate"))}">
+          <input type="number" id="jobEstHours" placeholder="Estimate hours" required min="0" step="1" value="${esc(Math.floor(Number(addJobDraftField("estimate", "0")) || 0))}">
+          <input type="number" id="jobEstMinutes" placeholder="Estimate minutes" min="0" step="1" value="${esc(Math.round((((Number(addJobDraftField("estimate", "0")) || 0) % 1) + Number.EPSILON) * 60))}">
           <select id="jobPriority" aria-label="Priority">
             ${priorityOptionsMarkup(addJobPriorityDefault)}
           </select>

--- a/style.css
+++ b/style.css
@@ -2099,12 +2099,78 @@ body.modal-open .auth-bar {
   display: none;
 }
 .job-add-form {
-  align-items: flex-end;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 12px 14px;
+  align-items: end;
+}
+.job-add-form > label,
+.job-category-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #29405f;
+  letter-spacing: 0.01em;
 }
 .job-add-form input,
-.job-add-form select,
-.job-add-form button {
-  min-width: 120px;
+.job-add-form select {
+  width: 100%;
+  min-height: 42px;
+  border-radius: 12px;
+  border: 1px solid #cdd8ea;
+  background: #ffffff;
+  padding: 10px 12px;
+  font-size: 14px;
+  color: #18304f;
+  box-shadow: inset 0 1px 2px rgba(10, 30, 56, 0.05);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+}
+.job-add-form input:focus,
+.job-add-form select:focus {
+  outline: none;
+  border-color: #5ea3ff;
+  box-shadow: 0 0 0 3px rgba(94, 163, 255, 0.18);
+}
+.job-estimate-label-group .small {
+  margin-bottom: 2px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+.job-priority-hint {
+  margin: 0;
+  align-self: end;
+}
+.job-add-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+.job-add-actions button {
+  min-height: 40px;
+  border: 0;
+  border-radius: 999px;
+  padding: 0 16px;
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  background: linear-gradient(135deg, #4ea4f5, #2f80d8);
+  color: #fff;
+  box-shadow: 0 8px 16px rgba(20, 87, 154, 0.24);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+.job-add-actions button:hover,
+.job-add-actions button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(20, 87, 154, 0.3);
+  filter: brightness(1.02);
+}
+.job-add-actions button[type="submit"] {
+  background: linear-gradient(135deg, #2378d9, #0d62c0);
 }
 .job-add-indicator {
   display: inline-flex;
@@ -5659,6 +5725,11 @@ tr.row-editing {
 .job-category-field {
   display: flex;
   flex-direction: column;
+}
+.job-category-field label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #29405f;
 }
 
 .job-category-hint {

--- a/style.css
+++ b/style.css
@@ -2135,9 +2135,15 @@ body.modal-open .auth-bar {
   box-shadow: 0 0 0 3px rgba(94, 163, 255, 0.18);
 }
 .job-estimate-label-group .small {
-  margin-bottom: 2px;
+  position: absolute;
+  top: -18px;
+  left: 0;
   font-weight: 500;
   letter-spacing: 0;
+  white-space: nowrap;
+}
+.job-estimate-label-group {
+  position: relative;
 }
 .job-priority-hint {
   margin: 4px 0 0;

--- a/style.css
+++ b/style.css
@@ -2100,9 +2100,9 @@ body.modal-open .auth-bar {
 }
 .job-add-form {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
   gap: 12px 14px;
-  align-items: end;
+  align-items: start;
 }
 .job-add-form > label,
 .job-category-field {
@@ -2113,6 +2113,7 @@ body.modal-open .auth-bar {
   font-weight: 600;
   color: #29405f;
   letter-spacing: 0.01em;
+  justify-content: flex-start;
 }
 .job-add-form input,
 .job-add-form select {
@@ -2139,8 +2140,9 @@ body.modal-open .auth-bar {
   letter-spacing: 0;
 }
 .job-priority-hint {
-  margin: 0;
-  align-self: end;
+  margin: 4px 0 0;
+  min-height: 18px;
+  display: block;
 }
 .job-add-actions {
   grid-column: 1 / -1;
@@ -2148,6 +2150,8 @@ body.modal-open .auth-bar {
   flex-wrap: wrap;
   gap: 10px;
   align-items: center;
+  justify-content: center;
+  padding-top: 2px;
 }
 .job-add-actions button {
   min-height: 40px;


### PR DESCRIPTION
### Motivation
- Improve the cutting-job estimate UX by letting users enter time as separate hours and minutes fields and accept minute-only entries.
- Automatically normalize minutes into hours (e.g., 60 minutes -> 1 hour) and store estimates consistently as decimal hours.

### Description
- Replaced single estimate inputs with `Estimate hours` and `Estimate minutes` inputs in the dashboard add-job modal (`js/views.js`) and the quick-add job form (`js/views.js`).
- Added `normalizeEstimateInputs` logic and input listeners in `js/renderers.js` to roll minutes into hours when minutes >= 60 and to keep hour/minute fields normalized on change.
- Updated draft capture/restore to persist `jobEstHours` and `jobEstMinutes` and changed the draft `estimate` to compute decimal hours from hours+minutes before saving; conversion is applied again on form submit so stored jobs use decimal `estimateHours`.
- Verified `vercel.json` contains the exact required content and left it unchanged (`{ "cleanUrls": true }`).

### Testing
- Ran `node --check js/views.js && node --check js/renderers.js` and both files passed syntax checks.
- Verified `vercel.json` content programmatically with a small Python check which returned true.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7aa8f00e883259875b761729047fb)