### PR TITLE
Use central data table for cost efficiency snapshot

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11653,6 +11653,30 @@ function renderCosts(){
   }
 
   function setupEfficiencyCalculator(currentModel){
+    const openSnapshotBtns = Array.from(content.querySelectorAll("[data-open-efficiency-snapshot]"));
+    const closeSnapshot = ()=>{
+      const modal = document.getElementById("efficiencySnapshotModal");
+      if (!(modal instanceof HTMLElement)) return;
+      modal.hidden = true;
+      document.body.classList.remove("cost-data-center-open");
+    };
+    const openSnapshot = ()=>{
+      const modal = document.getElementById("efficiencySnapshotModal");
+      if (!(modal instanceof HTMLElement)) return;
+      modal.hidden = false;
+      if (modal.parentElement !== document.body) document.body.appendChild(modal);
+      document.body.classList.add("cost-data-center-open");
+    };
+    openSnapshotBtns.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", openSnapshot);
+    });
+    const closeSnapshotBtns = Array.from(content.querySelectorAll("[data-close-efficiency-snapshot]"));
+    closeSnapshotBtns.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", closeSnapshot);
+    });
+
     const panel = content.querySelector("[data-efficiency-calc]");
     if (!(panel instanceof HTMLElement)) return;
     const snapshot = currentModel && currentModel.efficiencySnapshot ? currentModel.efficiencySnapshot : {};
@@ -11665,7 +11689,6 @@ function renderCosts(){
     const rangeLabelEl = panel.querySelector("[data-efficiency-calc-range-label]");
     const totalEl = panel.querySelector("[data-efficiency-calc-total]");
     const avgEl = panel.querySelector("[data-efficiency-calc-average]");
-    const openSnapshotBtn = panel.querySelector("[data-open-efficiency-snapshot]");
     const goJobsBtn = panel.querySelector("[data-go-jobs-history]");
     if (!(chargeInput instanceof HTMLInputElement) || !(costInput instanceof HTMLInputElement)) return;
 
@@ -11769,25 +11792,17 @@ function renderCosts(){
         updateRangeButtons();
       });
     }
-    if (openSnapshotBtn instanceof HTMLElement){
-      openSnapshotBtn.addEventListener("click", ()=>{
+    if (typeof window !== "undefined"){
+      if (typeof window.__efficiencySnapshotEscHandler === "function"){
+        document.removeEventListener("keydown", window.__efficiencySnapshotEscHandler);
+      }
+      window.__efficiencySnapshotEscHandler = (event)=>{
+        if (event.key !== "Escape") return;
         const modal = document.getElementById("efficiencySnapshotModal");
-        if (!(modal instanceof HTMLElement)) return;
-        modal.hidden = false;
-        if (modal.parentElement !== document.body) document.body.appendChild(modal);
-        document.body.classList.add("cost-data-center-open");
-      });
+        if (modal instanceof HTMLElement && !modal.hidden) closeSnapshot();
+      };
+      document.addEventListener("keydown", window.__efficiencySnapshotEscHandler);
     }
-    const closeSnapshotBtns = Array.from(document.querySelectorAll("[data-close-efficiency-snapshot]"));
-    closeSnapshotBtns.forEach(btn => {
-      if (!(btn instanceof HTMLElement)) return;
-      btn.addEventListener("click", ()=>{
-        const modal = document.getElementById("efficiencySnapshotModal");
-        if (!(modal instanceof HTMLElement)) return;
-        modal.hidden = true;
-        document.body.classList.remove("cost-data-center-open");
-      });
-    });
     if (goJobsBtn instanceof HTMLElement){
       goJobsBtn.addEventListener("click", ()=>{
         goToJobsHistory();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -15024,6 +15024,22 @@ function computeCostModel(){
     rows: efficiencyRows,
     emptyMessage: "No valid completed cutting tasks with settings links were found in the central data table."
   };
+  const efficiencyDisplayProfit = Math.max(0, efficiencyTotals.profit);
+  const efficiencyDisplayAverage = efficiencyCount ? (efficiencyDisplayProfit / efficiencyCount) : 0;
+  const cuttingCard = Array.isArray(summaryCards) ? summaryCards.find(card => card && card.key === "cuttingJobs") : null;
+  if (cuttingCard){
+    cuttingCard.value = formatterCurrency(efficiencyDisplayProfit, { decimals: 0, showPlus: true });
+    cuttingCard.hint = efficiencyCount
+      ? `Average gain/loss ${formatterCurrency(efficiencyDisplayAverage, { decimals: 0, showPlus: true })} across ${efficiencyCount} completed job${efficiencyCount===1?"":"s"} (source: central data table).`
+      : "No cutting jobs logged yet.";
+  }
+  const combinedCard = Array.isArray(summaryCards) ? summaryCards.find(card => card && card.key === "combinedImpact") : null;
+  if (combinedCard){
+    combinedCard.value = formatterCurrency(efficiencyDisplayProfit - predictedAnnual, { decimals: 0, showPlus: true });
+  }
+  jobSummary.countLabel = efficiencyCount ? `${efficiencyCount} completed` : "0";
+  jobSummary.totalLabel = formatterCurrency(efficiencyDisplayProfit, { decimals: 0, showPlus: true });
+  jobSummary.averageLabel = formatterCurrency(efficiencyDisplayAverage, { decimals: 0, showPlus: true });
 
   const taskById = new Map();
   [Array.isArray(intervalTasksAll) ? intervalTasksAll : [], Array.isArray(asReqTasksAll) ? asReqTasksAll : []].forEach(list => {

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11661,6 +11661,8 @@ function renderCosts(){
     const chargeInput = panel.querySelector("[data-efficiency-calc-charge]");
     const costInput = panel.querySelector("[data-efficiency-calc-cost]");
     const resetBtn = panel.querySelector("[data-efficiency-calc-reset]");
+    const rangeButtons = Array.from(panel.querySelectorAll("[data-efficiency-calc-range]"));
+    const rangeLabelEl = panel.querySelector("[data-efficiency-calc-range-label]");
     const totalEl = panel.querySelector("[data-efficiency-calc-total]");
     const avgEl = panel.querySelector("[data-efficiency-calc-average]");
     if (!(chargeInput instanceof HTMLInputElement) || !(costInput instanceof HTMLInputElement)) return;
@@ -11679,11 +11681,62 @@ function renderCosts(){
     const defaultCost = Math.max(0, asNumber(defaults.costRate, asNumber(costInput.value, 0)));
     chargeInput.value = String(defaultCharge);
     costInput.value = String(defaultCost);
+    let activeRange = "1m";
+
+    const getRangeStart = (rangeKey)=>{
+      const now = new Date();
+      now.setHours(23, 59, 59, 999);
+      const start = new Date(now);
+      start.setHours(0, 0, 0, 0);
+      if (rangeKey === "all") return null;
+      if (rangeKey === "ytd"){
+        return new Date(start.getFullYear(), 0, 1);
+      }
+      const monthMap = { "1m": 1, "2m": 2, "3m": 3, "6m": 6, "1y": 12 };
+      const monthsBack = monthMap[rangeKey];
+      if (!monthsBack) return null;
+      return new Date(start.getFullYear(), start.getMonth() - monthsBack, start.getDate());
+    };
+    const parseRowDate = (row)=>{
+      const raw = String(row?.dateLabel || "");
+      if (!raw) return null;
+      const parsed = new Date(`${raw}T00:00:00`);
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
+    };
+    const withinRange = (row, rangeKey)=>{
+      if (rangeKey === "all") return true;
+      const rowDate = parseRowDate(row);
+      if (!(rowDate instanceof Date)) return false;
+      const start = getRangeStart(rangeKey);
+      if (!(start instanceof Date)) return true;
+      return rowDate >= start;
+    };
+    const updateRangeButtons = ()=>{
+      rangeButtons.forEach(btn => {
+        const key = String(btn.getAttribute("data-efficiency-calc-range") || "");
+        const isActive = key === activeRange;
+        btn.classList.toggle("is-active", isActive);
+        btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+      });
+      const labels = {
+        "1m": "Range: past 1 month from central data table rows.",
+        "2m": "Range: past 2 months from central data table rows.",
+        "3m": "Range: past 3 months from central data table rows.",
+        "6m": "Range: past 6 months from central data table rows.",
+        "1y": "Range: past 1 year from central data table rows.",
+        ytd: "Range: year to date from central data table rows.",
+        all: "Range: all time from central data table rows."
+      };
+      if (rangeLabelEl instanceof HTMLElement){
+        rangeLabelEl.textContent = labels[activeRange] || labels["1m"];
+      }
+    };
 
     const recalc = ()=>{
       const chargeRate = Math.max(0, asNumber(chargeInput.value, defaultCharge));
       const costRate = Math.max(0, asNumber(costInput.value, defaultCost));
-      const totals = rows.reduce((acc, row)=>{
+      const visibleRows = rows.filter(row => withinRange(row, activeRange));
+      const totals = visibleRows.reduce((acc, row)=>{
         const hours = Math.max(0, asNumber(row?.hoursValue, 0));
         const material = Math.max(0, asNumber(row?.materialValue ?? row?.materialCostValue, 0));
         acc.rows += 1;
@@ -11692,10 +11745,26 @@ function renderCosts(){
       }, { rows: 0, net: 0 });
       if (totalEl) totalEl.textContent = formatUsd(totals.net);
       if (avgEl) avgEl.textContent = formatUsd(totals.rows ? (totals.net / totals.rows) : 0);
+      const tableRows = Array.from(content.querySelectorAll("[data-efficiency-row]"));
+      tableRows.forEach(tr => {
+        const rowId = String(tr.getAttribute("data-efficiency-id") || "");
+        const rowObj = rows.find(row => String(row?.id || "") === rowId) || null;
+        const show = rowObj ? withinRange(rowObj, activeRange) : false;
+        tr.hidden = !show;
+      });
     };
 
     chargeInput.addEventListener("input", recalc);
     costInput.addEventListener("input", recalc);
+    rangeButtons.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", ()=>{
+        const next = String(btn.getAttribute("data-efficiency-calc-range") || "1m");
+        activeRange = next || "1m";
+        updateRangeButtons();
+        recalc();
+      });
+    });
     if (resetBtn instanceof HTMLElement){
       resetBtn.addEventListener("click", ()=>{
         chargeInput.value = String(defaultCharge);
@@ -11703,6 +11772,7 @@ function renderCosts(){
         recalc();
       });
     }
+    updateRangeButtons();
     recalc();
   }
 
@@ -15058,12 +15128,12 @@ function computeCostModel(){
       chargeRateValue: Number(row?.chargeRateValue) || 0,
       costRateValue: Number(row?.costRateValue) || 0,
       revenueValue: Math.max(0, (Number(row?.hoursValue) || 0) * (Number(row?.chargeRateValue) || 0)),
-      beforeExpenseLabel: formatterCurrency(Math.max(0, (Number(row?.hoursValue) || 0) * (Number(row?.chargeRateValue) || 0)), { decimals: 2, showPlus: true }),
+      netGainLabel: formatterCurrency(Number(row?.totalProfitValue) || 0, { decimals: 2, showPlus: true }),
       materialValue: Math.max(0, Number(row?.materialCostValue) || 0),
       laborValue: Math.max(0, Number(row?.laborCostValue) || 0),
       totalCostValue: Number(row?.totalCostValue) || 0,
       totalProfitValue: Number(row?.totalProfitValue) || 0,
-      formulaTitle: "Source: Central data table completed cutting jobs row. Before expense gain = Hours × Charge Rate. Excludes maintenance parts, labor, and consumables reductions.",
+      formulaTitle: "Source: Central data table completed cutting jobs row. Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost.",
       settingsLink: row?.settingsLink || ""
     }));
   const efficiencyTotals = efficiencyRows.reduce((acc, row) => {
@@ -15083,15 +15153,15 @@ function computeCostModel(){
     averageCostLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.cost / efficiencyCount) : 0, { decimals: 2 }),
     totalProfitLabel: formatterCurrency(efficiencyTotals.profit, { decimals: Math.abs(efficiencyTotals.profit) < 1000 ? 2 : 0, showPlus: true }),
     averageProfitLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.profit / efficiencyCount) : 0, { decimals: 2, showPlus: true }),
-    totalBeforeExpenseLabel: formatterCurrency(efficiencyTotals.revenue, { decimals: Math.abs(efficiencyTotals.revenue) < 1000 ? 2 : 0, showPlus: true }),
-    averageBeforeExpenseLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.revenue / efficiencyCount) : 0, { decimals: 2, showPlus: true }),
+    totalNetGainLabel: formatterCurrency(efficiencyTotals.profit, { decimals: Math.abs(efficiencyTotals.profit) < 1000 ? 2 : 0, showPlus: true }),
+    averageNetGainLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.profit / efficiencyCount) : 0, { decimals: 2, showPlus: true }),
     sourceLabel: "Source: central data table completed cutting jobs rows.",
-    formulaLabel: "Before expense gain = Hours × Charge Rate",
-    disclaimerLabel: "Before expense only: does not include reductions for maintenance parts, labor, or consumables.",
+    formulaLabel: "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost",
+    disclaimerLabel: "Uses central data table values only.",
     rows: efficiencyRows,
     emptyMessage: "No valid completed cutting tasks with settings links were found in the central data table."
   };
-  const efficiencyMathDetails = `Before expense gain = Hours × Charge Rate. Revenue ${formatterCurrency(efficiencyTotals.revenue, { decimals: 0 })} from ${formatHoursValue(efficiencyTotals.hours)}. This excludes maintenance parts, labor, and consumables reductions.`;
+  const efficiencyMathDetails = `Net gain = (Hours × (Charge Rate - Cost Rate)) - Material. Revenue ${formatterCurrency(efficiencyTotals.revenue, { decimals: 0 })}, Labor ${formatterCurrency(efficiencyTotals.labor, { decimals: 0 })}, Material ${formatterCurrency(efficiencyTotals.material, { decimals: 0 })}, Net ${formatterCurrency(efficiencyTotals.profit, { decimals: 0, showPlus: true })}.`;
   efficiencySnapshot.mathDetailsLabel = efficiencyMathDetails;
   const totalCalcHours = efficiencyTotals.hours > 0 ? efficiencyTotals.hours : 0;
   const defaultChargeRateForCalc = totalCalcHours > 0 ? (efficiencyTotals.revenue / totalCalcHours) : JOB_RATE_PER_HOUR;
@@ -15100,13 +15170,13 @@ function computeCostModel(){
     chargeRate: Number.isFinite(defaultChargeRateForCalc) ? defaultChargeRateForCalc : JOB_RATE_PER_HOUR,
     costRate: Number.isFinite(defaultCostRateForCalc) ? defaultCostRateForCalc : JOB_BASE_COST_PER_HOUR
   };
-  const efficiencyDisplayProfit = Math.max(0, efficiencyTotals.revenue);
+  const efficiencyDisplayProfit = efficiencyTotals.profit;
   const efficiencyDisplayAverage = efficiencyCount ? (efficiencyDisplayProfit / efficiencyCount) : 0;
   const cuttingCard = Array.isArray(summaryCards) ? summaryCards.find(card => card && card.key === "cuttingJobs") : null;
   if (cuttingCard){
     cuttingCard.value = formatterCurrency(efficiencyDisplayProfit, { decimals: 0, showPlus: true });
     cuttingCard.hint = efficiencyCount
-      ? `Average gain before expense ${formatterCurrency(efficiencyDisplayAverage, { decimals: 0, showPlus: true })} across ${efficiencyCount} completed job${efficiencyCount===1?"":"s"} (source: central data table).`
+      ? `Average net gain ${formatterCurrency(efficiencyDisplayAverage, { decimals: 0, showPlus: true })} across ${efficiencyCount} completed job${efficiencyCount===1?"":"s"} (source: central data table).`
       : "No cutting jobs logged yet.";
     cuttingCard.tooltip = `Source: central data table completed rows. ${efficiencyMathDetails}`;
   }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -15001,11 +15001,12 @@ function computeCostModel(){
       totalProfitLabel: formatterCurrency(Number(row?.totalProfitValue) || 0, { decimals: 2, showPlus: true }),
       hoursValue: Number(row?.hoursValue) || 0,
       revenueValue: Math.max(0, (Number(row?.hoursValue) || 0) * (Number(row?.chargeRateValue) || 0)),
+      beforeExpenseLabel: formatterCurrency(Math.max(0, (Number(row?.hoursValue) || 0) * (Number(row?.chargeRateValue) || 0)), { decimals: 2, showPlus: true }),
       materialValue: Math.max(0, Number(row?.materialCostValue) || 0),
       laborValue: Math.max(0, Number(row?.laborCostValue) || 0),
       totalCostValue: Number(row?.totalCostValue) || 0,
       totalProfitValue: Number(row?.totalProfitValue) || 0,
-      formulaTitle: "Source: Central data table completed cutting jobs row. Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost).",
+      formulaTitle: "Source: Central data table completed cutting jobs row. Before expense gain = Hours × Charge Rate. Excludes maintenance parts, labor, and consumables reductions.",
       settingsLink: row?.settingsLink || ""
     }));
   const efficiencyTotals = efficiencyRows.reduce((acc, row) => {
@@ -15025,20 +15026,23 @@ function computeCostModel(){
     averageCostLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.cost / efficiencyCount) : 0, { decimals: 2 }),
     totalProfitLabel: formatterCurrency(efficiencyTotals.profit, { decimals: Math.abs(efficiencyTotals.profit) < 1000 ? 2 : 0, showPlus: true }),
     averageProfitLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.profit / efficiencyCount) : 0, { decimals: 2, showPlus: true }),
+    totalBeforeExpenseLabel: formatterCurrency(efficiencyTotals.revenue, { decimals: Math.abs(efficiencyTotals.revenue) < 1000 ? 2 : 0, showPlus: true }),
+    averageBeforeExpenseLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.revenue / efficiencyCount) : 0, { decimals: 2, showPlus: true }),
     sourceLabel: "Source: central data table completed cutting jobs rows.",
-    formulaLabel: "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)",
+    formulaLabel: "Before expense gain = Hours × Charge Rate",
+    disclaimerLabel: "Before expense only: does not include reductions for maintenance parts, labor, or consumables.",
     rows: efficiencyRows,
     emptyMessage: "No valid completed cutting tasks with settings links were found in the central data table."
   };
-  const efficiencyMathDetails = `Profit = Revenue - (Labor + Material). Revenue ${formatterCurrency(efficiencyTotals.revenue, { decimals: 0 })}, Labor ${formatterCurrency(efficiencyTotals.labor, { decimals: 0 })}, Material ${formatterCurrency(efficiencyTotals.material, { decimals: 0 })}, Profit ${formatterCurrency(efficiencyTotals.profit, { decimals: 0, showPlus: true })}, Hours ${formatHoursValue(efficiencyTotals.hours)}.`;
+  const efficiencyMathDetails = `Before expense gain = Hours × Charge Rate. Revenue ${formatterCurrency(efficiencyTotals.revenue, { decimals: 0 })} from ${formatHoursValue(efficiencyTotals.hours)}. This excludes maintenance parts, labor, and consumables reductions.`;
   efficiencySnapshot.mathDetailsLabel = efficiencyMathDetails;
-  const efficiencyDisplayProfit = Math.max(0, efficiencyTotals.profit);
+  const efficiencyDisplayProfit = Math.max(0, efficiencyTotals.revenue);
   const efficiencyDisplayAverage = efficiencyCount ? (efficiencyDisplayProfit / efficiencyCount) : 0;
   const cuttingCard = Array.isArray(summaryCards) ? summaryCards.find(card => card && card.key === "cuttingJobs") : null;
   if (cuttingCard){
     cuttingCard.value = formatterCurrency(efficiencyDisplayProfit, { decimals: 0, showPlus: true });
     cuttingCard.hint = efficiencyCount
-      ? `Average gain/loss ${formatterCurrency(efficiencyDisplayAverage, { decimals: 0, showPlus: true })} across ${efficiencyCount} completed job${efficiencyCount===1?"":"s"} (source: central data table).`
+      ? `Average gain before expense ${formatterCurrency(efficiencyDisplayAverage, { decimals: 0, showPlus: true })} across ${efficiencyCount} completed job${efficiencyCount===1?"":"s"} (source: central data table).`
       : "No cutting jobs logged yet.";
     cuttingCard.tooltip = `Source: central data table completed rows. ${efficiencyMathDetails}`;
   }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -14387,6 +14387,8 @@ function computeCostModel(){
       ...report,
       totalCutCostLabel: formatterCurrency(report.totalCutCost, { showPlus: true, decimals: Math.abs(report.totalCutCost) < 1000 ? 2 : 0 }),
       totalMaintenanceCostLabel: formatterCurrency(report.totalMaintenanceCost, { decimals: report.totalMaintenanceCost < 1000 ? 2 : 0 }),
+      totalCutProfitLabel: formatterCurrency(report.totalCutCost, { showPlus: true, decimals: Math.abs(report.totalCutCost) < 1000 ? 2 : 0 }),
+      totalMaintenanceLossLabel: formatterCurrency(-Math.abs(report.totalMaintenanceCost), { showPlus: true, decimals: report.totalMaintenanceCost < 1000 ? 2 : 0 }),
       totalCutHoursLabel: formatHours(report.totalCutHours),
       weekLabel: `${formatDateLabelShort(new Date(report.weekStartISO))} - ${formatDateLabelShort(new Date(report.weekEndISO))}`
     }));
@@ -14947,6 +14949,7 @@ function computeCostModel(){
     const materialCostValue = Number.isFinite(materialCost) && materialCost >= 0 ? materialCost : 0;
     const laborCostValue = Math.max(0, hours) * costRate;
     const totalCostValue = materialCostValue + laborCostValue;
+    const totalProfitValue = (Math.max(0, hours) * chargeRate) - totalCostValue;
     const completedISO = typeof job?.completedAtISO === "string" && job.completedAtISO ? job.completedAtISO : "";
     return {
       id: job?.id != null ? String(job.id) : `completed_job_${index}`,
@@ -14969,9 +14972,12 @@ function computeCostModel(){
       cumulativeCutNumberLabel: `#${Math.max(1, totalCompletedJobs - index)}`,
       categoryCutNumberLabel: `#${categoryCutCount}`,
       hoursValue: hours,
+      chargeRateValue: chargeRate,
+      costRateValue: costRate,
       materialCostValue,
       laborCostValue,
       totalCostValue,
+      totalProfitValue,
       settingsLink: job?.id != null ? `#/settings?jobId=${encodeURIComponent(String(job.id))}` : ""
     };
   });
@@ -14992,23 +14998,31 @@ function computeCostModel(){
       partCostLabel: formatterCurrency(Number(row?.materialCostValue) || 0, { decimals: 2 }),
       laborCostLabel: formatterCurrency(Number(row?.laborCostValue) || 0, { decimals: 2 }),
       totalCostLabel: formatterCurrency(Number(row?.totalCostValue) || 0, { decimals: 2 }),
+      totalProfitLabel: formatterCurrency(Number(row?.totalProfitValue) || 0, { decimals: 2, showPlus: true }),
       hoursValue: Number(row?.hoursValue) || 0,
       totalCostValue: Number(row?.totalCostValue) || 0,
+      totalProfitValue: Number(row?.totalProfitValue) || 0,
+      formulaTitle: "Source: Central data table completed cutting jobs row. Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost).",
       settingsLink: row?.settingsLink || ""
     }));
   const efficiencyTotals = efficiencyRows.reduce((acc, row) => {
     if (Number.isFinite(row?.hoursValue)) acc.hours += Math.max(0, Number(row.hoursValue));
     if (Number.isFinite(row?.totalCostValue)) acc.cost += Math.max(0, Number(row.totalCostValue));
+    if (Number.isFinite(row?.totalProfitValue)) acc.profit += Number(row.totalProfitValue);
     return acc;
-  }, { hours: 0, cost: 0 });
+  }, { hours: 0, cost: 0, profit: 0 });
   const efficiencyCount = efficiencyRows.length;
   const efficiencySnapshot = {
     countLabel: String(efficiencyCount),
     totalHoursLabel: formatHoursValue(efficiencyTotals.hours),
     totalCostLabel: formatterCurrency(efficiencyTotals.cost, { decimals: efficiencyTotals.cost < 1000 ? 2 : 0 }),
     averageCostLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.cost / efficiencyCount) : 0, { decimals: 2 }),
+    totalProfitLabel: formatterCurrency(efficiencyTotals.profit, { decimals: Math.abs(efficiencyTotals.profit) < 1000 ? 2 : 0, showPlus: true }),
+    averageProfitLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.profit / efficiencyCount) : 0, { decimals: 2, showPlus: true }),
+    sourceLabel: "Source: central data table completed cutting jobs rows.",
+    formulaLabel: "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)",
     rows: efficiencyRows,
-    emptyMessage: "No valid completed cutting tasks with settings links were found in the data center table."
+    emptyMessage: "No valid completed cutting tasks with settings links were found in the central data table."
   };
 
   const taskById = new Map();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10630,6 +10630,7 @@ function renderCosts(){
   setupCostTimeframeModal(model);
   setupJobCategoryWindow(model);
   setupWeeklyReportWindow(model);
+  setupEfficiencyCalculator(model);
   setupMaintenanceDataCenterActions({ openImmediately: wasDataCenterOpen });
 
   function focusCalendarAtOccurrence(taskId, dateISO){
@@ -11649,6 +11650,60 @@ function renderCosts(){
     if (canvas instanceof HTMLCanvasElement){
       drawWeeklyReportChart(canvas, reportForChart);
     }
+  }
+
+  function setupEfficiencyCalculator(currentModel){
+    const panel = content.querySelector("[data-efficiency-calc]");
+    if (!(panel instanceof HTMLElement)) return;
+    const snapshot = currentModel && currentModel.efficiencySnapshot ? currentModel.efficiencySnapshot : {};
+    const rows = Array.isArray(snapshot.rows) ? snapshot.rows : [];
+    const defaults = snapshot.calculatorDefaults || {};
+    const chargeInput = panel.querySelector("[data-efficiency-calc-charge]");
+    const costInput = panel.querySelector("[data-efficiency-calc-cost]");
+    const resetBtn = panel.querySelector("[data-efficiency-calc-reset]");
+    const totalEl = panel.querySelector("[data-efficiency-calc-total]");
+    const avgEl = panel.querySelector("[data-efficiency-calc-average]");
+    if (!(chargeInput instanceof HTMLInputElement) || !(costInput instanceof HTMLInputElement)) return;
+
+    const formatUsd = (value)=> new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: Math.abs(Number(value) || 0) < 1000 ? 2 : 0,
+      maximumFractionDigits: Math.abs(Number(value) || 0) < 1000 ? 2 : 0
+    }).format(Number.isFinite(Number(value)) ? Number(value) : 0);
+    const asNumber = (value, fallback = 0)=>{
+      const num = Number(value);
+      return Number.isFinite(num) ? num : fallback;
+    };
+    const defaultCharge = Math.max(0, asNumber(defaults.chargeRate, asNumber(chargeInput.value, 0)));
+    const defaultCost = Math.max(0, asNumber(defaults.costRate, asNumber(costInput.value, 0)));
+    chargeInput.value = String(defaultCharge);
+    costInput.value = String(defaultCost);
+
+    const recalc = ()=>{
+      const chargeRate = Math.max(0, asNumber(chargeInput.value, defaultCharge));
+      const costRate = Math.max(0, asNumber(costInput.value, defaultCost));
+      const totals = rows.reduce((acc, row)=>{
+        const hours = Math.max(0, asNumber(row?.hoursValue, 0));
+        const material = Math.max(0, asNumber(row?.materialValue ?? row?.materialCostValue, 0));
+        acc.rows += 1;
+        acc.net += (hours * (chargeRate - costRate)) - material;
+        return acc;
+      }, { rows: 0, net: 0 });
+      if (totalEl) totalEl.textContent = formatUsd(totals.net);
+      if (avgEl) avgEl.textContent = formatUsd(totals.rows ? (totals.net / totals.rows) : 0);
+    };
+
+    chargeInput.addEventListener("input", recalc);
+    costInput.addEventListener("input", recalc);
+    if (resetBtn instanceof HTMLElement){
+      resetBtn.addEventListener("click", ()=>{
+        chargeInput.value = String(defaultCharge);
+        costInput.value = String(defaultCost);
+        recalc();
+      });
+    }
+    recalc();
   }
 
   function setupJobCategoryWindow(currentModel){
@@ -15000,6 +15055,8 @@ function computeCostModel(){
       totalCostLabel: formatterCurrency(Number(row?.totalCostValue) || 0, { decimals: 2 }),
       totalProfitLabel: formatterCurrency(Number(row?.totalProfitValue) || 0, { decimals: 2, showPlus: true }),
       hoursValue: Number(row?.hoursValue) || 0,
+      chargeRateValue: Number(row?.chargeRateValue) || 0,
+      costRateValue: Number(row?.costRateValue) || 0,
       revenueValue: Math.max(0, (Number(row?.hoursValue) || 0) * (Number(row?.chargeRateValue) || 0)),
       beforeExpenseLabel: formatterCurrency(Math.max(0, (Number(row?.hoursValue) || 0) * (Number(row?.chargeRateValue) || 0)), { decimals: 2, showPlus: true }),
       materialValue: Math.max(0, Number(row?.materialCostValue) || 0),
@@ -15036,6 +15093,13 @@ function computeCostModel(){
   };
   const efficiencyMathDetails = `Before expense gain = Hours × Charge Rate. Revenue ${formatterCurrency(efficiencyTotals.revenue, { decimals: 0 })} from ${formatHoursValue(efficiencyTotals.hours)}. This excludes maintenance parts, labor, and consumables reductions.`;
   efficiencySnapshot.mathDetailsLabel = efficiencyMathDetails;
+  const totalCalcHours = efficiencyTotals.hours > 0 ? efficiencyTotals.hours : 0;
+  const defaultChargeRateForCalc = totalCalcHours > 0 ? (efficiencyTotals.revenue / totalCalcHours) : JOB_RATE_PER_HOUR;
+  const defaultCostRateForCalc = totalCalcHours > 0 ? (efficiencyTotals.labor / totalCalcHours) : JOB_BASE_COST_PER_HOUR;
+  efficiencySnapshot.calculatorDefaults = {
+    chargeRate: Number.isFinite(defaultChargeRateForCalc) ? defaultChargeRateForCalc : JOB_RATE_PER_HOUR,
+    costRate: Number.isFinite(defaultCostRateForCalc) ? defaultCostRateForCalc : JOB_BASE_COST_PER_HOUR
+  };
   const efficiencyDisplayProfit = Math.max(0, efficiencyTotals.revenue);
   const efficiencyDisplayAverage = efficiencyCount ? (efficiencyDisplayProfit / efficiencyCount) : 0;
   const cuttingCard = Array.isArray(summaryCards) ? summaryCards.find(card => card && card.key === "cuttingJobs") : null;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -15000,6 +15000,9 @@ function computeCostModel(){
       totalCostLabel: formatterCurrency(Number(row?.totalCostValue) || 0, { decimals: 2 }),
       totalProfitLabel: formatterCurrency(Number(row?.totalProfitValue) || 0, { decimals: 2, showPlus: true }),
       hoursValue: Number(row?.hoursValue) || 0,
+      revenueValue: Math.max(0, (Number(row?.hoursValue) || 0) * (Number(row?.chargeRateValue) || 0)),
+      materialValue: Math.max(0, Number(row?.materialCostValue) || 0),
+      laborValue: Math.max(0, Number(row?.laborCostValue) || 0),
       totalCostValue: Number(row?.totalCostValue) || 0,
       totalProfitValue: Number(row?.totalProfitValue) || 0,
       formulaTitle: "Source: Central data table completed cutting jobs row. Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost).",
@@ -15007,10 +15010,13 @@ function computeCostModel(){
     }));
   const efficiencyTotals = efficiencyRows.reduce((acc, row) => {
     if (Number.isFinite(row?.hoursValue)) acc.hours += Math.max(0, Number(row.hoursValue));
+    if (Number.isFinite(row?.revenueValue)) acc.revenue += Math.max(0, Number(row.revenueValue));
+    if (Number.isFinite(row?.materialValue)) acc.material += Math.max(0, Number(row.materialValue));
+    if (Number.isFinite(row?.laborValue)) acc.labor += Math.max(0, Number(row.laborValue));
     if (Number.isFinite(row?.totalCostValue)) acc.cost += Math.max(0, Number(row.totalCostValue));
     if (Number.isFinite(row?.totalProfitValue)) acc.profit += Number(row.totalProfitValue);
     return acc;
-  }, { hours: 0, cost: 0, profit: 0 });
+  }, { hours: 0, revenue: 0, material: 0, labor: 0, cost: 0, profit: 0 });
   const efficiencyCount = efficiencyRows.length;
   const efficiencySnapshot = {
     countLabel: String(efficiencyCount),
@@ -15024,6 +15030,8 @@ function computeCostModel(){
     rows: efficiencyRows,
     emptyMessage: "No valid completed cutting tasks with settings links were found in the central data table."
   };
+  const efficiencyMathDetails = `Profit = Revenue - (Labor + Material). Revenue ${formatterCurrency(efficiencyTotals.revenue, { decimals: 0 })}, Labor ${formatterCurrency(efficiencyTotals.labor, { decimals: 0 })}, Material ${formatterCurrency(efficiencyTotals.material, { decimals: 0 })}, Profit ${formatterCurrency(efficiencyTotals.profit, { decimals: 0, showPlus: true })}, Hours ${formatHoursValue(efficiencyTotals.hours)}.`;
+  efficiencySnapshot.mathDetailsLabel = efficiencyMathDetails;
   const efficiencyDisplayProfit = Math.max(0, efficiencyTotals.profit);
   const efficiencyDisplayAverage = efficiencyCount ? (efficiencyDisplayProfit / efficiencyCount) : 0;
   const cuttingCard = Array.isArray(summaryCards) ? summaryCards.find(card => card && card.key === "cuttingJobs") : null;
@@ -15032,6 +15040,7 @@ function computeCostModel(){
     cuttingCard.hint = efficiencyCount
       ? `Average gain/loss ${formatterCurrency(efficiencyDisplayAverage, { decimals: 0, showPlus: true })} across ${efficiencyCount} completed job${efficiencyCount===1?"":"s"} (source: central data table).`
       : "No cutting jobs logged yet.";
+    cuttingCard.tooltip = `Source: central data table completed rows. ${efficiencyMathDetails}`;
   }
   const combinedCard = Array.isArray(summaryCards) ? summaryCards.find(card => card && card.key === "combinedImpact") : null;
   if (combinedCard){

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11765,7 +11765,11 @@ function renderCosts(){
       }, { rows: 0, net: 0 });
       if (totalEl) totalEl.textContent = formatUsd(totals.net);
       if (avgEl) avgEl.textContent = formatUsd(totals.rows ? (totals.net / totals.rows) : 0);
-      const tableRows = Array.from(content.querySelectorAll("[data-efficiency-row]"));
+      const summaryTotalEl = document.querySelector("[data-efficiency-summary-total]");
+      const summaryAvgEl = document.querySelector("[data-efficiency-summary-average]");
+      if (summaryTotalEl) summaryTotalEl.textContent = formatUsd(totals.net);
+      if (summaryAvgEl) summaryAvgEl.textContent = formatUsd(totals.rows ? (totals.net / totals.rows) : 0);
+      const tableRows = Array.from(document.querySelectorAll("[data-efficiency-row]"));
       tableRows.forEach(tr => {
         const rowId = String(tr.getAttribute("data-efficiency-id") || "");
         const rowObj = rows.find(row => String(row?.id || "") === rowId) || null;
@@ -11805,9 +11809,23 @@ function renderCosts(){
     }
     if (goJobsBtn instanceof HTMLElement){
       goJobsBtn.addEventListener("click", ()=>{
+        closeSnapshot();
         goToJobsHistory();
       });
     }
+    const openJobBtns = Array.from(document.querySelectorAll("[data-efficiency-open-job]"));
+    openJobBtns.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", ()=>{
+        const id = String(btn.getAttribute("data-efficiency-open-job") || "");
+        if (!id) return;
+        if (typeof window !== "undefined"){
+          window.pendingJobFocus = { type: "jobRow", id };
+        }
+        closeSnapshot();
+        goToJobsHistory();
+      });
+    });
     updateRangeButtons();
     recalc();
   }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -14944,8 +14944,9 @@ function computeCostModel(){
     const costRate = Number.isFinite(costRateRaw) && costRateRaw >= 0 ? costRateRaw : JOB_BASE_COST_PER_HOUR;
     const materialCost = Number(job?.materialCost);
     const materialQty = Number(job?.materialQty);
-    const materialCostValue = Number.isFinite(materialCost) ? materialCost : 0;
-    const totalProfit = ((chargeRate * hours) - (costRate * hours)) - materialCostValue;
+    const materialCostValue = Number.isFinite(materialCost) && materialCost >= 0 ? materialCost : 0;
+    const laborCostValue = Math.max(0, hours) * costRate;
+    const totalCostValue = materialCostValue + laborCostValue;
     const completedISO = typeof job?.completedAtISO === "string" && job.completedAtISO ? job.completedAtISO : "";
     return {
       id: job?.id != null ? String(job.id) : `completed_job_${index}`,
@@ -14958,17 +14959,57 @@ function computeCostModel(){
       materialType: String(job?.material || "—"),
       materialCostLabel: Number.isFinite(materialCost) ? formatterCurrency(materialCost, { decimals: 2 }) : "—",
       materialQtyLabel: Number.isFinite(materialQty) ? String(materialQty) : "—",
-      totalProfitLabel: formatterCurrency(totalProfit, { decimals: 2 }),
       startDateLabel: job?.startISO || "—",
       dueDateLabel: job?.dueISO || "—",
       completedDateLabel: completedISO ? String(completedISO).slice(0, 10) : "—",
+      completedDateISO: completedISO ? String(completedISO).slice(0, 10) : "",
       projectNumber: String(job?.projectNumber || "—"),
       notes: String(job?.notes || "").trim() || "—",
       priorityLabel: Number.isFinite(Number(job?.priority)) ? String(Math.max(1, Math.floor(Number(job.priority)))) : "—",
       cumulativeCutNumberLabel: `#${Math.max(1, totalCompletedJobs - index)}`,
-      categoryCutNumberLabel: `#${categoryCutCount}`
+      categoryCutNumberLabel: `#${categoryCutCount}`,
+      hoursValue: hours,
+      materialCostValue,
+      laborCostValue,
+      totalCostValue,
+      settingsLink: job?.id != null ? `#/settings?jobId=${encodeURIComponent(String(job.id))}` : ""
     };
   });
+
+  const efficiencyRows = cuttingJobsDataTable
+    .filter(row => {
+      const hasDate = typeof row?.completedDateISO === "string" && row.completedDateISO.trim().length > 0;
+      const hasTaskName = typeof row?.name === "string" && row.name.trim().length > 0;
+      const hasSettingsLink = typeof row?.settingsLink === "string" && /^#\/settings\?jobId=/.test(row.settingsLink);
+      return hasDate && hasTaskName && hasSettingsLink;
+    })
+    .sort((a, b) => String(b?.completedDateISO || "").localeCompare(String(a?.completedDateISO || "")))
+    .map((row, index) => ({
+      id: row?.id != null ? String(row.id) : `efficiency_row_${index}`,
+      taskName: row?.name || "Completed task",
+      dateLabel: row?.completedDateISO || "—",
+      hoursLabel: formatHoursValue(Number(row?.hoursValue) || 0),
+      partCostLabel: formatterCurrency(Number(row?.materialCostValue) || 0, { decimals: 2 }),
+      laborCostLabel: formatterCurrency(Number(row?.laborCostValue) || 0, { decimals: 2 }),
+      totalCostLabel: formatterCurrency(Number(row?.totalCostValue) || 0, { decimals: 2 }),
+      hoursValue: Number(row?.hoursValue) || 0,
+      totalCostValue: Number(row?.totalCostValue) || 0,
+      settingsLink: row?.settingsLink || ""
+    }));
+  const efficiencyTotals = efficiencyRows.reduce((acc, row) => {
+    if (Number.isFinite(row?.hoursValue)) acc.hours += Math.max(0, Number(row.hoursValue));
+    if (Number.isFinite(row?.totalCostValue)) acc.cost += Math.max(0, Number(row.totalCostValue));
+    return acc;
+  }, { hours: 0, cost: 0 });
+  const efficiencyCount = efficiencyRows.length;
+  const efficiencySnapshot = {
+    countLabel: String(efficiencyCount),
+    totalHoursLabel: formatHoursValue(efficiencyTotals.hours),
+    totalCostLabel: formatterCurrency(efficiencyTotals.cost, { decimals: efficiencyTotals.cost < 1000 ? 2 : 0 }),
+    averageCostLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.cost / efficiencyCount) : 0, { decimals: 2 }),
+    rows: efficiencyRows,
+    emptyMessage: "No valid completed cutting tasks with settings links were found in the data center table."
+  };
 
   const taskById = new Map();
   [Array.isArray(intervalTasksAll) ? intervalTasksAll : [], Array.isArray(asReqTasksAll) ? asReqTasksAll : []].forEach(list => {
@@ -15105,6 +15146,7 @@ function computeCostModel(){
     orderRequestSummary,
     maintenanceDataTable,
     cuttingJobsDataTable,
+    efficiencySnapshot,
     chartColors: COST_CHART_COLORS,
     maintenanceSeries,
     jobSeries,

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11661,10 +11661,12 @@ function renderCosts(){
     const chargeInput = panel.querySelector("[data-efficiency-calc-charge]");
     const costInput = panel.querySelector("[data-efficiency-calc-cost]");
     const resetBtn = panel.querySelector("[data-efficiency-calc-reset]");
-    const rangeButtons = Array.from(panel.querySelectorAll("[data-efficiency-calc-range]"));
+    const rangeSelect = panel.querySelector("[data-efficiency-calc-range-select]");
     const rangeLabelEl = panel.querySelector("[data-efficiency-calc-range-label]");
     const totalEl = panel.querySelector("[data-efficiency-calc-total]");
     const avgEl = panel.querySelector("[data-efficiency-calc-average]");
+    const openSnapshotBtn = panel.querySelector("[data-open-efficiency-snapshot]");
+    const goJobsBtn = panel.querySelector("[data-go-jobs-history]");
     if (!(chargeInput instanceof HTMLInputElement) || !(costInput instanceof HTMLInputElement)) return;
 
     const formatUsd = (value)=> new Intl.NumberFormat(undefined, {
@@ -11712,12 +11714,7 @@ function renderCosts(){
       return rowDate >= start;
     };
     const updateRangeButtons = ()=>{
-      rangeButtons.forEach(btn => {
-        const key = String(btn.getAttribute("data-efficiency-calc-range") || "");
-        const isActive = key === activeRange;
-        btn.classList.toggle("is-active", isActive);
-        btn.setAttribute("aria-pressed", isActive ? "true" : "false");
-      });
+      if (rangeSelect instanceof HTMLSelectElement) rangeSelect.value = activeRange;
       const labels = {
         "1m": "Range: past 1 month from central data table rows.",
         "2m": "Range: past 2 months from central data table rows.",
@@ -11756,20 +11753,44 @@ function renderCosts(){
 
     chargeInput.addEventListener("input", recalc);
     costInput.addEventListener("input", recalc);
-    rangeButtons.forEach(btn => {
-      if (!(btn instanceof HTMLElement)) return;
-      btn.addEventListener("click", ()=>{
-        const next = String(btn.getAttribute("data-efficiency-calc-range") || "1m");
-        activeRange = next || "1m";
+    if (rangeSelect instanceof HTMLSelectElement){
+      rangeSelect.addEventListener("change", ()=>{
+        activeRange = String(rangeSelect.value || "1m");
         updateRangeButtons();
         recalc();
       });
-    });
+    }
     if (resetBtn instanceof HTMLElement){
       resetBtn.addEventListener("click", ()=>{
         chargeInput.value = String(defaultCharge);
         costInput.value = String(defaultCost);
+        activeRange = "1m";
         recalc();
+        updateRangeButtons();
+      });
+    }
+    if (openSnapshotBtn instanceof HTMLElement){
+      openSnapshotBtn.addEventListener("click", ()=>{
+        const modal = document.getElementById("efficiencySnapshotModal");
+        if (!(modal instanceof HTMLElement)) return;
+        modal.hidden = false;
+        if (modal.parentElement !== document.body) document.body.appendChild(modal);
+        document.body.classList.add("cost-data-center-open");
+      });
+    }
+    const closeSnapshotBtns = Array.from(document.querySelectorAll("[data-close-efficiency-snapshot]"));
+    closeSnapshotBtns.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", ()=>{
+        const modal = document.getElementById("efficiencySnapshotModal");
+        if (!(modal instanceof HTMLElement)) return;
+        modal.hidden = true;
+        document.body.classList.remove("cost-data-center-open");
+      });
+    });
+    if (goJobsBtn instanceof HTMLElement){
+      goJobsBtn.addEventListener("click", ()=>{
+        goToJobsHistory();
       });
     }
     updateRangeButtons();
@@ -12204,7 +12225,6 @@ function renderCosts(){
   };
 
   wireJobsHistoryShortcut(content.querySelector("[data-cost-jobs-history]"));
-  wireJobsHistoryShortcut(content.querySelector("[data-cost-cutting-card]"));
   wireJobsHistoryShortcut(content.querySelector(".cost-chart-toggle-link"));
 
   const normalizeHistoryDate = (value)=>{
@@ -15161,7 +15181,7 @@ function computeCostModel(){
     rows: efficiencyRows,
     emptyMessage: "No valid completed cutting tasks with settings links were found in the central data table."
   };
-  const efficiencyMathDetails = `Net gain = (Hours × (Charge Rate - Cost Rate)) - Material. Revenue ${formatterCurrency(efficiencyTotals.revenue, { decimals: 0 })}, Labor ${formatterCurrency(efficiencyTotals.labor, { decimals: 0 })}, Material ${formatterCurrency(efficiencyTotals.material, { decimals: 0 })}, Net ${formatterCurrency(efficiencyTotals.profit, { decimals: 0, showPlus: true })}.`;
+  const efficiencyMathDetails = `Net gain = (Hours × (Charge Rate - Cost Rate)) - Material. Revenue ${formatterCurrency(efficiencyTotals.revenue, { decimals: 0 })}, Run cost (cost/hr × hours) ${formatterCurrency(efficiencyTotals.labor, { decimals: 0 })}, Material ${formatterCurrency(efficiencyTotals.material, { decimals: 0 })}, Net ${formatterCurrency(efficiencyTotals.profit, { decimals: 0, showPlus: true })}.`;
   efficiencySnapshot.mathDetailsLabel = efficiencyMathDetails;
   const totalCalcHours = efficiencyTotals.hours > 0 ? efficiencyTotals.hours : 0;
   const defaultChargeRateForCalc = totalCalcHours > 0 ? (efficiencyTotals.revenue / totalCalcHours) : JOB_RATE_PER_HOUR;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10571,6 +10571,7 @@ function renderCosts(){
   const content = document.getElementById("content");
   if (!content) return;
   const previousModal = document.getElementById("costDataCenterModal");
+  const previousEfficiencyModal = document.getElementById("efficiencySnapshotModal");
   const wasDataCenterOpen = Boolean(previousModal && !previousModal.hasAttribute("hidden"));
   let pendingDataCenterScrollTop = null;
   if (previousModal instanceof HTMLElement && wasDataCenterOpen){
@@ -10581,6 +10582,10 @@ function renderCosts(){
   }
   if (previousModal && previousModal.parentElement === document.body){
     previousModal.remove();
+    document.body.classList.remove("cost-data-center-open");
+  }
+  if (previousEfficiencyModal && previousEfficiencyModal.parentElement === document.body){
+    previousEfficiencyModal.remove();
     document.body.classList.remove("cost-data-center-open");
   }
   const existingReceiptModal = document.getElementById("costReceiptModal");
@@ -11671,7 +11676,7 @@ function renderCosts(){
       if (!(btn instanceof HTMLElement)) return;
       btn.addEventListener("click", openSnapshot);
     });
-    const closeSnapshotBtns = Array.from(content.querySelectorAll("[data-close-efficiency-snapshot]"));
+    const closeSnapshotBtns = Array.from(document.querySelectorAll("[data-close-efficiency-snapshot]"));
     closeSnapshotBtns.forEach(btn => {
       if (!(btn instanceof HTMLElement)) return;
       btn.addEventListener("click", closeSnapshot);
@@ -11701,6 +11706,14 @@ function renderCosts(){
     const asNumber = (value, fallback = 0)=>{
       const num = Number(value);
       return Number.isFinite(num) ? num : fallback;
+    };
+    const normalizeToTwo = (inputEl, fallback)=>{
+      if (!(inputEl instanceof HTMLInputElement)) return fallback;
+      const raw = asNumber(inputEl.value, fallback);
+      const safe = Math.max(0, raw);
+      const normalized = Math.round(safe * 100) / 100;
+      inputEl.value = normalized.toFixed(2);
+      return normalized;
     };
     const defaultCharge = Math.max(0, asNumber(defaults.chargeRate, asNumber(chargeInput.value, 0)));
     const defaultCost = Math.max(0, asNumber(defaults.costRate, asNumber(costInput.value, 0)));
@@ -11753,8 +11766,8 @@ function renderCosts(){
     };
 
     const recalc = ()=>{
-      const chargeRate = Math.max(0, asNumber(chargeInput.value, defaultCharge));
-      const costRate = Math.max(0, asNumber(costInput.value, defaultCost));
+      const chargeRate = normalizeToTwo(chargeInput, defaultCharge);
+      const costRate = normalizeToTwo(costInput, defaultCost);
       const visibleRows = rows.filter(row => withinRange(row, activeRange));
       const totals = visibleRows.reduce((acc, row)=>{
         const hours = Math.max(0, asNumber(row?.hoursValue, 0));
@@ -11775,6 +11788,18 @@ function renderCosts(){
         const rowObj = rows.find(row => String(row?.id || "") === rowId) || null;
         const show = rowObj ? withinRange(rowObj, activeRange) : false;
         tr.hidden = !show;
+        if (!show) return;
+        const hours = Math.max(0, asNumber(tr.getAttribute("data-efficiency-hours"), asNumber(rowObj?.hoursValue, 0)));
+        const material = Math.max(0, asNumber(tr.getAttribute("data-efficiency-material"), asNumber(rowObj?.materialValue ?? rowObj?.materialCostValue, 0)));
+        const labor = hours * costRate;
+        const totalCost = labor + material;
+        const net = (hours * (chargeRate - costRate)) - material;
+        const laborCell = tr.querySelector("[data-efficiency-labor-cell]");
+        const totalCostCell = tr.querySelector("[data-efficiency-total-cost-cell]");
+        const profitCell = tr.querySelector("[data-efficiency-profit-cell]");
+        if (laborCell) laborCell.textContent = formatUsd(labor);
+        if (totalCostCell) totalCostCell.textContent = formatUsd(totalCost);
+        if (profitCell) profitCell.textContent = formatUsd(net);
       });
     };
 

--- a/js/views.js
+++ b/js/views.js
@@ -2247,8 +2247,8 @@ function viewCosts(model){
           <div class="cost-jobs-summary">
             <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
             <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
-            <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Before expense gain = Hours × Charge Rate"}`.trim())}"><span class="label">Total gain (before expense)</span><span>${esc(efficiencySnapshot.totalBeforeExpenseLabel || "$0.00")}</span></div>
-            <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Before expense gain = Hours × Charge Rate"}`.trim())}"><span class="label">Avg gain / row (before expense)</span><span>${esc(efficiencySnapshot.averageBeforeExpenseLabel || "$0.00")}</span></div>
+            <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Total net gain</span><span>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</span></div>
+            <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Avg net gain / row</span><span>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
           </div>
           <div class="cost-efficiency-calculator" data-efficiency-calc>
             <div class="cost-efficiency-calculator-row">
@@ -2262,25 +2262,35 @@ function viewCosts(model){
               </label>
               <button type="button" class="btn secondary" data-efficiency-calc-reset>Reset</button>
             </div>
-            <p class="small muted">Calculator only: temporary what-if net gain across all jobs. Refresh resets to central data table defaults.</p>
+            <div class="time-efficiency-toggles" role="tablist" aria-label="Efficiency range filter">
+              <button type="button" class="time-efficiency-toggle is-active" data-efficiency-calc-range="1m">1M</button>
+              <button type="button" class="time-efficiency-toggle" data-efficiency-calc-range="2m">2M</button>
+              <button type="button" class="time-efficiency-toggle" data-efficiency-calc-range="3m">3M</button>
+              <button type="button" class="time-efficiency-toggle" data-efficiency-calc-range="6m">6M</button>
+              <button type="button" class="time-efficiency-toggle" data-efficiency-calc-range="1y">1Y</button>
+              <button type="button" class="time-efficiency-toggle" data-efficiency-calc-range="ytd">YTD</button>
+              <button type="button" class="time-efficiency-toggle" data-efficiency-calc-range="all">All</button>
+            </div>
+            <p class="small muted" data-efficiency-calc-range-label>Range: past 1 month from central data table rows.</p>
+            <p class="small muted">Calculator only: temporary what-if net gain across filtered jobs. Refresh resets to central data table defaults.</p>
             <p class="small muted" data-efficiency-calc-result>
-              Net total gain (calculator): <strong data-efficiency-calc-total>${esc(efficiencySnapshot.totalProfitLabel || "$0.00")}</strong>
-              · Avg / row: <strong data-efficiency-calc-average>${esc(efficiencySnapshot.averageProfitLabel || "$0.00")}</strong>
+              Net total gain (calculator): <strong data-efficiency-calc-total>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</strong>
+              · Avg / row: <strong data-efficiency-calc-average>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</strong>
             </p>
           </div>
-          <p class="small muted" title="${esc(`${efficiencySnapshot.formulaLabel || "Before expense gain = Hours × Charge Rate"} ${efficiencySnapshot.disclaimerLabel || "Before expense only: does not include reductions for maintenance parts, labor, or consumables."}`)}" data-efficiency-source-note>${esc(efficiencySnapshot.sourceLabel || "Source: central data table completed cutting jobs rows.")} ${esc(efficiencySnapshot.disclaimerLabel || "Before expense only: does not include reductions for maintenance parts, labor, or consumables.")}</p>
+          <p class="small muted" title="${esc(`${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || "Uses central data table values only."}`)}" data-efficiency-source-note>${esc(efficiencySnapshot.sourceLabel || "Source: central data table completed cutting jobs rows.")} ${esc(efficiencySnapshot.disclaimerLabel || "Uses central data table values only.")}</p>
           <table class="cost-table">
-            <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Labor cost</th><th>Total cost</th><th title="${esc(`${efficiencySnapshot.formulaLabel || "Before expense gain = Hours × Charge Rate"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" aria-label="Before expense gain calculation">Gain (before expense)</th><th>Task link</th></tr></thead>
+            <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Labor cost</th><th>Total cost</th><th title="${esc(`${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" aria-label="Net gain calculation">Net gain</th><th>Task link</th></tr></thead>
             <tbody>
               ${efficiencyRows.length ? efficiencyRows.map(row => `
-                <tr>
+                <tr data-efficiency-row data-efficiency-id="${esc(row.id || "")}" data-efficiency-date="${esc(row.dateLabel || "")}">
                   <td>${esc(row.taskName || "Completed task")}</td>
                   <td>${esc(row.dateLabel || "—")}</td>
                   <td>${esc(row.hoursLabel || "0 hr")}</td>
                   <td>${esc(row.partCostLabel || "$0.00")}</td>
                   <td>${esc(row.laborCostLabel || "$0.00")}</td>
                   <td>${esc(row.totalCostLabel || "$0.00")}</td>
-                  <td title="${esc(`${row.formulaTitle || efficiencySnapshot.formulaLabel || "Before expense gain = Hours × Charge Rate"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" data-efficiency-profit-cell>${esc(row.beforeExpenseLabel || "$0.00")}</td>
+                  <td title="${esc(`${row.formulaTitle || efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" data-efficiency-profit-cell>${esc(row.netGainLabel || "$0.00")}</td>
                   <td>${row.settingsLink ? `<a href="${esc(row.settingsLink)}">Open settings</a>` : "Invalid link"}</td>
                 </tr>
               `).join("") : `

--- a/js/views.js
+++ b/js/views.js
@@ -1846,6 +1846,39 @@ function viewCosts(model){
           <div class="cost-summary-grid">
             ${summaryCardsHTML}
           </div>
+          <div class="cost-efficiency-calculator" data-efficiency-calc>
+            <div class="cost-efficiency-calculator-row">
+              <label>
+                <span class="label">Charge / hr (temporary)</span>
+                <input type="number" step="0.01" min="0" value="${esc(String(Number(calculatorDefaults.chargeRate) || 0))}" data-efficiency-calc-charge>
+              </label>
+              <label>
+                <span class="label">Cost / hr (temporary)</span>
+                <input type="number" step="0.01" min="0" value="${esc(String(Number(calculatorDefaults.costRate) || 0))}" data-efficiency-calc-cost>
+              </label>
+              <label>
+                <span class="label">Time range</span>
+                <select data-efficiency-calc-range-select>
+                  <option value="1m">Past 1 month</option>
+                  <option value="2m">Past 2 months</option>
+                  <option value="3m">Past 3 months</option>
+                  <option value="6m">Past 6 months</option>
+                  <option value="1y">Past 1 year</option>
+                  <option value="ytd">Year to date</option>
+                  <option value="all">All time</option>
+                </select>
+              </label>
+              <button type="button" class="btn secondary" data-efficiency-calc-reset>Reset</button>
+              <button type="button" class="btn secondary" data-open-efficiency-snapshot>Open snapshot</button>
+              <button type="button" class="btn secondary" data-go-jobs-history>Go to cutting jobs</button>
+            </div>
+            <p class="small muted" data-efficiency-calc-range-label>Range: past 1 month from central data table rows.</p>
+            <p class="small muted">Temporary calculator only. Refresh resets values to central data table defaults.</p>
+            <p class="small muted" data-efficiency-calc-result>
+              Net total gain (calculator): <strong data-efficiency-calc-total>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</strong>
+              · Avg / row: <strong data-efficiency-calc-average>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</strong>
+            </p>
+          </div>
           <div class="cost-window-insight">
             <div class="chart-info">
               <button type="button" class="chart-info-button" aria-describedby="costOverviewInsight" aria-label="Explain Cost Overview metrics">
@@ -2241,44 +2274,26 @@ function viewCosts(model){
         </div>
       </div>
 
-      <div class="dashboard-window" data-cost-window="efficiency">
-        <div class="block" data-cost-jobs-history role="link" tabindex="0">
-          <h3>Cutting Job Efficiency Snapshot</h3>
-          <div class="cost-jobs-summary">
-            <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
-            <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
-            <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Total net gain</span><span>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</span></div>
-            <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Avg net gain / row</span><span>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
-          </div>
-          <div class="cost-efficiency-calculator" data-efficiency-calc>
-            <div class="cost-efficiency-calculator-row">
-              <label>
-                <span class="label">Charge / hr (temporary)</span>
-                <input type="number" step="0.01" min="0" value="${esc(String(Number(calculatorDefaults.chargeRate) || 0))}" data-efficiency-calc-charge>
-              </label>
-              <label>
-                <span class="label">Cost / hr (temporary)</span>
-                <input type="number" step="0.01" min="0" value="${esc(String(Number(calculatorDefaults.costRate) || 0))}" data-efficiency-calc-cost>
-              </label>
-              <button type="button" class="btn secondary" data-efficiency-calc-reset>Reset</button>
-            </div>
-            <div class="time-efficiency-toggles" role="tablist" aria-label="Efficiency range filter">
-              <button type="button" class="time-efficiency-toggle is-active" data-efficiency-calc-range="1m">1M</button>
-              <button type="button" class="time-efficiency-toggle" data-efficiency-calc-range="2m">2M</button>
-              <button type="button" class="time-efficiency-toggle" data-efficiency-calc-range="3m">3M</button>
-              <button type="button" class="time-efficiency-toggle" data-efficiency-calc-range="6m">6M</button>
-              <button type="button" class="time-efficiency-toggle" data-efficiency-calc-range="1y">1Y</button>
-              <button type="button" class="time-efficiency-toggle" data-efficiency-calc-range="ytd">YTD</button>
-              <button type="button" class="time-efficiency-toggle" data-efficiency-calc-range="all">All</button>
-            </div>
-            <p class="small muted" data-efficiency-calc-range-label>Range: past 1 month from central data table rows.</p>
-            <p class="small muted">Calculator only: temporary what-if net gain across filtered jobs. Refresh resets to central data table defaults.</p>
-            <p class="small muted" data-efficiency-calc-result>
-              Net total gain (calculator): <strong data-efficiency-calc-total>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</strong>
-              · Avg / row: <strong data-efficiency-calc-average>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</strong>
-            </p>
-          </div>
-          <p class="small muted" title="${esc(`${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || "Uses central data table values only."}`)}" data-efficiency-source-note>${esc(efficiencySnapshot.sourceLabel || "Source: central data table completed cutting jobs rows.")} ${esc(efficiencySnapshot.disclaimerLabel || "Uses central data table values only.")}</p>
+
+    </div>
+  </div>
+
+  <div class="cost-data-center-modal" id="efficiencySnapshotModal" data-efficiency-snapshot-modal hidden>
+    <div class="cost-data-center-backdrop" data-close-efficiency-snapshot></div>
+    <div class="cost-data-center-panel" role="dialog" aria-modal="true" aria-label="Cutting Job Efficiency Snapshot" style="max-width:1100px;border-radius:16px;">
+      <div class="cost-data-center-header" style="border-radius:16px 16px 0 0;">
+        <h4>Cutting Job Efficiency Snapshot</h4>
+        <button type="button" class="btn ghost" data-close-efficiency-snapshot>Close</button>
+      </div>
+      <div class="cost-data-center-body">
+        <div class="cost-jobs-summary">
+          <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
+          <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
+          <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Total net gain</span><span>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</span></div>
+          <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Avg net gain / row</span><span>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
+        </div>
+        <p class="small muted" title="${esc(`${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || "Uses central data table values only."}`)}" data-efficiency-source-note>${esc(efficiencySnapshot.sourceLabel || "Source: central data table completed cutting jobs rows.")} ${esc(efficiencySnapshot.disclaimerLabel || "Uses central data table values only.")}</p>
+        <div class="cost-weekly-table-wrap">
           <table class="cost-table">
             <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Labor cost</th><th>Total cost</th><th title="${esc(`${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" aria-label="Net gain calculation">Net gain</th><th>Task link</th></tr></thead>
             <tbody>
@@ -2300,21 +2315,9 @@ function viewCosts(model){
               `}
             </tbody>
           </table>
-          <div class="cost-window-insight">
-            <div class="chart-info">
-              <button type="button" class="chart-info-button" aria-describedby="costEfficiencyInsight" aria-label="Explain Cutting Job Efficiency Snapshot">
-                <span aria-hidden="true">?</span>
-                <span class="sr-only">Show how the Cutting Job Efficiency Snapshot reveals margin trends</span>
-              </button>
-              <div class="chart-info-bubble" id="costEfficiencyInsight" role="tooltip">
-                <p>${esc(efficiencyInsight)}</p>
-              </div>
-            </div>
-          </div>
         </div>
       </div>
-    </div>
-  </div>`;
+    </div></div>`;
 }
 
 function viewJobs(){

--- a/js/views.js
+++ b/js/views.js
@@ -1175,6 +1175,17 @@ function ensureTaskCategories(){
 function viewCosts(model){
   const data = model || {};
   const esc = (str)=> String(str ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+  const efficiencyWindows = [
+    { key: "7d", label: "1W", days: 7, description: "Past 7 days" },
+    { key: "30d", label: "1M", days: 30, description: "Past 30 days" },
+    { key: "90d", label: "3M", days: 90, description: "Past 3 months" },
+    { key: "182d", label: "6M", days: 182, description: "Past 6 months" },
+    { key: "365d", label: "1Y", days: 365, description: "Past year" }
+  ];
+  const efficiencyButtons = efficiencyWindows.map((win, index) => `
+    <button type="button" class="time-efficiency-toggle${index === 0 ? " is-active" : ""}" data-efficiency-range="${esc(String(win.days))}" data-efficiency-range-label="${esc(win.description)}" aria-pressed="${index === 0 ? "true" : "false"}" title="${esc(win.description)}">${esc(win.label)}</button>
+  `).join("");
+  const defaultEfficiencyDescription = esc(efficiencyWindows[0]?.description || "Past 7 days");
   const cards = Array.isArray(data.summaryCards) ? data.summaryCards : [];
   const timeframeRows = Array.isArray(data.timeframeRows) ? data.timeframeRows : [];
   const historyRows = Array.isArray(data.historyRows) ? data.historyRows : [];
@@ -2284,6 +2295,41 @@ function viewCosts(model){
         <button type="button" class="btn ghost" data-close-efficiency-snapshot>Close</button>
       </div>
       <div class="cost-data-center-body">
+        <div class="time-efficiency-inline" id="costTimeEfficiency">
+          <div class="time-efficiency-inline-header">
+            <span class="time-efficiency-inline-title">Cutting time efficiency</span>
+            <div class="time-efficiency-controls">
+              <div class="time-efficiency-toggles" role="tablist">
+                ${efficiencyButtons}
+              </div>
+              <button type="button" class="time-efficiency-edit-btn" data-efficiency-edit>Edit range</button>
+            </div>
+          </div>
+          <div class="time-efficiency-edit" data-efficiency-edit-panel hidden>
+            <div class="time-efficiency-edit-row">
+              <label class="time-efficiency-edit-field">
+                <span class="time-efficiency-edit-label">Start date</span>
+                <input type="date" data-efficiency-start-input>
+              </label>
+              <div class="time-efficiency-edit-actions">
+                <button type="button" class="time-efficiency-edit-apply" data-efficiency-apply>Apply</button>
+                <button type="button" class="time-efficiency-edit-cancel" data-efficiency-cancel>Cancel</button>
+              </div>
+            </div>
+            <p class="small muted time-efficiency-edit-note" data-efficiency-edit-note></p>
+          </div>
+          <div class="time-efficiency-metrics" role="status" aria-live="polite">
+            <div class="time-efficiency-metric"><span class="label">Actual hours</span><span class="value" data-efficiency-actual>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Current target</span><span class="value" data-efficiency-target>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Gap vs target</span><span class="value" data-efficiency-gap-target>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">End goal</span><span class="value" data-efficiency-goal>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Avg usage/day</span><span class="value" data-efficiency-average>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Gap vs goal</span><span class="value" data-efficiency-gap-goal>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Efficiency (to date)</span><span class="value" data-efficiency-percent>—</span></div>
+          </div>
+          <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
+          <p class="small muted">Baseline adapts to your average logged hours per day.</p>
+        </div>
         <div class="cost-efficiency-calculator" data-efficiency-calc>
           <div class="cost-efficiency-calculator-row">
             <label>
@@ -2330,13 +2376,13 @@ function viewCosts(model){
             <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Labor cost</th><th>Total cost</th><th title="${esc(`${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" aria-label="Net gain calculation">Net gain</th><th>Task link</th></tr></thead>
             <tbody>
               ${efficiencyRows.length ? efficiencyRows.map(row => `
-                <tr data-efficiency-row data-efficiency-id="${esc(row.id || "")}" data-efficiency-date="${esc(row.dateLabel || "")}">
+                <tr data-efficiency-row data-efficiency-id="${esc(row.id || "")}" data-efficiency-date="${esc(row.dateLabel || "")}" data-efficiency-hours="${esc(String(Number(row.hoursValue) || 0))}" data-efficiency-material="${esc(String(Number(row.materialValue || 0)))}">
                   <td>${esc(row.taskName || "Completed task")}</td>
                   <td>${esc(row.dateLabel || "—")}</td>
                   <td>${esc(row.hoursLabel || "0 hr")}</td>
                   <td>${esc(row.partCostLabel || "$0.00")}</td>
-                  <td>${esc(row.laborCostLabel || "$0.00")}</td>
-                  <td>${esc(row.totalCostLabel || "$0.00")}</td>
+                  <td data-efficiency-labor-cell>${esc(row.laborCostLabel || "$0.00")}</td>
+                  <td data-efficiency-total-cost-cell>${esc(row.totalCostLabel || "$0.00")}</td>
                   <td title="${esc(`${row.formulaTitle || efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" data-efficiency-profit-cell>${esc(row.netGainLabel || "$0.00")}</td>
                   <td>${row.settingsLink ? `<button type="button" class="btn secondary" data-efficiency-open-job="${esc(row.id || "")}">Open job</button>` : "Invalid link"}</td>
                 </tr>

--- a/js/views.js
+++ b/js/views.js
@@ -1558,6 +1558,9 @@ function viewCosts(model){
       attrParts.push("tabindex=\"0\"");
     }
     const attr = attrParts.join(" ");
+    const cuttingOpenBtn = isCutting
+      ? `<button type="button" class="btn secondary" data-open-efficiency-snapshot>Open calculator</button>`
+      : "";
     return `
               <div ${attr}>
                 <div class="cost-card-icon">${esc(card.icon || "")}</div>
@@ -1565,6 +1568,7 @@ function viewCosts(model){
                   <div class="cost-card-title">${esc(card.title || "")}</div>
                   <div class="cost-card-value">${esc(card.value || "")}</div>
                   <div class="cost-card-hint">${esc(card.hint || "")}</div>
+                  ${cuttingOpenBtn}
                 </div>
               </div>
             `;
@@ -1846,9 +1850,6 @@ function viewCosts(model){
           <div class="cost-summary-grid">
             ${summaryCardsHTML}
           </div>
-          <div class="cost-overview-actions">
-            <button type="button" class="btn secondary" data-open-efficiency-snapshot>Open cutting efficiency calculator & snapshot</button>
-          </div>
           <div class="cost-window-insight">
             <div class="chart-info">
               <button type="button" class="chart-info-button" aria-describedby="costOverviewInsight" aria-label="Explain Cost Overview metrics">
@@ -2038,6 +2039,7 @@ function viewCosts(model){
               <div class="cost-data-center-tabs" role="tablist" aria-label="Data center tables">
                 <button type="button" class="cost-data-center-tab is-active" data-dc-tab="maintenance" role="tab" aria-selected="true">Maintenance Tasks</button>
                 <button type="button" class="cost-data-center-tab" data-dc-tab="cutting" role="tab" aria-selected="false">Completed Cutting Jobs</button>
+                <button type="button" class="cost-data-center-tab" data-dc-tab="efficiency" role="tab" aria-selected="false">Efficiency Metrics</button>
               </div>
               <div class="cost-data-center-panel-content" data-dc-panel="maintenance">
               <div class="cost-data-center-search">
@@ -2174,6 +2176,32 @@ function viewCosts(model){
                 </table>
                 ` : `<p class="small muted">No completed cutting jobs yet.</p>`}
               </div>
+              <div class="cost-data-center-panel-content" data-dc-panel="efficiency" hidden>
+                ${efficiencyRows.length ? `
+                <div class="cost-jobs-summary">
+                  <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
+                  <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
+                  <div><span class="label">Total net gain</span><span>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</span></div>
+                  <div><span class="label">Avg net gain / row</span><span>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
+                </div>
+                <table class="cost-table" style="margin-top:10px">
+                  <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Run cost</th><th>Total cost</th><th>Net gain</th></tr></thead>
+                  <tbody>
+                    ${efficiencyRows.map(row => `
+                      <tr>
+                        <td>${esc(row.taskName || "Completed task")}</td>
+                        <td>${esc(row.dateLabel || "—")}</td>
+                        <td>${esc(row.hoursLabel || "0 hr")}</td>
+                        <td>${esc(row.partCostLabel || "$0.00")}</td>
+                        <td>${esc(row.laborCostLabel || "$0.00")}</td>
+                        <td>${esc(row.totalCostLabel || "$0.00")}</td>
+                        <td>${esc(row.netGainLabel || "$0.00")}</td>
+                      </tr>
+                    `).join("")}
+                  </tbody>
+                </table>
+                ` : `<p class="small muted">No efficiency rows found in the central data table.</p>`}
+              </div>
             </div>
           </div>
         </div>
@@ -2291,8 +2319,10 @@ function viewCosts(model){
         <div class="cost-jobs-summary">
           <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
           <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
-          <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Total net gain</span><span>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</span></div>
-          <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Avg net gain / row</span><span>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
+          <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Total net gain</span><span data-efficiency-summary-total>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</span></div>
+          <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Avg net gain / row</span><span data-efficiency-summary-average>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
+          <div><span class="label">Total run cost</span><span>${esc(efficiencySnapshot.totalCostLabel || "$0.00")}</span></div>
+          <div><span class="label">Avg run cost / row</span><span>${esc(efficiencySnapshot.averageCostLabel || "$0.00")}</span></div>
         </div>
         <p class="small muted" title="${esc(`${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || "Uses central data table values only."}`)}" data-efficiency-source-note>${esc(efficiencySnapshot.sourceLabel || "Source: central data table completed cutting jobs rows.")} ${esc(efficiencySnapshot.disclaimerLabel || "Uses central data table values only.")}</p>
         <div class="cost-weekly-table-wrap">
@@ -2308,7 +2338,7 @@ function viewCosts(model){
                   <td>${esc(row.laborCostLabel || "$0.00")}</td>
                   <td>${esc(row.totalCostLabel || "$0.00")}</td>
                   <td title="${esc(`${row.formulaTitle || efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" data-efficiency-profit-cell>${esc(row.netGainLabel || "$0.00")}</td>
-                  <td>${row.settingsLink ? `<a href="${esc(row.settingsLink)}">Open settings</a>` : "Invalid link"}</td>
+                  <td>${row.settingsLink ? `<button type="button" class="btn secondary" data-efficiency-open-job="${esc(row.id || "")}">Open job</button>` : "Invalid link"}</td>
                 </tr>
               `).join("") : `
                 <tr>

--- a/js/views.js
+++ b/js/views.js
@@ -2202,15 +2202,15 @@ function viewCosts(model){
             <button type="button" class="btn secondary" data-cost-weekly-export ${selectedWeeklyReport ? "" : "disabled"}>Export week (Excel)</button>
           </div>
           <div class="cost-weekly-summary">
-            <div><span class="label">Cuts total</span><span>${esc(selectedWeeklyReport?.totalCutCostLabel || "$0")}</span></div>
-            <div><span class="label">Maintenance total</span><span>${esc(selectedWeeklyReport?.totalMaintenanceCostLabel || "$0")}</span></div>
+            <div><span class="label">Cuts total profit</span><span>${esc(selectedWeeklyReport?.totalCutProfitLabel || selectedWeeklyReport?.totalCutCostLabel || "$0")}</span></div>
+            <div><span class="label">Maintenance total loss</span><span>${esc(selectedWeeklyReport?.totalMaintenanceLossLabel || selectedWeeklyReport?.totalMaintenanceCostLabel || "$0")}</span></div>
             <div><span class="label">Cutting time</span><span>${esc(selectedWeeklyReport?.totalCutHoursLabel || "0 hr")}</span></div>
           </div>
           <div class="cost-weekly-grid">
             <details class="cost-weekly-section" open>
               <summary>Cuts completed</summary>
               <div class="cost-weekly-section-totals">
-                <span><strong>Cuts related total:</strong> ${esc(selectedWeeklyReport?.totalCutCostLabel || "$0")}</span>
+                <span><strong>Cuts related total profit:</strong> ${esc(selectedWeeklyReport?.totalCutProfitLabel || selectedWeeklyReport?.totalCutCostLabel || "$0")}</span>
                 <span><strong>Total cut time:</strong> ${esc(selectedWeeklyReport?.totalCutHoursLabel || "0 hr")}</span>
               </div>
               <div class="cost-weekly-table-wrap">
@@ -2223,7 +2223,7 @@ function viewCosts(model){
             <details class="cost-weekly-section" open>
               <summary>Maintenance completed</summary>
               <div class="cost-weekly-section-totals">
-                <span><strong>Maintenance related total:</strong> ${esc(selectedWeeklyReport?.totalMaintenanceCostLabel || "$0")}</span>
+                <span><strong>Maintenance related total loss:</strong> ${esc(selectedWeeklyReport?.totalMaintenanceLossLabel || selectedWeeklyReport?.totalMaintenanceCostLabel || "$0")}</span>
               </div>
               <div class="cost-weekly-table-wrap">
                 <table class="cost-table">
@@ -2243,11 +2243,12 @@ function viewCosts(model){
           <div class="cost-jobs-summary">
             <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
             <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
-            <div><span class="label">Total cost</span><span>${esc(efficiencySnapshot.totalCostLabel || "$0.00")}</span></div>
-            <div><span class="label">Avg cost / row</span><span>${esc(efficiencySnapshot.averageCostLabel || "$0.00")}</span></div>
+            <div title="${esc(`Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)"}`)}"><span class="label">Total profit</span><span>${esc(efficiencySnapshot.totalProfitLabel || "$0.00")}</span></div>
+            <div title="${esc(`Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)"}`)}"><span class="label">Avg profit / row</span><span>${esc(efficiencySnapshot.averageProfitLabel || "$0.00")}</span></div>
           </div>
+          <p class="small muted" title="${esc(efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)")}" data-efficiency-source-note>${esc(efficiencySnapshot.sourceLabel || "Source: central data table completed cutting jobs rows.")}</p>
           <table class="cost-table">
-            <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Labor cost</th><th>Total cost</th><th>Task link</th></tr></thead>
+            <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Labor cost</th><th>Total cost</th><th title="${esc(efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)")}" aria-label="Profit calculation">Profit</th><th>Task link</th></tr></thead>
             <tbody>
               ${efficiencyRows.length ? efficiencyRows.map(row => `
                 <tr>
@@ -2257,11 +2258,12 @@ function viewCosts(model){
                   <td>${esc(row.partCostLabel || "$0.00")}</td>
                   <td>${esc(row.laborCostLabel || "$0.00")}</td>
                   <td>${esc(row.totalCostLabel || "$0.00")}</td>
+                  <td title="${esc(row.formulaTitle || efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)")}" data-efficiency-profit-cell>${esc(row.totalProfitLabel || "$0.00")}</td>
                   <td>${row.settingsLink ? `<a href="${esc(row.settingsLink)}">Open settings</a>` : "Invalid link"}</td>
                 </tr>
               `).join("") : `
                 <tr>
-                  <td colspan="7" class="cost-table-placeholder">${esc(efficiencySnapshot.emptyMessage || "No valid completed rows available from the data center table.")}</td>
+                  <td colspan="8" class="cost-table-placeholder">${esc(efficiencySnapshot.emptyMessage || "No valid completed rows available from the central data table.")}</td>
                 </tr>
               `}
             </tbody>

--- a/js/views.js
+++ b/js/views.js
@@ -1846,38 +1846,8 @@ function viewCosts(model){
           <div class="cost-summary-grid">
             ${summaryCardsHTML}
           </div>
-          <div class="cost-efficiency-calculator" data-efficiency-calc>
-            <div class="cost-efficiency-calculator-row">
-              <label>
-                <span class="label">Charge / hr (temporary)</span>
-                <input type="number" step="0.01" min="0" value="${esc(String(Number(calculatorDefaults.chargeRate) || 0))}" data-efficiency-calc-charge>
-              </label>
-              <label>
-                <span class="label">Cost / hr (temporary)</span>
-                <input type="number" step="0.01" min="0" value="${esc(String(Number(calculatorDefaults.costRate) || 0))}" data-efficiency-calc-cost>
-              </label>
-              <label>
-                <span class="label">Time range</span>
-                <select data-efficiency-calc-range-select>
-                  <option value="1m">Past 1 month</option>
-                  <option value="2m">Past 2 months</option>
-                  <option value="3m">Past 3 months</option>
-                  <option value="6m">Past 6 months</option>
-                  <option value="1y">Past 1 year</option>
-                  <option value="ytd">Year to date</option>
-                  <option value="all">All time</option>
-                </select>
-              </label>
-              <button type="button" class="btn secondary" data-efficiency-calc-reset>Reset</button>
-              <button type="button" class="btn secondary" data-open-efficiency-snapshot>Open snapshot</button>
-              <button type="button" class="btn secondary" data-go-jobs-history>Go to cutting jobs</button>
-            </div>
-            <p class="small muted" data-efficiency-calc-range-label>Range: past 1 month from central data table rows.</p>
-            <p class="small muted">Temporary calculator only. Refresh resets values to central data table defaults.</p>
-            <p class="small muted" data-efficiency-calc-result>
-              Net total gain (calculator): <strong data-efficiency-calc-total>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</strong>
-              · Avg / row: <strong data-efficiency-calc-average>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</strong>
-            </p>
+          <div class="cost-overview-actions">
+            <button type="button" class="btn secondary" data-open-efficiency-snapshot>Open cutting efficiency calculator & snapshot</button>
           </div>
           <div class="cost-window-insight">
             <div class="chart-info">
@@ -2286,6 +2256,38 @@ function viewCosts(model){
         <button type="button" class="btn ghost" data-close-efficiency-snapshot>Close</button>
       </div>
       <div class="cost-data-center-body">
+        <div class="cost-efficiency-calculator" data-efficiency-calc>
+          <div class="cost-efficiency-calculator-row">
+            <label>
+              <span class="label">Charge / hr (temporary)</span>
+              <input type="number" step="0.01" min="0" value="${esc(String(Number(calculatorDefaults.chargeRate) || 0))}" data-efficiency-calc-charge>
+            </label>
+            <label>
+              <span class="label">Cost / hr (temporary)</span>
+              <input type="number" step="0.01" min="0" value="${esc(String(Number(calculatorDefaults.costRate) || 0))}" data-efficiency-calc-cost>
+            </label>
+            <label>
+              <span class="label">Time range</span>
+              <select data-efficiency-calc-range-select>
+                <option value="1m">Past 1 month</option>
+                <option value="2m">Past 2 months</option>
+                <option value="3m">Past 3 months</option>
+                <option value="6m">Past 6 months</option>
+                <option value="1y">Past 1 year</option>
+                <option value="ytd">Year to date</option>
+                <option value="all">All time</option>
+              </select>
+            </label>
+            <button type="button" class="btn secondary" data-efficiency-calc-reset>Reset</button>
+            <button type="button" class="btn secondary" data-go-jobs-history>Go to cutting jobs</button>
+          </div>
+          <p class="small muted" data-efficiency-calc-range-label>Range: past 1 month from central data table rows.</p>
+          <p class="small muted">Temporary calculator only. Refresh resets values to central data table defaults.</p>
+          <p class="small muted" data-efficiency-calc-result>
+            Net total gain (calculator): <strong data-efficiency-calc-total>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</strong>
+            · Avg / row: <strong data-efficiency-calc-average>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</strong>
+          </p>
+        </div>
         <div class="cost-jobs-summary">
           <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
           <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
@@ -2315,6 +2317,17 @@ function viewCosts(model){
               `}
             </tbody>
           </table>
+        </div>
+        <div class="cost-window-insight">
+          <div class="chart-info">
+            <button type="button" class="chart-info-button" aria-describedby="costEfficiencyInsight" aria-label="Explain Cutting Job Efficiency Snapshot">
+              <span aria-hidden="true">?</span>
+              <span class="sr-only">Show how the Cutting Job Efficiency Snapshot reveals margin trends</span>
+            </button>
+            <div class="chart-info-bubble" id="costEfficiencyInsight" role="tooltip">
+              <p>${esc(efficiencyInsight)}</p>
+            </div>
+          </div>
         </div>
       </div>
     </div></div>`;

--- a/js/views.js
+++ b/js/views.js
@@ -1544,6 +1544,9 @@ function viewCosts(model){
     if (key){
       attrParts.push(`data-card-key="${esc(key)}"`);
     }
+    if (card && card.tooltip){
+      attrParts.push(`title="${esc(card.tooltip)}"`);
+    }
     if (isForecast){
       attrParts.push("role=\"button\"");
       attrParts.push("tabindex=\"0\"");
@@ -2243,8 +2246,8 @@ function viewCosts(model){
           <div class="cost-jobs-summary">
             <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
             <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
-            <div title="${esc(`Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)"}`)}"><span class="label">Total profit</span><span>${esc(efficiencySnapshot.totalProfitLabel || "$0.00")}</span></div>
-            <div title="${esc(`Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)"}`)}"><span class="label">Avg profit / row</span><span>${esc(efficiencySnapshot.averageProfitLabel || "$0.00")}</span></div>
+            <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)"}`.trim())}"><span class="label">Total profit</span><span>${esc(efficiencySnapshot.totalProfitLabel || "$0.00")}</span></div>
+            <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)"}`.trim())}"><span class="label">Avg profit / row</span><span>${esc(efficiencySnapshot.averageProfitLabel || "$0.00")}</span></div>
           </div>
           <p class="small muted" title="${esc(efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)")}" data-efficiency-source-note>${esc(efficiencySnapshot.sourceLabel || "Source: central data table completed cutting jobs rows.")}</p>
           <table class="cost-table">

--- a/js/views.js
+++ b/js/views.js
@@ -2246,12 +2246,12 @@ function viewCosts(model){
           <div class="cost-jobs-summary">
             <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
             <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
-            <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)"}`.trim())}"><span class="label">Total profit</span><span>${esc(efficiencySnapshot.totalProfitLabel || "$0.00")}</span></div>
-            <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)"}`.trim())}"><span class="label">Avg profit / row</span><span>${esc(efficiencySnapshot.averageProfitLabel || "$0.00")}</span></div>
+            <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Before expense gain = Hours × Charge Rate"}`.trim())}"><span class="label">Total gain (before expense)</span><span>${esc(efficiencySnapshot.totalBeforeExpenseLabel || "$0.00")}</span></div>
+            <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Before expense gain = Hours × Charge Rate"}`.trim())}"><span class="label">Avg gain / row (before expense)</span><span>${esc(efficiencySnapshot.averageBeforeExpenseLabel || "$0.00")}</span></div>
           </div>
-          <p class="small muted" title="${esc(efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)")}" data-efficiency-source-note>${esc(efficiencySnapshot.sourceLabel || "Source: central data table completed cutting jobs rows.")}</p>
+          <p class="small muted" title="${esc(`${efficiencySnapshot.formulaLabel || "Before expense gain = Hours × Charge Rate"} ${efficiencySnapshot.disclaimerLabel || "Before expense only: does not include reductions for maintenance parts, labor, or consumables."}`)}" data-efficiency-source-note>${esc(efficiencySnapshot.sourceLabel || "Source: central data table completed cutting jobs rows.")} ${esc(efficiencySnapshot.disclaimerLabel || "Before expense only: does not include reductions for maintenance parts, labor, or consumables.")}</p>
           <table class="cost-table">
-            <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Labor cost</th><th>Total cost</th><th title="${esc(efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)")}" aria-label="Profit calculation">Profit</th><th>Task link</th></tr></thead>
+            <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Labor cost</th><th>Total cost</th><th title="${esc(`${efficiencySnapshot.formulaLabel || "Before expense gain = Hours × Charge Rate"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" aria-label="Before expense gain calculation">Gain (before expense)</th><th>Task link</th></tr></thead>
             <tbody>
               ${efficiencyRows.length ? efficiencyRows.map(row => `
                 <tr>
@@ -2261,7 +2261,7 @@ function viewCosts(model){
                   <td>${esc(row.partCostLabel || "$0.00")}</td>
                   <td>${esc(row.laborCostLabel || "$0.00")}</td>
                   <td>${esc(row.totalCostLabel || "$0.00")}</td>
-                  <td title="${esc(row.formulaTitle || efficiencySnapshot.formulaLabel || "Profit = (Hours × Charge Rate) - (Hours × Cost Rate + Material Cost)")}" data-efficiency-profit-cell>${esc(row.totalProfitLabel || "$0.00")}</td>
+                  <td title="${esc(`${row.formulaTitle || efficiencySnapshot.formulaLabel || "Before expense gain = Hours × Charge Rate"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" data-efficiency-profit-cell>${esc(row.beforeExpenseLabel || "$0.00")}</td>
                   <td>${row.settingsLink ? `<a href="${esc(row.settingsLink)}">Open settings</a>` : "Invalid link"}</td>
                 </tr>
               `).join("") : `

--- a/js/views.js
+++ b/js/views.js
@@ -1175,28 +1175,6 @@ function ensureTaskCategories(){
 function viewCosts(model){
   const data = model || {};
   const esc = (str)=> String(str ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
-  const efficiencyWindows = (Array.isArray(TIME_EFFICIENCY_WINDOWS) && TIME_EFFICIENCY_WINDOWS.length)
-    ? TIME_EFFICIENCY_WINDOWS
-    : [
-        { key: "7d", label: "1W", days: 7, description: "Past 7 days" },
-        { key: "30d", label: "1M", days: 30, description: "Past 30 days" },
-        { key: "90d", label: "3M", days: 90, description: "Past 3 months" },
-        { key: "182d", label: "6M", days: 182, description: "Past 6 months" },
-        { key: "365d", label: "1Y", days: 365, description: "Past year" }
-      ];
-  const efficiencyButtons = efficiencyWindows.map((win, index) => {
-    const days = Number(win?.days) || 0;
-    const label = esc(win?.label ?? `${days || ""}`);
-    const description = esc(win?.description ?? (days ? `Past ${days} days` : "Selected window"));
-    const isActive = index === 0;
-    return `
-      <button type="button" class="time-efficiency-toggle${isActive ? " is-active" : ""}" data-efficiency-range="${esc(String(days))}" data-efficiency-range-label="${description}" aria-pressed="${isActive ? "true" : "false"}" title="${description}">
-        ${label}
-      </button>
-    `;
-  }).join("");
-  const defaultEfficiencyDescription = esc(efficiencyWindows[0]?.description || "Past 7 days");
-
   const cards = Array.isArray(data.summaryCards) ? data.summaryCards : [];
   const timeframeRows = Array.isArray(data.timeframeRows) ? data.timeframeRows : [];
   const historyRows = Array.isArray(data.historyRows) ? data.historyRows : [];
@@ -1229,6 +1207,8 @@ function viewCosts(model){
       .filter(Boolean)
   )).sort((a, b) => a.localeCompare(b));
   const cuttingJobsDataTable = Array.isArray(data.cuttingJobsDataTable) ? data.cuttingJobsDataTable : [];
+  const efficiencySnapshot = data.efficiencySnapshot || {};
+  const efficiencyRows = Array.isArray(efficiencySnapshot.rows) ? efficiencySnapshot.rows : [];
   const cuttingJobCategoryOptions = Array.from(new Set(
     cuttingJobsDataTable
       .map(row => ({ id: String(row?.categoryId || ""), label: String(row?.categoryLabel || "") }))
@@ -2260,74 +2240,30 @@ function viewCosts(model){
       <div class="dashboard-window" data-cost-window="efficiency">
         <div class="block" data-cost-jobs-history role="link" tabindex="0">
           <h3>Cutting Job Efficiency Snapshot</h3>
-          <div class="time-efficiency-inline" id="costTimeEfficiency">
-            <div class="time-efficiency-inline-header">
-              <span class="time-efficiency-inline-title">Cutting time efficiency</span>
-              <div class="time-efficiency-controls">
-                <div class="time-efficiency-toggles" role="tablist">
-                  ${efficiencyButtons}
-                </div>
-                <button type="button" class="time-efficiency-edit-btn" data-efficiency-edit>Edit range</button>
-              </div>
-            </div>
-            <div class="time-efficiency-edit" data-efficiency-edit-panel hidden>
-              <div class="time-efficiency-edit-row">
-                <label class="time-efficiency-edit-field">
-                  <span class="time-efficiency-edit-label">Start date</span>
-                  <input type="date" data-efficiency-start-input>
-                </label>
-                <div class="time-efficiency-edit-actions">
-                  <button type="button" class="time-efficiency-edit-apply" data-efficiency-apply>Apply</button>
-                  <button type="button" class="time-efficiency-edit-cancel" data-efficiency-cancel>Cancel</button>
-                </div>
-              </div>
-              <p class="small muted time-efficiency-edit-note" data-efficiency-edit-note></p>
-            </div>
-            <div class="time-efficiency-metrics" role="status" aria-live="polite">
-              <div class="time-efficiency-metric">
-                <span class="label">Actual hours</span>
-                <span class="value" data-efficiency-actual>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">Current target</span>
-                <span class="value" data-efficiency-target>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">Gap vs target</span>
-                <span class="value" data-efficiency-gap-target>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">End goal</span>
-                <span class="value" data-efficiency-goal>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-              <span class="label">Avg usage/day</span>
-                <span class="value" data-efficiency-average>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">Gap vs goal</span>
-                <span class="value" data-efficiency-gap-goal>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">Efficiency (to date)</span>
-                <span class="value" data-efficiency-percent>—</span>
-              </div>
-            </div>
-            <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
-            <p class="small muted">Baseline adapts to your average logged hours per day.</p>
-          </div>
           <div class="cost-jobs-summary">
-            <div><span class="label">Jobs tracked</span><span>—</span></div>
-            <div><span class="label">Total gain / loss</span><span>—</span></div>
-            <div><span class="label">Avg per job</span><span>—</span></div>
-            <div><span class="label">Rolling avg (chart)</span><span>—</span></div>
+            <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
+            <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
+            <div><span class="label">Total cost</span><span>${esc(efficiencySnapshot.totalCostLabel || "$0.00")}</span></div>
+            <div><span class="label">Avg cost / row</span><span>${esc(efficiencySnapshot.averageCostLabel || "$0.00")}</span></div>
           </div>
           <table class="cost-table">
-            <thead><tr><th>Job</th><th>Milestone</th><th>Status</th><th>Cost impact</th></tr></thead>
+            <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Labor cost</th><th>Total cost</th><th>Task link</th></tr></thead>
             <tbody>
-              <tr>
-                <td colspan="4" class="cost-table-placeholder">Job history visualization coming soon.</td>
-              </tr>
+              ${efficiencyRows.length ? efficiencyRows.map(row => `
+                <tr>
+                  <td>${esc(row.taskName || "Completed task")}</td>
+                  <td>${esc(row.dateLabel || "—")}</td>
+                  <td>${esc(row.hoursLabel || "0 hr")}</td>
+                  <td>${esc(row.partCostLabel || "$0.00")}</td>
+                  <td>${esc(row.laborCostLabel || "$0.00")}</td>
+                  <td>${esc(row.totalCostLabel || "$0.00")}</td>
+                  <td>${row.settingsLink ? `<a href="${esc(row.settingsLink)}">Open settings</a>` : "Invalid link"}</td>
+                </tr>
+              `).join("") : `
+                <tr>
+                  <td colspan="7" class="cost-table-placeholder">${esc(efficiencySnapshot.emptyMessage || "No valid completed rows available from the data center table.")}</td>
+                </tr>
+              `}
             </tbody>
           </table>
           <div class="cost-window-insight">

--- a/js/views.js
+++ b/js/views.js
@@ -1209,6 +1209,7 @@ function viewCosts(model){
   const cuttingJobsDataTable = Array.isArray(data.cuttingJobsDataTable) ? data.cuttingJobsDataTable : [];
   const efficiencySnapshot = data.efficiencySnapshot || {};
   const efficiencyRows = Array.isArray(efficiencySnapshot.rows) ? efficiencySnapshot.rows : [];
+  const calculatorDefaults = efficiencySnapshot.calculatorDefaults || {};
   const cuttingJobCategoryOptions = Array.from(new Set(
     cuttingJobsDataTable
       .map(row => ({ id: String(row?.categoryId || ""), label: String(row?.categoryLabel || "") }))
@@ -2248,6 +2249,24 @@ function viewCosts(model){
             <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
             <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Before expense gain = Hours × Charge Rate"}`.trim())}"><span class="label">Total gain (before expense)</span><span>${esc(efficiencySnapshot.totalBeforeExpenseLabel || "$0.00")}</span></div>
             <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Before expense gain = Hours × Charge Rate"}`.trim())}"><span class="label">Avg gain / row (before expense)</span><span>${esc(efficiencySnapshot.averageBeforeExpenseLabel || "$0.00")}</span></div>
+          </div>
+          <div class="cost-efficiency-calculator" data-efficiency-calc>
+            <div class="cost-efficiency-calculator-row">
+              <label>
+                <span class="label">Charge / hr (temporary)</span>
+                <input type="number" step="0.01" min="0" value="${esc(String(Number(calculatorDefaults.chargeRate) || 0))}" data-efficiency-calc-charge>
+              </label>
+              <label>
+                <span class="label">Cost / hr (temporary)</span>
+                <input type="number" step="0.01" min="0" value="${esc(String(Number(calculatorDefaults.costRate) || 0))}" data-efficiency-calc-cost>
+              </label>
+              <button type="button" class="btn secondary" data-efficiency-calc-reset>Reset</button>
+            </div>
+            <p class="small muted">Calculator only: temporary what-if net gain across all jobs. Refresh resets to central data table defaults.</p>
+            <p class="small muted" data-efficiency-calc-result>
+              Net total gain (calculator): <strong data-efficiency-calc-total>${esc(efficiencySnapshot.totalProfitLabel || "$0.00")}</strong>
+              · Avg / row: <strong data-efficiency-calc-average>${esc(efficiencySnapshot.averageProfitLabel || "$0.00")}</strong>
+            </p>
           </div>
           <p class="small muted" title="${esc(`${efficiencySnapshot.formulaLabel || "Before expense gain = Hours × Charge Rate"} ${efficiencySnapshot.disclaimerLabel || "Before expense only: does not include reductions for maintenance parts, labor, or consumables."}`)}" data-efficiency-source-note>${esc(efficiencySnapshot.sourceLabel || "Source: central data table completed cutting jobs rows.")} ${esc(efficiencySnapshot.disclaimerLabel || "Before expense only: does not include reductions for maintenance parts, labor, or consumables.")}</p>
           <table class="cost-table">


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc/time-window efficiency UI with a reliable snapshot derived directly from the central cutting jobs data table so the efficiency view uses a single canonical source of truth.
- Compute and expose numeric cost fields (hours, part/labor/total costs) and a settings deep-link per completed job so downstream views can show accurate totals and link back to job settings.

### Description
- In `js/renderers.js` updated `computeCostModel` to compute `materialCostValue`, `laborCostValue`, `totalCostValue`, `completedDateISO`, `hoursValue`, and `settingsLink` for each completed cutting-job row and to return a new `efficiencySnapshot` (rows, totals, averages, and empty message).
- In `js/views.js` removed the old time-window controls and placeholder content and changed the Cost view `Cutting Job Efficiency Snapshot` panel to consume `efficiencySnapshot`, render summary metrics and a detailed table (task/date/hours/part cost/labor cost/total cost/task link).
- Kept `vercel.json` as the required static-site configuration (`{ "cleanUrls": true }`).

### Testing
- Ran `git diff --check` to verify no whitespace/patch issues; the check succeeded.
- Ran `node --check js/renderers.js` and `node --check js/views.js` to validate syntax; both checks passed.
- Verified working tree status with `git status --short` to confirm only the intended files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d331f9488325b327039d9137edf0)