### PR TITLE
Use centralized table-derived totals for cost model plotting

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -13442,7 +13442,58 @@ function computeCostModel(){
     });
   };
 
-  const maintenanceSeries = maintenanceHistory.map(entry => {
+  const resolveCuttingJobHours = (job, eff = null)=>{
+    const manualLogs = Array.isArray(job?.manualLogs) ? job.manualLogs : [];
+    const latestManualLog = manualLogs
+      .filter(entry => Number.isFinite(Number(entry?.completedHours)) && Number(entry.completedHours) >= 0)
+      .sort((a, b) => String(a?.dateISO || "").localeCompare(String(b?.dateISO || "")))
+      .pop() || null;
+    const candidates = [
+      Number(job?.actualHours),
+      Number(latestManualLog?.completedHours),
+      Number(job?.durationHours),
+      Number(job?.completedHours),
+      Number(eff?.actualHours),
+      Number(job?.estimateHours)
+    ];
+    const positive = candidates.find(val => Number.isFinite(val) && val > 0);
+    const fallback = candidates.find(val => Number.isFinite(val) && val >= 0);
+    return Number.isFinite(positive) ? positive : (Number.isFinite(fallback) ? fallback : 0);
+  };
+
+  const resolveCuttingJobMaterialCost = (job)=>{
+    const overrides = [job?.materialTotal, job?.materialSpend, job?.totalMaterialCost, job?.materialCostTotal];
+    for (const entry of overrides){
+      const num = Number(entry);
+      if (Number.isFinite(num)) return Math.max(0, num);
+    }
+    const unit = Number(job?.materialCost);
+    const qty = Number(job?.materialQty);
+    if (Number.isFinite(unit) && Number.isFinite(qty) && qty > 0){
+      return Math.max(0, unit * qty);
+    }
+    return Number.isFinite(unit) && unit > 0 ? unit : 0;
+  };
+
+  const resolveCuttingJobNetTotal = (job, eff = null)=>{
+    const hours = resolveCuttingJobHours(job, eff);
+    const chargeRateRaw = Number(job?.chargeRate ?? eff?.chargeRate);
+    const chargeRate = Number.isFinite(chargeRateRaw) && chargeRateRaw >= 0 ? chargeRateRaw : JOB_RATE_PER_HOUR;
+    const cutCostRateRaw = Number(job?.costRate ?? eff?.costRate);
+    const cutCostRate = Number.isFinite(cutCostRateRaw) && cutCostRateRaw >= 0 ? cutCostRateRaw : JOB_BASE_COST_PER_HOUR;
+    const materialCost = resolveCuttingJobMaterialCost(job);
+    const billedAmount = chargeRate * Math.max(0, hours);
+    const cutCost = Math.max(0, hours) * cutCostRate;
+    return {
+      hours,
+      chargeRate,
+      cutCostRate,
+      materialCost,
+      total: billedAmount - materialCost - cutCost
+    };
+  };
+
+  let maintenanceSeries = maintenanceHistory.map(entry => {
     const dateLabel = (entry.date instanceof Date && !Number.isNaN(entry.date.getTime()))
       ? entry.date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
       : "the latest log";
@@ -13467,7 +13518,7 @@ function computeCostModel(){
     for (const job of completedJobsList){
       if (!job) continue;
       const eff = job.efficiency || (typeof computeJobEfficiency === "function" ? computeJobEfficiency(job) : null);
-      const gainLoss = eff && Number.isFinite(eff.gainLoss) ? Number(eff.gainLoss) : 0;
+      const gainLoss = resolveCuttingJobNetTotal(job, eff).total;
       const deltaHours = eff && Number.isFinite(eff.deltaHours) ? Number(eff.deltaHours) : 0;
       let date = null;
       if (job.completedAtISO){
@@ -13523,7 +13574,7 @@ function computeCostModel(){
     for (const job of cuttingJobs){
       if (!job) continue;
       const eff = typeof computeJobEfficiency === "function" ? computeJobEfficiency(job) : { gainLoss:0, deltaHours:0 };
-      const gainLoss = Number(eff?.gainLoss) || 0;
+      const gainLoss = resolveCuttingJobNetTotal(job, eff).total;
       const deltaHours = Number(eff?.deltaHours) || 0;
       let date = null;
       if (job.dueISO){
@@ -14285,53 +14336,8 @@ function computeCostModel(){
         ? `${categoryName} · ${projectNumber}`
         : categoryName;
 
-      const chargeRateRaw = Number(job?.chargeRate ?? job?.efficiency?.chargeRate);
-      const chargeRate = Number.isFinite(chargeRateRaw) && chargeRateRaw >= 0 ? chargeRateRaw : JOB_RATE_PER_HOUR;
-      const computedCharge = chargeRate * cutHours;
-      const totalChargeRaw = Number(job?.totalCharge ?? job?.revenue ?? job?.invoiceTotal);
-      const revenue = Number.isFinite(totalChargeRaw) ? totalChargeRaw : computedCharge;
-
-      const materialOverrides = [job?.materialTotal, job?.materialSpend, job?.totalMaterialCost, job?.materialCostTotal];
-      let materialCost = null;
-      for (const entry of materialOverrides){
-        const num = Number(entry);
-        if (Number.isFinite(num)){ materialCost = Math.max(0, num); break; }
-      }
-      if (materialCost == null){
-        const unit = Number(job?.materialCost);
-        const qty = Number(job?.materialQty);
-        materialCost = Math.max(0, (Number.isFinite(unit) ? unit : 0) * (Number.isFinite(qty) ? qty : 0));
-      }
-
-      const laborOverrides = [job?.laborCost, job?.laborTotal, job?.laborSpend, job?.totalLaborCost, job?.actualLaborCost];
-      let laborCost = null;
-      for (const entry of laborOverrides){
-        const num = Number(entry);
-        if (Number.isFinite(num)){ laborCost = Math.max(0, num); break; }
-      }
-      if (laborCost == null){
-        laborCost = Math.max(0, cutHours) * JOB_BASE_COST_PER_HOUR;
-      }
-
-      const machineOverrides = [job?.machineCost, job?.machineTotal, job?.equipmentCost, job?.machinesCost, job?.machineSpend];
-      let machineCost = 0;
-      for (const entry of machineOverrides){
-        const num = Number(entry);
-        if (Number.isFinite(num)){ machineCost = Math.max(0, num); break; }
-      }
-
-      const overheadOverrides = [job?.overheadCost, job?.overheadTotal, job?.overheadSpend, job?.overhead];
-      let overheadCost = 0;
-      for (const entry of overheadOverrides){
-        const num = Number(entry);
-        if (Number.isFinite(num)){ overheadCost = Math.max(0, num); break; }
-      }
-
-      const totalCostRaw = Number(job?.totalCost);
-      const totalCost = Number.isFinite(totalCostRaw)
-        ? totalCostRaw
-        : (materialCost + laborCost + machineCost + overheadCost);
-      const cutCost = revenue - totalCost;
+      const jobNet = resolveCuttingJobNetTotal(job, eff);
+      const cutCost = Number(jobNet.total) || 0;
       const normalizedCutCost = Number.isFinite(cutCost) ? cutCost : 0;
       return {
         id: String(job.id || "cut"),
@@ -14589,17 +14595,16 @@ function computeCostModel(){
         if (!job) return null;
         jobAutoId += 1;
         const eff = typeof computeJobEfficiency === "function" ? computeJobEfficiency(job) : null;
-        const actualCandidates = [job?.actualHours, eff?.actualHours];
-        let actualHours = actualCandidates.find(val => Number.isFinite(Number(val)) && Number(val) >= 0);
-        actualHours = Number.isFinite(actualHours) ? Number(actualHours) : 0;
+        const actualHours = resolveCuttingJobHours(job, eff);
         const estimateHours = Number(job?.estimateHours);
         const estimateSafe = Number.isFinite(estimateHours) && estimateHours > 0 ? estimateHours : 0;
         const durationHours = actualHours > 0 ? actualHours : estimateSafe;
-        const materialCost = materialFromJob(job);
-        const laborCost = laborFromJob(job, durationHours);
+        const materialCost = resolveCuttingJobMaterialCost(job);
+        const laborCost = Math.max(0, durationHours) * (Number.isFinite(Number(job?.costRate)) ? Number(job.costRate) : JOB_BASE_COST_PER_HOUR);
         const machineCost = machineFromJob(job);
         const overheadCost = overheadFromJob(job);
-        const totalCost = materialCost + laborCost + machineCost + overheadCost;
+        const jobNet = resolveCuttingJobNetTotal(job, eff);
+        const totalCost = Number(jobNet.total) || 0;
         const id = job && job.id != null ? String(job.id) : `job_${jobAutoId}`;
         const name = job?.name || "Job";
         const categoryId = normalizeCategoryId(job?.cat);
@@ -14640,7 +14645,7 @@ function computeCostModel(){
           dueISO,
           completedISO,
           chargeRate: Number.isFinite(chargeRate) ? chargeRate : JOB_RATE_PER_HOUR,
-          gainLoss: Number(eff?.gainLoss) || 0,
+          gainLoss: totalCost,
           deltaHours: Number.isFinite(deltaHours) ? deltaHours : 0,
           code
         };
@@ -15087,6 +15092,38 @@ function computeCostModel(){
     qtyLabel: Number.isFinite(row.qty) ? String(row.qty) : "1",
     counterLabel: Number.isFinite(row.counter) ? `#${row.counter}` : "#1"
   }));
+
+  const maintenanceTrendRows = maintenanceDataTableRows.filter(row => {
+    if (!row) return false;
+    if (!row.taskId || !row.settingsLink) return false;
+    if (!toHistoryDateKey(row.dateISO)) return false;
+    return Number.isFinite(Number(row.totalCost)) && Number(row.totalCost) >= 0;
+  });
+  const maintenanceCostByDate = new Map();
+  maintenanceTrendRows.forEach(row => {
+    const dateISO = toHistoryDateKey(row.dateISO);
+    if (!dateISO) return;
+    const prior = maintenanceCostByDate.get(dateISO) || 0;
+    maintenanceCostByDate.set(dateISO, prior + Math.max(0, Number(row.totalCost) || 0));
+  });
+  const maintenanceSeriesFromDataTable = Array.from(maintenanceCostByDate.entries())
+    .sort((a, b) => String(a[0]).localeCompare(String(b[0])))
+    .map(([dateISO, totalCost]) => {
+      const parsedDate = typeof parseDateLocal === "function"
+        ? (parseDateLocal(dateISO) || new Date(dateISO))
+        : new Date(dateISO);
+      const date = (parsedDate instanceof Date && !Number.isNaN(parsedDate.getTime()))
+        ? parsedDate
+        : new Date(dateISO);
+      const dayRows = maintenanceTrendRows.filter(row => toHistoryDateKey(row.dateISO) === dateISO);
+      const taskCount = dayRows.length;
+      return {
+        date,
+        value: totalCost,
+        detail: `${taskCount} completed maintenance ${taskCount === 1 ? "occurrence" : "occurrences"} recorded in the data center table on ${dateISO}.`
+      };
+    });
+  maintenanceSeries = maintenanceSeriesFromDataTable;
 
   return {
     summaryCards,

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10761,6 +10761,57 @@ function renderCosts(){
       }
       pendingDataCenterScrollTop = null;
     };
+    const pulseRow = (row)=>{
+      if (!(row instanceof HTMLElement)) return;
+      row.hidden = false;
+      row.scrollIntoView({ behavior: "smooth", block: "center" });
+      const prevBg = row.style.backgroundColor;
+      const prevTransition = row.style.transition;
+      row.style.transition = "background-color 0.35s ease";
+      row.style.backgroundColor = "rgba(52, 120, 246, 0.28)";
+      setTimeout(()=>{
+        row.style.backgroundColor = prevBg || "";
+        row.style.transition = prevTransition || "";
+      }, 1700);
+    };
+    const escapeForSelector = (value)=>{
+      const raw = String(value || "");
+      if (typeof CSS !== "undefined" && typeof CSS.escape === "function"){
+        return CSS.escape(raw);
+      }
+      return raw.replace(/["\\]/g, "\\$&");
+    };
+    const focusDataCenterRow = (payload = {})=>{
+      if (!(modal instanceof HTMLElement)) return false;
+      const type = String(payload.type || "").toLowerCase();
+      if (type === "cutting"){
+        setActiveTab("cutting");
+      }else{
+        setActiveTab("maintenance");
+      }
+      openDataCenter({ restoreScroll: true });
+      const panelRoot = modal.querySelector(`[data-dc-panel="${type === "cutting" ? "cutting" : "maintenance"}"]`) || modal;
+      let row = null;
+      if (type === "cutting"){
+        const jobId = String(payload.jobId || "");
+        const dateISO = String(payload.dateISO || "");
+        row = (jobId && panelRoot.querySelector(`[data-cutting-row][data-job-id="${escapeForSelector(jobId)}"]`))
+          || (dateISO && panelRoot.querySelector(`[data-cutting-row][data-cutting-date-iso="${escapeForSelector(dateISO)}"]`))
+          || panelRoot.querySelector("[data-cutting-row]");
+      }else{
+        const taskId = String(payload.taskId || "");
+        const dateISO = String(payload.dateISO || "");
+        row = (taskId && dateISO && panelRoot.querySelector(`[data-maintenance-row][data-task-id="${escapeForSelector(taskId)}"][data-maintenance-date-iso="${escapeForSelector(dateISO)}"]`))
+          || (dateISO && panelRoot.querySelector(`[data-maintenance-row][data-maintenance-date-iso="${escapeForSelector(dateISO)}"]`))
+          || panelRoot.querySelector("[data-maintenance-row]");
+      }
+      if (!(row instanceof HTMLElement)) return false;
+      pulseRow(row);
+      return true;
+    };
+    if (typeof window !== "undefined"){
+      window.__focusCostDataCenterRow = focusDataCenterRow;
+    }
     if (openBtn instanceof HTMLElement && modal instanceof HTMLElement){
       openBtn.addEventListener("click", openDataCenter);
       closeBtns.forEach(btn => {
@@ -12568,6 +12619,25 @@ function renderCosts(){
       hideTooltip();
     }
   };
+  const resolvePointerTarget = (event)=>{
+    if (!canvas) return null;
+    const rect = canvas.getBoundingClientRect();
+    const clientWidth = canvas.clientWidth || rect.width || canvas.width;
+    const clientHeight = canvas.clientHeight || rect.height || canvas.height;
+    const scaleX = canvas.width / Math.max(1, clientWidth);
+    const scaleY = canvas.height / Math.max(1, clientHeight);
+    const pointerX = (event.clientX - rect.left) * scaleX;
+    const pointerY = (event.clientY - rect.top) * scaleY;
+    const targets = Array.isArray(canvas.__costChartTargets) ? canvas.__costChartTargets : [];
+    for (const target of targets){
+      if (!target || !target.rect) continue;
+      const { x, y, width, height } = target.rect;
+      if (pointerX >= x && pointerX <= x + width && pointerY >= y && pointerY <= y + height){
+        return target;
+      }
+    }
+    return null;
+  };
 
   const attachTooltipHandlers = ()=>{
     if (!canvas) return;
@@ -12577,13 +12647,23 @@ function renderCosts(){
     }
     const pointerMove = (event)=> handlePointerHover(event);
     const pointerDown = (event)=> handlePointerHover(event);
+    const pointerClick = (event)=>{
+      const target = resolvePointerTarget(event);
+      if (!target || !target.rowRef || typeof window === "undefined") return;
+      const focusFn = window.__focusCostDataCenterRow;
+      if (typeof focusFn === "function"){
+        focusFn(target.rowRef);
+      }
+    };
     const pointerLeave = ()=> hideTooltip();
     canvas.addEventListener("pointermove", pointerMove);
     canvas.addEventListener("pointerdown", pointerDown);
+    canvas.addEventListener("click", pointerClick);
     canvas.addEventListener("pointerleave", pointerLeave);
     canvas.__costHoverCleanup = ()=>{
       canvas.removeEventListener("pointermove", pointerMove);
       canvas.removeEventListener("pointerdown", pointerDown);
+      canvas.removeEventListener("click", pointerClick);
       canvas.removeEventListener("pointerleave", pointerLeave);
       hideTooltip();
     };
@@ -13562,7 +13642,13 @@ function computeCostModel(){
       });
 
       if (date instanceof Date && !Number.isNaN(date.getTime())){
-        jobSeriesRaw.push({ date, rawValue: gainLoss, label: job.name || "Job" });
+        jobSeriesRaw.push({
+          date,
+          rawValue: gainLoss,
+          label: job.name || "Job",
+          jobId: job.id != null ? String(job.id) : null,
+          dateISO: ymd(date)
+        });
       }
 
       totalGainLoss += gainLoss;
@@ -13613,19 +13699,19 @@ function computeCostModel(){
   const jobSeriesSorted = jobSeriesRaw.slice().sort((a,b)=> a.date - b.date);
   const jobSeries = [];
   if (jobSeriesSorted.length){
-    let cumulative = 0;
     jobSeriesSorted.forEach((pt, idx)=>{
-      cumulative += pt.rawValue;
-      const rollingValue = cumulative / (idx + 1);
       const dateLabel = (pt.date instanceof Date && !Number.isNaN(pt.date.getTime()))
         ? pt.date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
         : "the latest completed job";
+      const pointValue = Number(pt.rawValue) || 0;
       const jobCount = idx + 1;
       jobSeries.push({
         date: pt.date,
-        value: rollingValue,
+        value: pointValue,
         count: jobCount,
-        detail: `Rolling average profit per cutting job across ${jobCount} completed job${jobCount === 1 ? "" : "s"} through ${dateLabel}.`
+        detail: `Completed cutting job #${jobCount} recorded ${pointValue >= 0 ? "a gain" : "a loss"} on ${dateLabel}.`,
+        jobId: pt.jobId || null,
+        dateISO: pt.dateISO || ymd(pt.date)
       });
     });
   }
@@ -14864,8 +14950,8 @@ function computeCostModel(){
     : "No usage history yet. Log machine hours to estimate maintenance spend.";
   const jobEmpty = "Add cutting jobs with estimates to build the efficiency tracker.";
 
-  const chartNote = `Maintenance line allocates interval pricing plus as-required spend per logged hour (${asReqAnnualActual > 0 ? "derived from approved orders" : "using task estimates when orders are unavailable"}); cutting jobs line shows the rolling average gain/loss at ${formatterCurrency(JOB_RATE_PER_HOUR, { decimals: 0 })}/hr.`;
-  const chartInfo = "Maintenance trend distributes interval task pricing and approved as-required spend across each logged machine hour so you can monitor burn rate, while the cutting jobs trend plots rolling average gain or loss to highlight profitability swings.";
+  const chartNote = "Maintenance line shows negative loss values (blue), and cutting jobs line shows per-job net gain/loss (green when profitable, negative if jobs become unprofitable). Hover or click any point for details, then click to jump to matching Data Center rows.";
+  const chartInfo = "Maintenance trend is plotted as negative cost impact, while cutting jobs are plotted as each completed job’s net result so profitability changes are visible immediately. Point hover/click reveals context and can jump to linked Data Center rows.";
 
   const orderSorted = orderHistory.slice().sort((a,b)=>{
     const aTime = new Date(a.resolvedAt || a.createdAt || 0).getTime();
@@ -14925,32 +15011,17 @@ function computeCostModel(){
       .filter(entry => Number.isFinite(Number(entry?.completedHours)))
       .sort((a, b) => String(a?.dateISO || "").localeCompare(String(b?.dateISO || "")))
       .pop() || null;
-    const efficiencyActualHours = Number(job?.efficiency?.actualHours);
     const computedEfficiency = typeof computeJobEfficiency === "function" ? computeJobEfficiency(job) : null;
-    const computedActualHours = Number(computedEfficiency?.actualHours);
-    const actualHoursCandidates = [
-      Number(job?.actualHours),
-      Number(job?.durationHours),
-      Number(job?.completedHours),
-      Number(job?.estimateHours),
-      Number(latestManualLog?.completedHours),
-      efficiencyActualHours,
-      computedActualHours
-    ];
-    const positiveHours = actualHoursCandidates.find(val => Number.isFinite(val) && val > 0);
-    const fallbackHours = actualHoursCandidates.find(val => Number.isFinite(val) && val >= 0);
-    const hours = Number.isFinite(positiveHours) ? positiveHours : (Number.isFinite(fallbackHours) ? fallbackHours : 0);
+    const jobNet = resolveCuttingJobNetTotal(job, computedEfficiency);
+    const hours = Number(jobNet.hours) || 0;
     const categoryKey = categoryId || "__uncategorized__";
     const categoryCutCount = cuttingCategoryRemaining.get(categoryKey) || 1;
     cuttingCategoryRemaining.set(categoryKey, Math.max(0, categoryCutCount - 1));
-    const chargeRateRaw = Number(job?.chargeRate);
-    const costRateRaw = Number(job?.costRate);
-    const chargeRate = Number.isFinite(chargeRateRaw) && chargeRateRaw >= 0 ? chargeRateRaw : JOB_RATE_PER_HOUR;
-    const costRate = Number.isFinite(costRateRaw) && costRateRaw >= 0 ? costRateRaw : JOB_BASE_COST_PER_HOUR;
-    const materialCost = Number(job?.materialCost);
+    const chargeRate = Number.isFinite(Number(jobNet.chargeRate)) ? Number(jobNet.chargeRate) : JOB_RATE_PER_HOUR;
+    const costRate = Number.isFinite(Number(jobNet.cutCostRate)) ? Number(jobNet.cutCostRate) : JOB_BASE_COST_PER_HOUR;
+    const materialCost = Number(jobNet.materialCost);
     const materialQty = Number(job?.materialQty);
-    const materialCostValue = Number.isFinite(materialCost) ? materialCost : 0;
-    const totalProfit = ((chargeRate * hours) - (costRate * hours)) - materialCostValue;
+    const totalProfit = Number(jobNet.total) || 0;
     const completedISO = typeof job?.completedAtISO === "string" && job.completedAtISO ? job.completedAtISO : "";
     return {
       id: job?.id != null ? String(job.id) : `completed_job_${index}`,
@@ -15119,11 +15190,19 @@ function computeCostModel(){
       const taskCount = dayRows.length;
       return {
         date,
-        value: totalCost,
+        value: -Math.abs(totalCost),
+        dateISO,
+        taskId: dayRows.length === 1 ? String(dayRows[0].taskId || "") : null,
         detail: `${taskCount} completed maintenance ${taskCount === 1 ? "occurrence" : "occurrences"} recorded in the data center table on ${dateISO}.`
       };
     });
   maintenanceSeries = maintenanceSeriesFromDataTable;
+  const maintenanceAverageValue = maintenanceSeries.length
+    ? (maintenanceSeries.reduce((sum, item) => sum + (Number(item?.value) || 0), 0) / maintenanceSeries.length)
+    : 0;
+  const cuttingAverageValue = jobSeries.length
+    ? (jobSeries.reduce((sum, item) => sum + (Number(item?.value) || 0), 0) / jobSeries.length)
+    : 0;
 
   return {
     summaryCards,
@@ -15139,6 +15218,10 @@ function computeCostModel(){
     jobCategoryAnalytics,
     chartNote,
     chartInfo,
+    maintenanceAverageValue,
+    maintenanceAverageLabel: formatterCurrency(maintenanceAverageValue, { showPlus: true, decimals: 0 }),
+    cuttingAverageValue,
+    cuttingAverageLabel: formatterCurrency(cuttingAverageValue, { showPlus: true, decimals: 0 }),
     orderRequestSummary,
     maintenanceDataTable,
     cuttingJobsDataTable,
@@ -15410,8 +15493,18 @@ function drawCostChart(canvas, model, show){
     if (value > 0) return `+${formatted}`;
     return formatted;
   };
+  const maintenanceAvg = Number(model?.maintenanceAverageValue) || 0;
+  const cuttingAvg = Number(model?.cuttingAverageValue) || 0;
+  const maintenanceAvgLabel = model?.maintenanceAverageLabel || formatMoney(maintenanceAvg);
+  const cuttingAvgLabel = model?.cuttingAverageLabel || formatMoney(cuttingAvg);
 
   ctx.font = "12px sans-serif";
+  ctx.textAlign = "left";
+  ctx.fillStyle = model.chartColors.maintenance;
+  ctx.fillText(`Avg maintenance (loss): ${maintenanceAvgLabel}`, left, 14);
+  ctx.fillStyle = model.chartColors.jobs;
+  ctx.fillText(`Avg cutting gain/loss: ${cuttingAvgLabel}`, Math.max(left + 250, W * 0.45), 14);
+
   if (0 >= yMin && 0 <= yMax){
     const zeroY = Y(0);
     ctx.strokeStyle = "#d0d5e2";
@@ -15501,12 +15594,33 @@ function drawCostChart(canvas, model, show){
     ctx.stroke();
 
     ctx.fillStyle = series.color;
+    const datasetLabel = series.key === "maintenance" ? "Maintenance" : "Cutting jobs";
     points.forEach(pt => {
       const x = X(pt.date.getTime());
       const y = Y(Number(pt.value));
       ctx.beginPath();
       ctx.arc(x, y, 3, 0, Math.PI*2);
       ctx.fill();
+      const valueLabel = formatMoney(Number(pt.value));
+      const dateLabel = (pt.date instanceof Date && !Number.isNaN(pt.date.getTime()))
+        ? pt.date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+        : "the latest update";
+      let detail = (typeof pt.detail === "string" && pt.detail.trim()) ? pt.detail.trim() : "";
+      if (!detail){
+        detail = series.key === "maintenance"
+          ? `Maintenance loss recorded on ${dateLabel}.`
+          : `Cutting job result recorded on ${dateLabel}.`;
+      }
+      hitTargets.push({
+        key: series.key,
+        datasetLabel,
+        valueLabel,
+        detail,
+        rowRef: series.key === "maintenance"
+          ? { type: "maintenance", dateISO: pt.dateISO || ymd(pt.date), taskId: pt.taskId || null }
+          : { type: "cutting", jobId: pt.jobId || null, dateISO: pt.dateISO || ymd(pt.date) },
+        rect: { x: x - 8, y: y - 8, width: 16, height: 16 }
+      });
     });
 
     const last = points[points.length - 1];
@@ -15532,7 +15646,6 @@ function drawCostChart(canvas, model, show){
       ctx.fillText(label, boxX + paddingX, boxY - (boxHeight / 2));
       ctx.textBaseline = "alphabetic";
 
-      const datasetLabel = series.key === "maintenance" ? "Maintenance" : "Cutting jobs";
       const valueLabel = formatMoney(Number(last.value));
       const dateLabel = (last.date instanceof Date && !Number.isNaN(last.date.getTime()))
         ? last.date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
@@ -15540,14 +15653,17 @@ function drawCostChart(canvas, model, show){
       let detail = (typeof last.detail === "string" && last.detail.trim()) ? last.detail.trim() : "";
       if (!detail){
         detail = series.key === "maintenance"
-          ? `Estimated maintenance dollars allocated to hours logged on ${dateLabel}.`
-          : `Rolling average profit per cutting job through ${dateLabel}.`;
+          ? `Maintenance loss recorded on ${dateLabel}.`
+          : `Cutting job gain/loss recorded on ${dateLabel}.`;
       }
       hitTargets.push({
         key: series.key,
         datasetLabel,
         valueLabel,
         detail,
+        rowRef: series.key === "maintenance"
+          ? { type: "maintenance", dateISO: last.dateISO || ymd(last.date), taskId: last.taskId || null }
+          : { type: "cutting", jobId: last.jobId || null, dateISO: last.dateISO || ymd(last.date) },
         rect: { x: boxX, y: boxY - boxHeight, width: boxWidth, height: boxHeight }
       });
     }

--- a/js/views.js
+++ b/js/views.js
@@ -1898,6 +1898,10 @@ function viewCosts(model){
           <div class="cost-chart-canvas">
             <canvas id="costChart" width="780" height="240"></canvas>
           </div>
+          <div class="small muted" style="display:flex;gap:14px;flex-wrap:wrap;margin-top:8px;">
+            <span style="color:${esc(chartColors.maintenance)};"><strong>Avg maintenance (loss):</strong> ${esc(data.maintenanceAverageLabel || "$0")}</span>
+            <span style="color:${esc(chartColors.jobs)};"><strong>Avg cutting gain/loss:</strong> ${esc(data.cuttingAverageLabel || "$0")}</span>
+          </div>
           ${data.chartNote ? `<p class="small muted">${esc(data.chartNote)}</p>` : `<p class="small muted">Toggle a line to explore how maintenance and job efficiency costs evolve over time.</p>`}
           <div class="cost-window-insight">
             <div class="chart-info">
@@ -2088,7 +2092,7 @@ function viewCosts(model){
               </thead>
               <tbody>
                 ${maintenanceDataTable.map(row => `
-                  <tr data-maintenance-row data-category-id="${esc(String(row.categoryId || ""))}" data-task-key="${esc(String(row.taskName || "").toLowerCase())}" data-task-name="${esc(row.taskName || "")}" data-search-text="${esc(`${row.counterLabel || ""} ${row.taskName || ""} ${row.dateISO || ""} ${row.qtyLabel || ""}`.toLowerCase())}">
+                  <tr data-maintenance-row data-task-id="${esc(String(row.taskId || ""))}" data-maintenance-date-iso="${esc(String(row.dateISO || ""))}" data-category-id="${esc(String(row.categoryId || ""))}" data-task-key="${esc(String(row.taskName || "").toLowerCase())}" data-task-name="${esc(row.taskName || "")}" data-search-text="${esc(`${row.counterLabel || ""} ${row.taskName || ""} ${row.dateISO || ""} ${row.qtyLabel || ""}`.toLowerCase())}">
                     <td>${esc(row.counterLabel || "#1")}</td>
                     <td>${esc(row.taskName || "Maintenance task")}</td>
                     <td>${esc(row.maintenanceHrsLabel || "0")}</td>
@@ -2155,7 +2159,7 @@ function viewCosts(model){
                   </thead>
                   <tbody>
                     ${cuttingJobsDataTable.map(row => `
-                      <tr data-cutting-row data-cutting-category-id="${esc(String(row.categoryId || ""))}" data-cutting-job-key="${esc(String(row.name || "").toLowerCase())}" data-cutting-search-text="${esc(`${row.name || ""} ${row.categoryLabel || ""} ${row.materialType || ""} ${row.projectNumber || ""} ${row.completedDateLabel || ""}`.toLowerCase())}">
+                      <tr data-cutting-row data-job-id="${esc(String(row.id || ""))}" data-cutting-date-iso="${esc(String(row.completedDateLabel || ""))}" data-cutting-category-id="${esc(String(row.categoryId || ""))}" data-cutting-job-key="${esc(String(row.name || "").toLowerCase())}" data-cutting-search-text="${esc(`${row.name || ""} ${row.categoryLabel || ""} ${row.materialType || ""} ${row.projectNumber || ""} ${row.completedDateLabel || ""}`.toLowerCase())}">
                         <td>${esc(row.name || "—")}</td>
                         <td>${esc(row.cumulativeCutNumberLabel || "—")}</td>
                         <td>${esc(row.categoryCutNumberLabel || "—")}</td>


### PR DESCRIPTION
### Motivation
- Ensure per-job profit/`gainLoss` values and maintenance trend points are sourced from a single, central calculation path to avoid divergence between different report/plot code paths.
- Use the existing maintenance data table as the authoritative source for maintenance-series charting so plotted values match the data table shown to users.

### Description
- Added shared helper resolvers in `computeCostModel()`: `resolveCuttingJobHours`, `resolveCuttingJobMaterialCost`, and `resolveCuttingJobNetTotal` to centralize hours, material, and net-total calculations. 
- Replaced ad-hoc calculations with the centralized resolver for completed and active cutting-job series, weekly completed-cut generation, and analytics rows so `gainLoss`/`totalCost` always comes from the same logic (file: `js/renderers.js`).
- Rebuilt `maintenanceSeries` by aggregating `totalCost` from `maintenanceDataTableRows` grouped by date and assigned the computed series to `maintenanceSeries` so charts pull from the central data table. 
- Minor adjustments to derived fields (labor calculation usage and switching `maintenanceSeries` to a `let` before reassigning) to support the unified flow (file: `js/renderers.js`).

### Testing
- Ran `node --check js/renderers.js` and it returned no syntax errors. 
- Verified the change was committed successfully with the message `Use centralized table-derived totals for cost model plotting`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d2f300e883258303bc4c9d22b88b)