### PR TITLE
Add Cutting Job Efficiency Snapshot modal, calculator, and time-efficiency goal controls

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -4542,25 +4542,9 @@ function toggleTimeEfficiencyEditPanel(widget, show){
   }
 }
 
-function applyTimeEfficiencyEdit(widget){
+  function applyTimeEfficiencyEdit(widget){
   if (!widget) return;
   const days = Number(widget.currentDays) || Number(widget.defaultDays) || 7;
-  if (!widget.editInput || widget.editInput.disabled){
-    toggleTimeEfficiencyEditPanel(widget, false);
-    return;
-  }
-  const raw = widget.editInput.value;
-  if (!raw){
-    widget.customStartByRange?.delete(days);
-    toggleTimeEfficiencyEditPanel(widget, false);
-    refreshTimeEfficiencyWidget(widget);
-    return;
-  }
-  const normalized = normalizeTimeEfficiencyStart(days, raw);
-  if (!normalized){
-    widget.editInput.classList.add("has-error");
-    return;
-  }
   if (widget.goalInput){
     const weeklyGoal = Number(widget.goalInput.value);
     if (Number.isFinite(weeklyGoal) && weeklyGoal > 0){
@@ -4577,6 +4561,24 @@ function applyTimeEfficiencyEdit(widget){
       else window.appConfig = nextConfig;
       if (typeof persist === "function") persist();
     }
+  }
+  if (!widget.editInput || widget.editInput.disabled){
+    toggleTimeEfficiencyEditPanel(widget, false);
+    refreshTimeEfficiencyWidgets();
+    return;
+  }
+  const raw = widget.editInput.value;
+  if (!raw){
+    widget.customStartByRange?.delete(days);
+    toggleTimeEfficiencyEditPanel(widget, false);
+    refreshTimeEfficiencyWidget(widget);
+    refreshTimeEfficiencyWidgets();
+    return;
+  }
+  const normalized = normalizeTimeEfficiencyStart(days, raw);
+  if (!normalized){
+    widget.editInput.classList.add("has-error");
+    return;
   }
   widget.editInput.classList.remove("has-error");
   widget.editInput.value = normalized;
@@ -11687,7 +11689,9 @@ function renderCosts(){
 
   function setupEfficiencyCalculator(currentModel){
     const openSnapshotBtns = Array.from(content.querySelectorAll("[data-open-efficiency-snapshot]"));
+    let suppressCloseUntil = 0;
     const closeSnapshot = ()=>{
+      if (Date.now() < suppressCloseUntil) return;
       const modal = document.getElementById("efficiencySnapshotModal");
       if (!(modal instanceof HTMLElement)) return;
       modal.hidden = true;
@@ -11699,6 +11703,7 @@ function renderCosts(){
       modal.hidden = false;
       if (modal.parentElement !== document.body) document.body.appendChild(modal);
       document.body.classList.add("cost-data-center-open");
+      suppressCloseUntil = Date.now() + 250;
     };
     openSnapshotBtns.forEach(btn => {
       if (!(btn instanceof HTMLElement)) return;
@@ -11799,8 +11804,8 @@ function renderCosts(){
     };
 
     const recalc = ()=>{
-      const chargeRate = normalizeToTwo(chargeInput, defaultCharge);
-      const costRate = normalizeToTwo(costInput, defaultCost);
+      const chargeRate = Math.max(0, asNumber(chargeInput.value, defaultCharge));
+      const costRate = Math.max(0, asNumber(costInput.value, defaultCost));
       const visibleRows = rows.filter(row => withinRange(row, activeRange));
       const totals = visibleRows.reduce((acc, row)=>{
         const hours = Math.max(0, asNumber(row?.hoursValue, 0));
@@ -11838,6 +11843,8 @@ function renderCosts(){
 
     chargeInput.addEventListener("input", recalc);
     costInput.addEventListener("input", recalc);
+    chargeInput.addEventListener("blur", ()=>{ normalizeToTwo(chargeInput, defaultCharge); recalc(); });
+    costInput.addEventListener("blur", ()=>{ normalizeToTwo(costInput, defaultCost); recalc(); });
     if (rangeSelect instanceof HTMLSelectElement){
       rangeSelect.addEventListener("change", ()=>{
         activeRange = String(rangeSelect.value || "1m");

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11696,6 +11696,7 @@ function renderCosts(){
       if (!(modal instanceof HTMLElement)) return;
       modal.hidden = true;
       document.body.classList.remove("cost-data-center-open");
+      if (typeof window !== "undefined") window.__efficiencySnapshotModalOpen = false;
     };
     const openSnapshot = ()=>{
       const modal = document.getElementById("efficiencySnapshotModal");
@@ -11704,6 +11705,7 @@ function renderCosts(){
       if (modal.parentElement !== document.body) document.body.appendChild(modal);
       document.body.classList.add("cost-data-center-open");
       suppressCloseUntil = Date.now() + 250;
+      if (typeof window !== "undefined") window.__efficiencySnapshotModalOpen = true;
     };
     openSnapshotBtns.forEach(btn => {
       if (!(btn instanceof HTMLElement)) return;
@@ -11894,6 +11896,9 @@ function renderCosts(){
     });
     updateRangeButtons();
     recalc();
+    if (typeof window !== "undefined" && window.__efficiencySnapshotModalOpen){
+      openSnapshot();
+    }
   }
 
   function setupJobCategoryWindow(currentModel){

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11714,7 +11714,8 @@ function renderCosts(){
         openSnapshot();
       });
     });
-    const closeSnapshotBtns = Array.from(document.querySelectorAll("[data-close-efficiency-snapshot]"));
+    const closeSnapshotBtns = Array.from(document.querySelectorAll("[data-close-efficiency-snapshot]"))
+      .filter(btn => !(btn instanceof HTMLElement) ? false : !btn.classList.contains("cost-data-center-backdrop"));
     closeSnapshotBtns.forEach(btn => {
       if (!(btn instanceof HTMLElement)) return;
       btn.addEventListener("click", closeSnapshot);

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -4512,6 +4512,15 @@ function updateTimeEfficiencyEditPanel(widget){
       widget.editInput.value = saved;
     }
   }
+  if (widget.goalInput){
+    const configuredDaily = (typeof getConfiguredDailyHours === "function")
+      ? Number(getConfiguredDailyHours())
+      : Number(CUTTING_BASELINE_DAILY_HOURS || 0);
+    const weeklyGoal = Number.isFinite(configuredDaily) && configuredDaily > 0
+      ? configuredDaily * 7
+      : 56;
+    widget.goalInput.value = weeklyGoal.toFixed(1);
+  }
 }
 
 function toggleTimeEfficiencyEditPanel(widget, show){
@@ -4552,6 +4561,23 @@ function applyTimeEfficiencyEdit(widget){
     widget.editInput.classList.add("has-error");
     return;
   }
+  if (widget.goalInput){
+    const weeklyGoal = Number(widget.goalInput.value);
+    if (Number.isFinite(weeklyGoal) && weeklyGoal > 0){
+      const dailyGoal = Math.max(0.1, Math.round((weeklyGoal / 7) * 100) / 100);
+      const currentConfig = (typeof normalizeAppConfig === "function")
+        ? normalizeAppConfig(window.appConfig)
+        : (window.appConfig || {});
+      const nextConfig = {
+        ...currentConfig,
+        predictionMode: "fixed",
+        dailyHours: dailyGoal
+      };
+      if (typeof setAppConfig === "function") setAppConfig(nextConfig);
+      else window.appConfig = nextConfig;
+      if (typeof persist === "function") persist();
+    }
+  }
   widget.editInput.classList.remove("has-error");
   widget.editInput.value = normalized;
   if (widget.customStartByRange){
@@ -4559,6 +4585,7 @@ function applyTimeEfficiencyEdit(widget){
   }
   toggleTimeEfficiencyEditPanel(widget, false);
   refreshTimeEfficiencyWidget(widget);
+  refreshTimeEfficiencyWidgets();
 }
 
 function setupTimeEfficiencyWidget(root){
@@ -4595,7 +4622,8 @@ function setupTimeEfficiencyWidget(root){
     editInput: root.querySelector("[data-efficiency-start-input]"),
     applyBtn: root.querySelector("[data-efficiency-apply]") || root.querySelector("[data-efficiency-save]") || null,
     cancelBtn: root.querySelector("[data-efficiency-cancel]") || null,
-    editNote: root.querySelector("[data-efficiency-edit-note]") || null
+    editNote: root.querySelector("[data-efficiency-edit-note]") || null,
+    goalInput: root.querySelector("[data-efficiency-goal-input]") || null
   };
   toggles.forEach(btn => {
     btn.addEventListener("click", ()=> selectTimeEfficiencyRange(widget, btn));
@@ -10571,6 +10599,7 @@ function renderCosts(){
   const content = document.getElementById("content");
   if (!content) return;
   const previousModal = document.getElementById("costDataCenterModal");
+  const previousEfficiencyModal = document.getElementById("efficiencySnapshotModal");
   const wasDataCenterOpen = Boolean(previousModal && !previousModal.hasAttribute("hidden"));
   let pendingDataCenterScrollTop = null;
   if (previousModal instanceof HTMLElement && wasDataCenterOpen){
@@ -10581,6 +10610,10 @@ function renderCosts(){
   }
   if (previousModal && previousModal.parentElement === document.body){
     previousModal.remove();
+    document.body.classList.remove("cost-data-center-open");
+  }
+  if (previousEfficiencyModal && previousEfficiencyModal.parentElement === document.body){
+    previousEfficiencyModal.remove();
     document.body.classList.remove("cost-data-center-open");
   }
   const existingReceiptModal = document.getElementById("costReceiptModal");
@@ -10630,6 +10663,7 @@ function renderCosts(){
   setupCostTimeframeModal(model);
   setupJobCategoryWindow(model);
   setupWeeklyReportWindow(model);
+  setupEfficiencyCalculator(model);
   setupMaintenanceDataCenterActions({ openImmediately: wasDataCenterOpen });
 
   function focusCalendarAtOccurrence(taskId, dateISO){
@@ -11651,6 +11685,209 @@ function renderCosts(){
     }
   }
 
+  function setupEfficiencyCalculator(currentModel){
+    const openSnapshotBtns = Array.from(content.querySelectorAll("[data-open-efficiency-snapshot]"));
+    const closeSnapshot = ()=>{
+      const modal = document.getElementById("efficiencySnapshotModal");
+      if (!(modal instanceof HTMLElement)) return;
+      modal.hidden = true;
+      document.body.classList.remove("cost-data-center-open");
+    };
+    const openSnapshot = ()=>{
+      const modal = document.getElementById("efficiencySnapshotModal");
+      if (!(modal instanceof HTMLElement)) return;
+      modal.hidden = false;
+      if (modal.parentElement !== document.body) document.body.appendChild(modal);
+      document.body.classList.add("cost-data-center-open");
+    };
+    openSnapshotBtns.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", (event)=>{
+        event.preventDefault();
+        event.stopPropagation();
+        if (typeof event.stopImmediatePropagation === "function") event.stopImmediatePropagation();
+        openSnapshot();
+      });
+    });
+    const closeSnapshotBtns = Array.from(document.querySelectorAll("[data-close-efficiency-snapshot]"));
+    closeSnapshotBtns.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", closeSnapshot);
+    });
+
+    const panel = content.querySelector("[data-efficiency-calc]");
+    if (!(panel instanceof HTMLElement)) return;
+    const snapshot = currentModel && currentModel.efficiencySnapshot ? currentModel.efficiencySnapshot : {};
+    const rows = Array.isArray(snapshot.rows) ? snapshot.rows : [];
+    const defaults = snapshot.calculatorDefaults || {};
+    const chargeInput = panel.querySelector("[data-efficiency-calc-charge]");
+    const costInput = panel.querySelector("[data-efficiency-calc-cost]");
+    const resetBtn = panel.querySelector("[data-efficiency-calc-reset]");
+    const rangeSelect = panel.querySelector("[data-efficiency-calc-range-select]");
+    const rangeLabelEl = panel.querySelector("[data-efficiency-calc-range-label]");
+    const totalEl = panel.querySelector("[data-efficiency-calc-total]");
+    const avgEl = panel.querySelector("[data-efficiency-calc-average]");
+    const goJobsBtn = panel.querySelector("[data-go-jobs-history]");
+    if (!(chargeInput instanceof HTMLInputElement) || !(costInput instanceof HTMLInputElement)) return;
+
+    const formatUsd = (value)=> new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: Math.abs(Number(value) || 0) < 1000 ? 2 : 0,
+      maximumFractionDigits: Math.abs(Number(value) || 0) < 1000 ? 2 : 0
+    }).format(Number.isFinite(Number(value)) ? Number(value) : 0);
+    const asNumber = (value, fallback = 0)=>{
+      const num = Number(value);
+      return Number.isFinite(num) ? num : fallback;
+    };
+    const normalizeToTwo = (inputEl, fallback)=>{
+      if (!(inputEl instanceof HTMLInputElement)) return fallback;
+      const raw = asNumber(inputEl.value, fallback);
+      const safe = Math.max(0, raw);
+      const normalized = Math.round(safe * 100) / 100;
+      inputEl.value = normalized.toFixed(2);
+      return normalized;
+    };
+    const defaultCharge = Math.max(0, asNumber(defaults.chargeRate, asNumber(chargeInput.value, 0)));
+    const defaultCost = Math.max(0, asNumber(defaults.costRate, asNumber(costInput.value, 0)));
+    chargeInput.value = String(defaultCharge);
+    costInput.value = String(defaultCost);
+    let activeRange = "1m";
+
+    const getRangeStart = (rangeKey)=>{
+      const now = new Date();
+      now.setHours(23, 59, 59, 999);
+      const start = new Date(now);
+      start.setHours(0, 0, 0, 0);
+      if (rangeKey === "all") return null;
+      if (rangeKey === "ytd"){
+        return new Date(start.getFullYear(), 0, 1);
+      }
+      const monthMap = { "1m": 1, "2m": 2, "3m": 3, "6m": 6, "1y": 12 };
+      const monthsBack = monthMap[rangeKey];
+      if (!monthsBack) return null;
+      return new Date(start.getFullYear(), start.getMonth() - monthsBack, start.getDate());
+    };
+    const parseRowDate = (row)=>{
+      const raw = String(row?.dateLabel || "");
+      if (!raw) return null;
+      const parsed = new Date(`${raw}T00:00:00`);
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
+    };
+    const withinRange = (row, rangeKey)=>{
+      if (rangeKey === "all") return true;
+      const rowDate = parseRowDate(row);
+      if (!(rowDate instanceof Date)) return false;
+      const start = getRangeStart(rangeKey);
+      if (!(start instanceof Date)) return true;
+      return rowDate >= start;
+    };
+    const updateRangeButtons = ()=>{
+      if (rangeSelect instanceof HTMLSelectElement) rangeSelect.value = activeRange;
+      const labels = {
+        "1m": "Range: past 1 month from central data table rows.",
+        "2m": "Range: past 2 months from central data table rows.",
+        "3m": "Range: past 3 months from central data table rows.",
+        "6m": "Range: past 6 months from central data table rows.",
+        "1y": "Range: past 1 year from central data table rows.",
+        ytd: "Range: year to date from central data table rows.",
+        all: "Range: all time from central data table rows."
+      };
+      if (rangeLabelEl instanceof HTMLElement){
+        rangeLabelEl.textContent = labels[activeRange] || labels["1m"];
+      }
+    };
+
+    const recalc = ()=>{
+      const chargeRate = normalizeToTwo(chargeInput, defaultCharge);
+      const costRate = normalizeToTwo(costInput, defaultCost);
+      const visibleRows = rows.filter(row => withinRange(row, activeRange));
+      const totals = visibleRows.reduce((acc, row)=>{
+        const hours = Math.max(0, asNumber(row?.hoursValue, 0));
+        const material = Math.max(0, asNumber(row?.materialValue ?? row?.materialCostValue, 0));
+        acc.rows += 1;
+        acc.net += (hours * (chargeRate - costRate)) - material;
+        return acc;
+      }, { rows: 0, net: 0 });
+      if (totalEl) totalEl.textContent = formatUsd(totals.net);
+      if (avgEl) avgEl.textContent = formatUsd(totals.rows ? (totals.net / totals.rows) : 0);
+      const summaryTotalEl = document.querySelector("[data-efficiency-summary-total]");
+      const summaryAvgEl = document.querySelector("[data-efficiency-summary-average]");
+      if (summaryTotalEl) summaryTotalEl.textContent = formatUsd(totals.net);
+      if (summaryAvgEl) summaryAvgEl.textContent = formatUsd(totals.rows ? (totals.net / totals.rows) : 0);
+      const tableRows = Array.from(document.querySelectorAll("[data-efficiency-row]"));
+      tableRows.forEach(tr => {
+        const rowId = String(tr.getAttribute("data-efficiency-id") || "");
+        const rowObj = rows.find(row => String(row?.id || "") === rowId) || null;
+        const show = rowObj ? withinRange(rowObj, activeRange) : false;
+        tr.hidden = !show;
+        if (!show) return;
+        const hours = Math.max(0, asNumber(tr.getAttribute("data-efficiency-hours"), asNumber(rowObj?.hoursValue, 0)));
+        const material = Math.max(0, asNumber(tr.getAttribute("data-efficiency-material"), asNumber(rowObj?.materialValue ?? rowObj?.materialCostValue, 0)));
+        const labor = hours * costRate;
+        const totalCost = labor + material;
+        const net = (hours * (chargeRate - costRate)) - material;
+        const laborCell = tr.querySelector("[data-efficiency-labor-cell]");
+        const totalCostCell = tr.querySelector("[data-efficiency-total-cost-cell]");
+        const profitCell = tr.querySelector("[data-efficiency-profit-cell]");
+        if (laborCell) laborCell.textContent = formatUsd(labor);
+        if (totalCostCell) totalCostCell.textContent = formatUsd(totalCost);
+        if (profitCell) profitCell.textContent = formatUsd(net);
+      });
+    };
+
+    chargeInput.addEventListener("input", recalc);
+    costInput.addEventListener("input", recalc);
+    if (rangeSelect instanceof HTMLSelectElement){
+      rangeSelect.addEventListener("change", ()=>{
+        activeRange = String(rangeSelect.value || "1m");
+        updateRangeButtons();
+        recalc();
+      });
+    }
+    if (resetBtn instanceof HTMLElement){
+      resetBtn.addEventListener("click", ()=>{
+        chargeInput.value = String(defaultCharge);
+        costInput.value = String(defaultCost);
+        activeRange = "1m";
+        recalc();
+        updateRangeButtons();
+      });
+    }
+    if (typeof window !== "undefined"){
+      if (typeof window.__efficiencySnapshotEscHandler === "function"){
+        document.removeEventListener("keydown", window.__efficiencySnapshotEscHandler);
+      }
+      window.__efficiencySnapshotEscHandler = (event)=>{
+        if (event.key !== "Escape") return;
+        const modal = document.getElementById("efficiencySnapshotModal");
+        if (modal instanceof HTMLElement && !modal.hidden) closeSnapshot();
+      };
+      document.addEventListener("keydown", window.__efficiencySnapshotEscHandler);
+    }
+    if (goJobsBtn instanceof HTMLElement){
+      goJobsBtn.addEventListener("click", ()=>{
+        closeSnapshot();
+        goToJobsHistory();
+      });
+    }
+    const openJobBtns = Array.from(document.querySelectorAll("[data-efficiency-open-job]"));
+    openJobBtns.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", ()=>{
+        const id = String(btn.getAttribute("data-efficiency-open-job") || "");
+        if (!id) return;
+        if (typeof window !== "undefined"){
+          window.pendingJobFocus = { type: "jobRow", id };
+        }
+        closeSnapshot();
+        goToJobsHistory();
+      });
+    });
+    updateRangeButtons();
+    recalc();
+  }
+
   function setupJobCategoryWindow(currentModel){
     const panel = content.querySelector("[data-cost-job-categories]");
     if (!panel) return;
@@ -12079,7 +12316,6 @@ function renderCosts(){
   };
 
   wireJobsHistoryShortcut(content.querySelector("[data-cost-jobs-history]"));
-  wireJobsHistoryShortcut(content.querySelector("[data-cost-cutting-card]"));
   wireJobsHistoryShortcut(content.querySelector(".cost-chart-toggle-link"));
 
   const normalizeHistoryDate = (value)=>{
@@ -14387,6 +14623,8 @@ function computeCostModel(){
       ...report,
       totalCutCostLabel: formatterCurrency(report.totalCutCost, { showPlus: true, decimals: Math.abs(report.totalCutCost) < 1000 ? 2 : 0 }),
       totalMaintenanceCostLabel: formatterCurrency(report.totalMaintenanceCost, { decimals: report.totalMaintenanceCost < 1000 ? 2 : 0 }),
+      totalCutProfitLabel: formatterCurrency(report.totalCutCost, { showPlus: true, decimals: Math.abs(report.totalCutCost) < 1000 ? 2 : 0 }),
+      totalMaintenanceLossLabel: formatterCurrency(-Math.abs(report.totalMaintenanceCost), { showPlus: true, decimals: report.totalMaintenanceCost < 1000 ? 2 : 0 }),
       totalCutHoursLabel: formatHours(report.totalCutHours),
       weekLabel: `${formatDateLabelShort(new Date(report.weekStartISO))} - ${formatDateLabelShort(new Date(report.weekEndISO))}`
     }));
@@ -14944,8 +15182,10 @@ function computeCostModel(){
     const costRate = Number.isFinite(costRateRaw) && costRateRaw >= 0 ? costRateRaw : JOB_BASE_COST_PER_HOUR;
     const materialCost = Number(job?.materialCost);
     const materialQty = Number(job?.materialQty);
-    const materialCostValue = Number.isFinite(materialCost) ? materialCost : 0;
-    const totalProfit = ((chargeRate * hours) - (costRate * hours)) - materialCostValue;
+    const materialCostValue = Number.isFinite(materialCost) && materialCost >= 0 ? materialCost : 0;
+    const laborCostValue = Math.max(0, hours) * costRate;
+    const totalCostValue = materialCostValue + laborCostValue;
+    const totalProfitValue = (Math.max(0, hours) * chargeRate) - totalCostValue;
     const completedISO = typeof job?.completedAtISO === "string" && job.completedAtISO ? job.completedAtISO : "";
     return {
       id: job?.id != null ? String(job.id) : `completed_job_${index}`,
@@ -14958,17 +15198,106 @@ function computeCostModel(){
       materialType: String(job?.material || "—"),
       materialCostLabel: Number.isFinite(materialCost) ? formatterCurrency(materialCost, { decimals: 2 }) : "—",
       materialQtyLabel: Number.isFinite(materialQty) ? String(materialQty) : "—",
-      totalProfitLabel: formatterCurrency(totalProfit, { decimals: 2 }),
       startDateLabel: job?.startISO || "—",
       dueDateLabel: job?.dueISO || "—",
       completedDateLabel: completedISO ? String(completedISO).slice(0, 10) : "—",
+      completedDateISO: completedISO ? String(completedISO).slice(0, 10) : "",
       projectNumber: String(job?.projectNumber || "—"),
       notes: String(job?.notes || "").trim() || "—",
       priorityLabel: Number.isFinite(Number(job?.priority)) ? String(Math.max(1, Math.floor(Number(job.priority)))) : "—",
       cumulativeCutNumberLabel: `#${Math.max(1, totalCompletedJobs - index)}`,
-      categoryCutNumberLabel: `#${categoryCutCount}`
+      categoryCutNumberLabel: `#${categoryCutCount}`,
+      hoursValue: hours,
+      chargeRateValue: chargeRate,
+      costRateValue: costRate,
+      materialCostValue,
+      laborCostValue,
+      totalCostValue,
+      totalProfitValue,
+      settingsLink: job?.id != null ? `#/settings?jobId=${encodeURIComponent(String(job.id))}` : ""
     };
   });
+
+  const efficiencyRows = cuttingJobsDataTable
+    .filter(row => {
+      const hasDate = typeof row?.completedDateISO === "string" && row.completedDateISO.trim().length > 0;
+      const hasTaskName = typeof row?.name === "string" && row.name.trim().length > 0;
+      const hasSettingsLink = typeof row?.settingsLink === "string" && /^#\/settings\?jobId=/.test(row.settingsLink);
+      return hasDate && hasTaskName && hasSettingsLink;
+    })
+    .sort((a, b) => String(b?.completedDateISO || "").localeCompare(String(a?.completedDateISO || "")))
+    .map((row, index) => ({
+      id: row?.id != null ? String(row.id) : `efficiency_row_${index}`,
+      taskName: row?.name || "Completed task",
+      dateLabel: row?.completedDateISO || "—",
+      hoursLabel: formatHoursValue(Number(row?.hoursValue) || 0),
+      partCostLabel: formatterCurrency(Number(row?.materialCostValue) || 0, { decimals: 2 }),
+      laborCostLabel: formatterCurrency(Number(row?.laborCostValue) || 0, { decimals: 2 }),
+      totalCostLabel: formatterCurrency(Number(row?.totalCostValue) || 0, { decimals: 2 }),
+      totalProfitLabel: formatterCurrency(Number(row?.totalProfitValue) || 0, { decimals: 2, showPlus: true }),
+      hoursValue: Number(row?.hoursValue) || 0,
+      chargeRateValue: Number(row?.chargeRateValue) || 0,
+      costRateValue: Number(row?.costRateValue) || 0,
+      revenueValue: Math.max(0, (Number(row?.hoursValue) || 0) * (Number(row?.chargeRateValue) || 0)),
+      netGainLabel: formatterCurrency(Number(row?.totalProfitValue) || 0, { decimals: 2, showPlus: true }),
+      materialValue: Math.max(0, Number(row?.materialCostValue) || 0),
+      laborValue: Math.max(0, Number(row?.laborCostValue) || 0),
+      totalCostValue: Number(row?.totalCostValue) || 0,
+      totalProfitValue: Number(row?.totalProfitValue) || 0,
+      formulaTitle: "Source: Central data table completed cutting jobs row. Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost.",
+      settingsLink: row?.settingsLink || ""
+    }));
+  const efficiencyTotals = efficiencyRows.reduce((acc, row) => {
+    if (Number.isFinite(row?.hoursValue)) acc.hours += Math.max(0, Number(row.hoursValue));
+    if (Number.isFinite(row?.revenueValue)) acc.revenue += Math.max(0, Number(row.revenueValue));
+    if (Number.isFinite(row?.materialValue)) acc.material += Math.max(0, Number(row.materialValue));
+    if (Number.isFinite(row?.laborValue)) acc.labor += Math.max(0, Number(row.laborValue));
+    if (Number.isFinite(row?.totalCostValue)) acc.cost += Math.max(0, Number(row.totalCostValue));
+    if (Number.isFinite(row?.totalProfitValue)) acc.profit += Number(row.totalProfitValue);
+    return acc;
+  }, { hours: 0, revenue: 0, material: 0, labor: 0, cost: 0, profit: 0 });
+  const efficiencyCount = efficiencyRows.length;
+  const efficiencySnapshot = {
+    countLabel: String(efficiencyCount),
+    totalHoursLabel: formatHoursValue(efficiencyTotals.hours),
+    totalCostLabel: formatterCurrency(efficiencyTotals.cost, { decimals: efficiencyTotals.cost < 1000 ? 2 : 0 }),
+    averageCostLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.cost / efficiencyCount) : 0, { decimals: 2 }),
+    totalProfitLabel: formatterCurrency(efficiencyTotals.profit, { decimals: Math.abs(efficiencyTotals.profit) < 1000 ? 2 : 0, showPlus: true }),
+    averageProfitLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.profit / efficiencyCount) : 0, { decimals: 2, showPlus: true }),
+    totalNetGainLabel: formatterCurrency(efficiencyTotals.profit, { decimals: Math.abs(efficiencyTotals.profit) < 1000 ? 2 : 0, showPlus: true }),
+    averageNetGainLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.profit / efficiencyCount) : 0, { decimals: 2, showPlus: true }),
+    sourceLabel: "Source: central data table completed cutting jobs rows.",
+    formulaLabel: "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost",
+    disclaimerLabel: "Uses central data table values only.",
+    rows: efficiencyRows,
+    emptyMessage: "No valid completed cutting tasks with settings links were found in the central data table."
+  };
+  const efficiencyMathDetails = `Net gain = (Hours × (Charge Rate - Cost Rate)) - Material. Revenue ${formatterCurrency(efficiencyTotals.revenue, { decimals: 0 })}, Run cost (cost/hr × hours) ${formatterCurrency(efficiencyTotals.labor, { decimals: 0 })}, Material ${formatterCurrency(efficiencyTotals.material, { decimals: 0 })}, Net ${formatterCurrency(efficiencyTotals.profit, { decimals: 0, showPlus: true })}.`;
+  efficiencySnapshot.mathDetailsLabel = efficiencyMathDetails;
+  const totalCalcHours = efficiencyTotals.hours > 0 ? efficiencyTotals.hours : 0;
+  const defaultChargeRateForCalc = totalCalcHours > 0 ? (efficiencyTotals.revenue / totalCalcHours) : JOB_RATE_PER_HOUR;
+  const defaultCostRateForCalc = totalCalcHours > 0 ? (efficiencyTotals.labor / totalCalcHours) : JOB_BASE_COST_PER_HOUR;
+  efficiencySnapshot.calculatorDefaults = {
+    chargeRate: Number.isFinite(defaultChargeRateForCalc) ? defaultChargeRateForCalc : JOB_RATE_PER_HOUR,
+    costRate: Number.isFinite(defaultCostRateForCalc) ? defaultCostRateForCalc : JOB_BASE_COST_PER_HOUR
+  };
+  const efficiencyDisplayProfit = efficiencyTotals.profit;
+  const efficiencyDisplayAverage = efficiencyCount ? (efficiencyDisplayProfit / efficiencyCount) : 0;
+  const cuttingCard = Array.isArray(summaryCards) ? summaryCards.find(card => card && card.key === "cuttingJobs") : null;
+  if (cuttingCard){
+    cuttingCard.value = formatterCurrency(efficiencyDisplayProfit, { decimals: 0, showPlus: true });
+    cuttingCard.hint = efficiencyCount
+      ? `Average net gain ${formatterCurrency(efficiencyDisplayAverage, { decimals: 0, showPlus: true })} across ${efficiencyCount} completed job${efficiencyCount===1?"":"s"} (source: central data table).`
+      : "No cutting jobs logged yet.";
+    cuttingCard.tooltip = `Source: central data table completed rows. ${efficiencyMathDetails}`;
+  }
+  const combinedCard = Array.isArray(summaryCards) ? summaryCards.find(card => card && card.key === "combinedImpact") : null;
+  if (combinedCard){
+    combinedCard.value = formatterCurrency(efficiencyDisplayProfit - predictedAnnual, { decimals: 0, showPlus: true });
+  }
+  jobSummary.countLabel = efficiencyCount ? `${efficiencyCount} completed` : "0";
+  jobSummary.totalLabel = formatterCurrency(efficiencyDisplayProfit, { decimals: 0, showPlus: true });
+  jobSummary.averageLabel = formatterCurrency(efficiencyDisplayAverage, { decimals: 0, showPlus: true });
 
   const taskById = new Map();
   [Array.isArray(intervalTasksAll) ? intervalTasksAll : [], Array.isArray(asReqTasksAll) ? asReqTasksAll : []].forEach(list => {
@@ -15105,6 +15434,7 @@ function computeCostModel(){
     orderRequestSummary,
     maintenanceDataTable,
     cuttingJobsDataTable,
+    efficiencySnapshot,
     chartColors: COST_CHART_COLORS,
     maintenanceSeries,
     jobSeries,

--- a/js/views.js
+++ b/js/views.js
@@ -1569,8 +1569,6 @@ function viewCosts(model){
     }
     if (isCutting){
       attrParts.push("data-cost-cutting-card=\"\"");
-      attrParts.push("role=\"link\"");
-      attrParts.push("tabindex=\"0\"");
     }
     const attr = attrParts.join(" ");
     const cuttingOpenBtn = isCutting

--- a/js/views.js
+++ b/js/views.js
@@ -146,12 +146,16 @@ function viewDashboard(){
             </div>
           </div>
           <div class="time-efficiency-edit" data-efficiency-edit-panel hidden>
-            <div class="time-efficiency-edit-row">
-              <label class="time-efficiency-edit-field">
-                <span class="time-efficiency-edit-label">Start date</span>
-                <input type="date" data-efficiency-start-input>
-              </label>
-              <div class="time-efficiency-edit-actions">
+              <div class="time-efficiency-edit-row">
+                <label class="time-efficiency-edit-field">
+                  <span class="time-efficiency-edit-label">Start date</span>
+                  <input type="date" data-efficiency-start-input>
+                </label>
+                <label class="time-efficiency-edit-field">
+                  <span class="time-efficiency-edit-label">Goal / week (hr)</span>
+                  <input type="number" min="1" step="0.5" data-efficiency-goal-input>
+                </label>
+                <div class="time-efficiency-edit-actions">
                 <button type="button" class="time-efficiency-edit-apply" data-efficiency-apply>Apply</button>
                 <button type="button" class="time-efficiency-edit-cancel" data-efficiency-cancel>Cancel</button>
               </div>
@@ -1175,28 +1179,17 @@ function ensureTaskCategories(){
 function viewCosts(model){
   const data = model || {};
   const esc = (str)=> String(str ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
-  const efficiencyWindows = (Array.isArray(TIME_EFFICIENCY_WINDOWS) && TIME_EFFICIENCY_WINDOWS.length)
-    ? TIME_EFFICIENCY_WINDOWS
-    : [
-        { key: "7d", label: "1W", days: 7, description: "Past 7 days" },
-        { key: "30d", label: "1M", days: 30, description: "Past 30 days" },
-        { key: "90d", label: "3M", days: 90, description: "Past 3 months" },
-        { key: "182d", label: "6M", days: 182, description: "Past 6 months" },
-        { key: "365d", label: "1Y", days: 365, description: "Past year" }
-      ];
-  const efficiencyButtons = efficiencyWindows.map((win, index) => {
-    const days = Number(win?.days) || 0;
-    const label = esc(win?.label ?? `${days || ""}`);
-    const description = esc(win?.description ?? (days ? `Past ${days} days` : "Selected window"));
-    const isActive = index === 0;
-    return `
-      <button type="button" class="time-efficiency-toggle${isActive ? " is-active" : ""}" data-efficiency-range="${esc(String(days))}" data-efficiency-range-label="${description}" aria-pressed="${isActive ? "true" : "false"}" title="${description}">
-        ${label}
-      </button>
-    `;
-  }).join("");
+  const efficiencyWindows = [
+    { key: "7d", label: "1W", days: 7, description: "Past 7 days" },
+    { key: "30d", label: "1M", days: 30, description: "Past 30 days" },
+    { key: "90d", label: "3M", days: 90, description: "Past 3 months" },
+    { key: "182d", label: "6M", days: 182, description: "Past 6 months" },
+    { key: "365d", label: "1Y", days: 365, description: "Past year" }
+  ];
+  const efficiencyButtons = efficiencyWindows.map((win, index) => `
+    <button type="button" class="time-efficiency-toggle${index === 0 ? " is-active" : ""}" data-efficiency-range="${esc(String(win.days))}" data-efficiency-range-label="${esc(win.description)}" aria-pressed="${index === 0 ? "true" : "false"}" title="${esc(win.description)}">${esc(win.label)}</button>
+  `).join("");
   const defaultEfficiencyDescription = esc(efficiencyWindows[0]?.description || "Past 7 days");
-
   const cards = Array.isArray(data.summaryCards) ? data.summaryCards : [];
   const timeframeRows = Array.isArray(data.timeframeRows) ? data.timeframeRows : [];
   const historyRows = Array.isArray(data.historyRows) ? data.historyRows : [];
@@ -1229,6 +1222,9 @@ function viewCosts(model){
       .filter(Boolean)
   )).sort((a, b) => a.localeCompare(b));
   const cuttingJobsDataTable = Array.isArray(data.cuttingJobsDataTable) ? data.cuttingJobsDataTable : [];
+  const efficiencySnapshot = data.efficiencySnapshot || {};
+  const efficiencyRows = Array.isArray(efficiencySnapshot.rows) ? efficiencySnapshot.rows : [];
+  const calculatorDefaults = efficiencySnapshot.calculatorDefaults || {};
   const cuttingJobCategoryOptions = Array.from(new Set(
     cuttingJobsDataTable
       .map(row => ({ id: String(row?.categoryId || ""), label: String(row?.categoryLabel || "") }))
@@ -1564,6 +1560,9 @@ function viewCosts(model){
     if (key){
       attrParts.push(`data-card-key="${esc(key)}"`);
     }
+    if (card && card.tooltip){
+      attrParts.push(`title="${esc(card.tooltip)}"`);
+    }
     if (isForecast){
       attrParts.push("role=\"button\"");
       attrParts.push("tabindex=\"0\"");
@@ -1574,6 +1573,9 @@ function viewCosts(model){
       attrParts.push("tabindex=\"0\"");
     }
     const attr = attrParts.join(" ");
+    const cuttingOpenBtn = isCutting
+      ? `<button type="button" class="btn secondary" data-open-efficiency-snapshot>Open calculator</button>`
+      : "";
     return `
               <div ${attr}>
                 <div class="cost-card-icon">${esc(card.icon || "")}</div>
@@ -1581,6 +1583,7 @@ function viewCosts(model){
                   <div class="cost-card-title">${esc(card.title || "")}</div>
                   <div class="cost-card-value">${esc(card.value || "")}</div>
                   <div class="cost-card-hint">${esc(card.hint || "")}</div>
+                  ${cuttingOpenBtn}
                 </div>
               </div>
             `;
@@ -2051,6 +2054,7 @@ function viewCosts(model){
               <div class="cost-data-center-tabs" role="tablist" aria-label="Data center tables">
                 <button type="button" class="cost-data-center-tab is-active" data-dc-tab="maintenance" role="tab" aria-selected="true">Maintenance Tasks</button>
                 <button type="button" class="cost-data-center-tab" data-dc-tab="cutting" role="tab" aria-selected="false">Completed Cutting Jobs</button>
+                <button type="button" class="cost-data-center-tab" data-dc-tab="efficiency" role="tab" aria-selected="false">Efficiency Metrics</button>
               </div>
               <div class="cost-data-center-panel-content" data-dc-panel="maintenance">
               <div class="cost-data-center-search">
@@ -2187,6 +2191,32 @@ function viewCosts(model){
                 </table>
                 ` : `<p class="small muted">No completed cutting jobs yet.</p>`}
               </div>
+              <div class="cost-data-center-panel-content" data-dc-panel="efficiency" hidden>
+                ${efficiencyRows.length ? `
+                <div class="cost-jobs-summary">
+                  <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
+                  <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
+                  <div><span class="label">Total net gain</span><span>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</span></div>
+                  <div><span class="label">Avg net gain / row</span><span>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
+                </div>
+                <table class="cost-table" style="margin-top:10px">
+                  <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Run cost</th><th>Total cost</th><th>Net gain</th></tr></thead>
+                  <tbody>
+                    ${efficiencyRows.map(row => `
+                      <tr>
+                        <td>${esc(row.taskName || "Completed task")}</td>
+                        <td>${esc(row.dateLabel || "—")}</td>
+                        <td>${esc(row.hoursLabel || "0 hr")}</td>
+                        <td>${esc(row.partCostLabel || "$0.00")}</td>
+                        <td>${esc(row.laborCostLabel || "$0.00")}</td>
+                        <td>${esc(row.totalCostLabel || "$0.00")}</td>
+                        <td>${esc(row.netGainLabel || "$0.00")}</td>
+                      </tr>
+                    `).join("")}
+                  </tbody>
+                </table>
+                ` : `<p class="small muted">No efficiency rows found in the central data table.</p>`}
+              </div>
             </div>
           </div>
         </div>
@@ -2222,15 +2252,15 @@ function viewCosts(model){
             <button type="button" class="btn secondary" data-cost-weekly-export ${selectedWeeklyReport ? "" : "disabled"}>Export week (Excel)</button>
           </div>
           <div class="cost-weekly-summary">
-            <div><span class="label">Cuts total</span><span>${esc(selectedWeeklyReport?.totalCutCostLabel || "$0")}</span></div>
-            <div><span class="label">Maintenance total</span><span>${esc(selectedWeeklyReport?.totalMaintenanceCostLabel || "$0")}</span></div>
+            <div><span class="label">Cuts total profit</span><span>${esc(selectedWeeklyReport?.totalCutProfitLabel || selectedWeeklyReport?.totalCutCostLabel || "$0")}</span></div>
+            <div><span class="label">Maintenance total loss</span><span>${esc(selectedWeeklyReport?.totalMaintenanceLossLabel || selectedWeeklyReport?.totalMaintenanceCostLabel || "$0")}</span></div>
             <div><span class="label">Cutting time</span><span>${esc(selectedWeeklyReport?.totalCutHoursLabel || "0 hr")}</span></div>
           </div>
           <div class="cost-weekly-grid">
             <details class="cost-weekly-section" open>
               <summary>Cuts completed</summary>
               <div class="cost-weekly-section-totals">
-                <span><strong>Cuts related total:</strong> ${esc(selectedWeeklyReport?.totalCutCostLabel || "$0")}</span>
+                <span><strong>Cuts related total profit:</strong> ${esc(selectedWeeklyReport?.totalCutProfitLabel || selectedWeeklyReport?.totalCutCostLabel || "$0")}</span>
                 <span><strong>Total cut time:</strong> ${esc(selectedWeeklyReport?.totalCutHoursLabel || "0 hr")}</span>
               </div>
               <div class="cost-weekly-table-wrap">
@@ -2243,7 +2273,7 @@ function viewCosts(model){
             <details class="cost-weekly-section" open>
               <summary>Maintenance completed</summary>
               <div class="cost-weekly-section-totals">
-                <span><strong>Maintenance related total:</strong> ${esc(selectedWeeklyReport?.totalMaintenanceCostLabel || "$0")}</span>
+                <span><strong>Maintenance related total loss:</strong> ${esc(selectedWeeklyReport?.totalMaintenanceLossLabel || selectedWeeklyReport?.totalMaintenanceCostLabel || "$0")}</span>
               </div>
               <div class="cost-weekly-table-wrap">
                 <table class="cost-table">
@@ -2257,94 +2287,134 @@ function viewCosts(model){
         </div>
       </div>
 
-      <div class="dashboard-window" data-cost-window="efficiency">
-        <div class="block" data-cost-jobs-history role="link" tabindex="0">
-          <h3>Cutting Job Efficiency Snapshot</h3>
-          <div class="time-efficiency-inline" id="costTimeEfficiency">
-            <div class="time-efficiency-inline-header">
-              <span class="time-efficiency-inline-title">Cutting time efficiency</span>
-              <div class="time-efficiency-controls">
-                <div class="time-efficiency-toggles" role="tablist">
-                  ${efficiencyButtons}
-                </div>
-                <button type="button" class="time-efficiency-edit-btn" data-efficiency-edit>Edit range</button>
+
+    </div>
+  </div>
+
+  <div class="cost-data-center-modal" id="efficiencySnapshotModal" data-efficiency-snapshot-modal hidden>
+    <div class="cost-data-center-backdrop" data-close-efficiency-snapshot></div>
+    <div class="cost-data-center-panel" role="dialog" aria-modal="true" aria-label="Cutting Job Efficiency Snapshot" style="max-width:1100px;border-radius:16px;">
+      <div class="cost-data-center-header" style="border-radius:16px 16px 0 0;">
+        <h4>Cutting Job Efficiency Snapshot</h4>
+        <button type="button" class="btn ghost" data-close-efficiency-snapshot>Close</button>
+      </div>
+      <div class="cost-data-center-body">
+        <div class="time-efficiency-inline" id="costTimeEfficiency">
+          <div class="time-efficiency-inline-header">
+            <span class="time-efficiency-inline-title">Cutting time efficiency</span>
+            <div class="time-efficiency-controls">
+              <div class="time-efficiency-toggles" role="tablist">
+                ${efficiencyButtons}
               </div>
+              <button type="button" class="time-efficiency-edit-btn" data-efficiency-edit>Edit range</button>
             </div>
-            <div class="time-efficiency-edit" data-efficiency-edit-panel hidden>
-              <div class="time-efficiency-edit-row">
-                <label class="time-efficiency-edit-field">
-                  <span class="time-efficiency-edit-label">Start date</span>
-                  <input type="date" data-efficiency-start-input>
-                </label>
-                <div class="time-efficiency-edit-actions">
-                  <button type="button" class="time-efficiency-edit-apply" data-efficiency-apply>Apply</button>
-                  <button type="button" class="time-efficiency-edit-cancel" data-efficiency-cancel>Cancel</button>
-                </div>
-              </div>
-              <p class="small muted time-efficiency-edit-note" data-efficiency-edit-note></p>
-            </div>
-            <div class="time-efficiency-metrics" role="status" aria-live="polite">
-              <div class="time-efficiency-metric">
-                <span class="label">Actual hours</span>
-                <span class="value" data-efficiency-actual>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">Current target</span>
-                <span class="value" data-efficiency-target>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">Gap vs target</span>
-                <span class="value" data-efficiency-gap-target>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">End goal</span>
-                <span class="value" data-efficiency-goal>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-              <span class="label">Avg usage/day</span>
-                <span class="value" data-efficiency-average>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">Gap vs goal</span>
-                <span class="value" data-efficiency-gap-goal>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">Efficiency (to date)</span>
-                <span class="value" data-efficiency-percent>—</span>
-              </div>
-            </div>
-            <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
-            <p class="small muted">Baseline adapts to your average logged hours per day.</p>
           </div>
-          <div class="cost-jobs-summary">
-            <div><span class="label">Jobs tracked</span><span>—</span></div>
-            <div><span class="label">Total gain / loss</span><span>—</span></div>
-            <div><span class="label">Avg per job</span><span>—</span></div>
-            <div><span class="label">Rolling avg (chart)</span><span>—</span></div>
+          <div class="time-efficiency-edit" data-efficiency-edit-panel hidden>
+            <div class="time-efficiency-edit-row">
+              <label class="time-efficiency-edit-field">
+                <span class="time-efficiency-edit-label">Start date</span>
+                <input type="date" data-efficiency-start-input>
+              </label>
+              <label class="time-efficiency-edit-field">
+                <span class="time-efficiency-edit-label">Goal / week (hr)</span>
+                <input type="number" min="1" step="0.5" data-efficiency-goal-input>
+              </label>
+              <div class="time-efficiency-edit-actions">
+                <button type="button" class="time-efficiency-edit-apply" data-efficiency-apply>Apply</button>
+                <button type="button" class="time-efficiency-edit-cancel" data-efficiency-cancel>Cancel</button>
+              </div>
+            </div>
+            <p class="small muted time-efficiency-edit-note" data-efficiency-edit-note></p>
           </div>
+          <div class="time-efficiency-metrics" role="status" aria-live="polite">
+            <div class="time-efficiency-metric"><span class="label">Actual hours</span><span class="value" data-efficiency-actual>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Current target</span><span class="value" data-efficiency-target>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Gap vs target</span><span class="value" data-efficiency-gap-target>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">End goal</span><span class="value" data-efficiency-goal>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Avg usage/day</span><span class="value" data-efficiency-average>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Gap vs goal</span><span class="value" data-efficiency-gap-goal>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Efficiency (to date)</span><span class="value" data-efficiency-percent>—</span></div>
+          </div>
+          <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
+          <p class="small muted">Baseline adapts to your average logged hours per day.</p>
+        </div>
+        <div class="cost-efficiency-calculator" data-efficiency-calc>
+          <div class="cost-efficiency-calculator-row">
+            <label>
+              <span class="label">Charge / hr (temporary)</span>
+              <input type="number" step="1" min="0" value="${esc(String(Number(calculatorDefaults.chargeRate) || 0))}" data-efficiency-calc-charge>
+            </label>
+            <label>
+              <span class="label">Cost / hr (temporary)</span>
+              <input type="number" step="1" min="0" value="${esc(String(Number(calculatorDefaults.costRate) || 0))}" data-efficiency-calc-cost>
+            </label>
+            <label>
+              <span class="label">Time range</span>
+              <select data-efficiency-calc-range-select>
+                <option value="1m">Past 1 month</option>
+                <option value="2m">Past 2 months</option>
+                <option value="3m">Past 3 months</option>
+                <option value="6m">Past 6 months</option>
+                <option value="1y">Past 1 year</option>
+                <option value="ytd">Year to date</option>
+                <option value="all">All time</option>
+              </select>
+            </label>
+            <button type="button" class="btn secondary" data-efficiency-calc-reset>Reset</button>
+            <button type="button" class="btn secondary" data-go-jobs-history>Go to cutting jobs</button>
+          </div>
+          <p class="small muted" data-efficiency-calc-range-label>Range: past 1 month from central data table rows.</p>
+          <p class="small muted">Temporary calculator only. Refresh resets values to central data table defaults.</p>
+          <p class="small muted" data-efficiency-calc-result>
+            Net total gain (calculator): <strong data-efficiency-calc-total>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</strong>
+            · Avg / row: <strong data-efficiency-calc-average>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</strong>
+          </p>
+        </div>
+        <div class="cost-jobs-summary">
+          <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
+          <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
+          <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Total net gain</span><span data-efficiency-summary-total>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</span></div>
+          <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Avg net gain / row</span><span data-efficiency-summary-average>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
+          <div><span class="label">Total run cost</span><span>${esc(efficiencySnapshot.totalCostLabel || "$0.00")}</span></div>
+          <div><span class="label">Avg run cost / row</span><span>${esc(efficiencySnapshot.averageCostLabel || "$0.00")}</span></div>
+        </div>
+        <p class="small muted" title="${esc(`${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || "Uses central data table values only."}`)}" data-efficiency-source-note>${esc(efficiencySnapshot.sourceLabel || "Source: central data table completed cutting jobs rows.")} ${esc(efficiencySnapshot.disclaimerLabel || "Uses central data table values only.")}</p>
+        <div class="cost-weekly-table-wrap">
           <table class="cost-table">
-            <thead><tr><th>Job</th><th>Milestone</th><th>Status</th><th>Cost impact</th></tr></thead>
+            <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Labor cost</th><th>Total cost</th><th title="${esc(`${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" aria-label="Net gain calculation">Net gain</th><th>Task link</th></tr></thead>
             <tbody>
-              <tr>
-                <td colspan="4" class="cost-table-placeholder">Job history visualization coming soon.</td>
-              </tr>
+              ${efficiencyRows.length ? efficiencyRows.map(row => `
+                <tr data-efficiency-row data-efficiency-id="${esc(row.id || "")}" data-efficiency-date="${esc(row.dateLabel || "")}" data-efficiency-hours="${esc(String(Number(row.hoursValue) || 0))}" data-efficiency-material="${esc(String(Number(row.materialValue || 0)))}">
+                  <td>${esc(row.taskName || "Completed task")}</td>
+                  <td>${esc(row.dateLabel || "—")}</td>
+                  <td>${esc(row.hoursLabel || "0 hr")}</td>
+                  <td>${esc(row.partCostLabel || "$0.00")}</td>
+                  <td data-efficiency-labor-cell>${esc(row.laborCostLabel || "$0.00")}</td>
+                  <td data-efficiency-total-cost-cell>${esc(row.totalCostLabel || "$0.00")}</td>
+                  <td title="${esc(`${row.formulaTitle || efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" data-efficiency-profit-cell>${esc(row.netGainLabel || "$0.00")}</td>
+                  <td>${row.settingsLink ? `<button type="button" class="btn secondary" data-efficiency-open-job="${esc(row.id || "")}">Open job</button>` : "Invalid link"}</td>
+                </tr>
+              `).join("") : `
+                <tr>
+                  <td colspan="8" class="cost-table-placeholder">${esc(efficiencySnapshot.emptyMessage || "No valid completed rows available from the central data table.")}</td>
+                </tr>
+              `}
             </tbody>
           </table>
-          <div class="cost-window-insight">
-            <div class="chart-info">
-              <button type="button" class="chart-info-button" aria-describedby="costEfficiencyInsight" aria-label="Explain Cutting Job Efficiency Snapshot">
-                <span aria-hidden="true">?</span>
-                <span class="sr-only">Show how the Cutting Job Efficiency Snapshot reveals margin trends</span>
-              </button>
-              <div class="chart-info-bubble" id="costEfficiencyInsight" role="tooltip">
-                <p>${esc(efficiencyInsight)}</p>
-              </div>
+        </div>
+        <div class="cost-window-insight">
+          <div class="chart-info">
+            <button type="button" class="chart-info-button" aria-describedby="costEfficiencyInsight" aria-label="Explain Cutting Job Efficiency Snapshot">
+              <span aria-hidden="true">?</span>
+              <span class="sr-only">Show how the Cutting Job Efficiency Snapshot reveals margin trends</span>
+            </button>
+            <div class="chart-info-bubble" id="costEfficiencyInsight" role="tooltip">
+              <p>${esc(efficiencyInsight)}</p>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </div>`;
+    </div></div>`;
 }
 
 function viewJobs(){


### PR DESCRIPTION
### Motivation

- Provide a focused Efficiency Snapshot and temporary calculator to surface per-job net gain, run costs, and aggregate efficiency from the central cutting jobs data table. 
- Make weekly time-efficiency goals configurable from the UI and persist a fixed daily-hours prediction when the goal is applied.
- Improve summary cards and weekly reports to show profit/loss semantics for cutting and maintenance.

### Description

- Added an `efficiencySnapshot` computation in `computeCostModel()` that derives per-row efficiency rows, aggregated totals, calculator defaults, and display labels from existing cutting jobs data and job pricing fields. 
- Enriched cutting job objects with explicit cost/labor/profit numeric fields and added summary updates to `summaryCards` and `jobSummary`; updated weekly report labels for profit/loss presentation. 
- Implemented a new modal and UI in `viewCosts()` for the Efficiency Snapshot and a temporary calculator, including an efficiency data center tab, table rows, calculator controls, and an `efficiencySnapshotModal` with open/close wiring. 
- Added `setupEfficiencyCalculator()` and integrated it into `renderCosts()` to wire controls, range filters, recalculation logic, keyboard escape handling, and job navigation hooks, and updated the inline time-efficiency widget to include a `goal` input and persist `dailyHours` via `setAppConfig()`/`persist()`. 
- Minor view and wiring adjustments including adding `data-efficiency-goal-input`, goal propagation in `updateTimeEfficiencyEditPanel()` and `applyTimeEfficiencyEdit()`, and a few UX refinements (buttons, titles, and tooltips).

### Testing

- Ran the project's lint and static checks with `npm run lint` which completed without errors. 
- Executed the existing automated test suite with `npm test` and observed no failing tests. 
- Manually exercised the Costs page in a local dev build to verify the modal opens, calculator updates totals on input changes, and the time-efficiency goal persists to `appConfig` when applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d331f9488325b327039d9137edf0)