### PR TITLE
Add Cutting Job Efficiency Snapshot & Calculator; support weekly goal in Time Efficiency editor

### DIFF
--- a/js/computations.js
+++ b/js/computations.js
@@ -96,6 +96,7 @@ function computeTimeEfficiency(rangeDays, options = {}){
   const goalDailyHours = (goalMode === "average" && Number.isFinite(Number(averageDailyHours)) && Number(averageDailyHours) > 0)
     ? Number(averageDailyHours)
     : configuredDailyHours;
+  const goalDailyHoursLabel = `${Math.abs(goalDailyHours - Math.round(goalDailyHours)) < 0.05 ? Math.round(goalDailyHours) : goalDailyHours.toFixed(1)} hr`;
   let actual = 0;
   let coverage = 0;
   const cursor = new Date(startDate);
@@ -153,8 +154,8 @@ function computeTimeEfficiency(rangeDays, options = {}){
     goalModeLabel: goalMode === "average" ? "Go off average" : "Go off maximum",
     goalDailyHours,
     goalSourceLabel: goalMode === "average"
-      ? `Average cut hours/day (${formatHoursValue(goalDailyHours)})`
-      : `Dashboard goal hours/day (${formatHoursValue(goalDailyHours)})`,
+      ? `Average cut hours/day (${goalDailyHoursLabel})`
+      : `Dashboard goal hours/day (${goalDailyHoursLabel})`,
     averageDailyHours,
     startISO: ymd(startDate),
     endISO: ymd(endDate),

--- a/js/computations.js
+++ b/js/computations.js
@@ -77,15 +77,25 @@ function computeTimeEfficiency(rangeDays, options = {}){
   }
 
   const map = getDailyCutHoursMap();
-  const baselineDailyHoursRaw = (typeof getConfiguredDailyHours === "function")
-    ? Number(getConfiguredDailyHours())
-    : Number(CUTTING_BASELINE_DAILY_HOURS);
-  const baselineDailyHours = (Number.isFinite(baselineDailyHoursRaw) && baselineDailyHoursRaw > 0)
-    ? baselineDailyHoursRaw
+  const configuredGoalMode = (typeof window !== "undefined" && window.appConfig)
+    ? window.appConfig.timeEfficiencyGoalMode
+    : null;
+  const goalModeRaw = options.goalMode || configuredGoalMode || "maximum";
+  const goalMode = goalModeRaw === "average" ? "average" : "maximum";
+  const configuredDailyHoursRaw = (typeof getFixedDailyHours === "function")
+    ? Number(getFixedDailyHours())
+    : ((typeof getConfiguredDailyHours === "function")
+      ? Number(getConfiguredDailyHours())
+      : Number(CUTTING_BASELINE_DAILY_HOURS));
+  const configuredDailyHours = (Number.isFinite(configuredDailyHoursRaw) && configuredDailyHoursRaw > 0)
+    ? configuredDailyHoursRaw
     : CUTTING_BASELINE_DAILY_HOURS;
   const averageDailyHours = (typeof getAverageDailyCutHours === "function")
     ? getAverageDailyCutHours()
     : null;
+  const goalDailyHours = (goalMode === "average" && Number.isFinite(Number(averageDailyHours)) && Number(averageDailyHours) > 0)
+    ? Number(averageDailyHours)
+    : configuredDailyHours;
   let actual = 0;
   let coverage = 0;
   const cursor = new Date(startDate);
@@ -101,7 +111,7 @@ function computeTimeEfficiency(rangeDays, options = {}){
   }
 
   const workingDays = inclusiveDayCount(startDate, endDate) || 0;
-  const baseline = baselineDailyHours * workingDays;
+  const baseline = goalDailyHours * workingDays;
 
   const todayLocal = new Date();
   todayLocal.setHours(0,0,0,0);
@@ -120,7 +130,7 @@ function computeTimeEfficiency(rangeDays, options = {}){
   if (!Number.isFinite(elapsedDays)) elapsedDays = 0;
   elapsedDays = Math.max(0, Math.min(normalizedDays, Math.round(elapsedDays)));
 
-  const targetHours = baselineDailyHours * elapsedDays;
+  const targetHours = goalDailyHours * elapsedDays;
   const differenceToDate = actual - targetHours;
   const difference = actual - baseline;
   const percentToDate = targetHours > 0
@@ -139,6 +149,12 @@ function computeTimeEfficiency(rangeDays, options = {}){
     efficiencyPercent: percentToDate,
     efficiencyGoalPercent: percentGoal,
     coverageDays: coverage,
+    goalMode,
+    goalModeLabel: goalMode === "average" ? "Go off average" : "Go off maximum",
+    goalDailyHours,
+    goalSourceLabel: goalMode === "average"
+      ? `Average cut hours/day (${formatHoursValue(goalDailyHours)})`
+      : `Dashboard goal hours/day (${formatHoursValue(goalDailyHours)})`,
     averageDailyHours,
     startISO: ymd(startDate),
     endISO: ymd(endDate),

--- a/js/core.js
+++ b/js/core.js
@@ -58,7 +58,8 @@ const DEFAULT_APP_CONFIG = {
   excludeWeekends: false,
   dailyHours: DEFAULT_DAILY_HOURS,
   predictionMode: "fixed",
-  averageWindowDays: DEFAULT_PREDICTION_AVERAGE_WINDOW
+  averageWindowDays: DEFAULT_PREDICTION_AVERAGE_WINDOW,
+  timeEfficiencyGoalMode: "maximum"
 };
 let appConfig = { ...DEFAULT_APP_CONFIG };
 
@@ -239,6 +240,7 @@ function normalizeAppConfig(config){
       normalized.predictionMode = "fixed";
     }
     normalized.averageWindowDays = normalizePredictionAverageWindow(config.averageWindowDays);
+    normalized.timeEfficiencyGoalMode = config.timeEfficiencyGoalMode === "average" ? "average" : "maximum";
   }
   return normalized;
 }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11768,8 +11768,8 @@ function renderCosts(){
       : null;
     const defaultCharge = Math.max(0, asNumber(draft?.chargeRate, asNumber(defaults.chargeRate, asNumber(chargeInput.value, 0))));
     const defaultCost = Math.max(0, asNumber(draft?.costRate, asNumber(defaults.costRate, asNumber(costInput.value, 0))));
-    chargeInput.value = String(defaultCharge);
-    costInput.value = String(defaultCost);
+    chargeInput.value = defaultCharge.toFixed(2);
+    costInput.value = defaultCost.toFixed(2);
     let activeRange = "1m";
 
     const getRangeStart = (rangeKey)=>{
@@ -11870,8 +11870,8 @@ function renderCosts(){
     }
     if (resetBtn instanceof HTMLElement){
       resetBtn.addEventListener("click", ()=>{
-        chargeInput.value = String(defaultCharge);
-        costInput.value = String(defaultCost);
+        chargeInput.value = defaultCharge.toFixed(2);
+        costInput.value = defaultCost.toFixed(2);
         activeRange = "1m";
         recalc();
         updateRangeButtons();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11947,16 +11947,23 @@ function renderCosts(){
       const totals = visibleRows.reduce((acc, row)=>{
         const hours = Math.max(0, asNumber(row?.hoursValue, 0));
         const material = Math.max(0, asNumber(row?.materialValue ?? row?.materialCostValue, 0));
+        const labor = hours * costRate;
+        const totalCost = labor + material;
         acc.rows += 1;
         acc.net += (hours * (chargeRate - costRate)) - material;
+        acc.cost += totalCost;
         return acc;
-      }, { rows: 0, net: 0 });
+      }, { rows: 0, net: 0, cost: 0 });
       if (totalEl) totalEl.textContent = formatUsd(totals.net);
       if (avgEl) avgEl.textContent = formatUsd(totals.rows ? (totals.net / totals.rows) : 0);
       const summaryTotalEl = document.querySelector("[data-efficiency-summary-total]");
       const summaryAvgEl = document.querySelector("[data-efficiency-summary-average]");
+      const summaryCostEl = document.querySelector("[data-efficiency-summary-cost]");
+      const summaryCostAvgEl = document.querySelector("[data-efficiency-summary-cost-average]");
       if (summaryTotalEl) summaryTotalEl.textContent = formatUsd(totals.net);
       if (summaryAvgEl) summaryAvgEl.textContent = formatUsd(totals.rows ? (totals.net / totals.rows) : 0);
+      if (summaryCostEl) summaryCostEl.textContent = formatUsd(totals.cost);
+      if (summaryCostAvgEl) summaryCostAvgEl.textContent = formatUsd(totals.rows ? (totals.cost / totals.rows) : 0);
       const tableRows = Array.from(document.querySelectorAll("[data-efficiency-row]"));
       tableRows.forEach(tr => {
         const rowId = String(tr.getAttribute("data-efficiency-id") || "");

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -4512,6 +4512,15 @@ function updateTimeEfficiencyEditPanel(widget){
       widget.editInput.value = saved;
     }
   }
+  if (widget.goalInput){
+    const configuredDaily = (typeof getConfiguredDailyHours === "function")
+      ? Number(getConfiguredDailyHours())
+      : Number(CUTTING_BASELINE_DAILY_HOURS || 0);
+    const weeklyGoal = Number.isFinite(configuredDaily) && configuredDaily > 0
+      ? configuredDaily * 7
+      : 56;
+    widget.goalInput.value = weeklyGoal.toFixed(1);
+  }
 }
 
 function toggleTimeEfficiencyEditPanel(widget, show){
@@ -4533,11 +4542,29 @@ function toggleTimeEfficiencyEditPanel(widget, show){
   }
 }
 
-function applyTimeEfficiencyEdit(widget){
+  function applyTimeEfficiencyEdit(widget){
   if (!widget) return;
   const days = Number(widget.currentDays) || Number(widget.defaultDays) || 7;
+  if (widget.goalInput){
+    const weeklyGoal = Number(widget.goalInput.value);
+    if (Number.isFinite(weeklyGoal) && weeklyGoal > 0){
+      const dailyGoal = Math.max(0.1, Math.round((weeklyGoal / 7) * 100) / 100);
+      const currentConfig = (typeof normalizeAppConfig === "function")
+        ? normalizeAppConfig(window.appConfig)
+        : (window.appConfig || {});
+      const nextConfig = {
+        ...currentConfig,
+        predictionMode: "fixed",
+        dailyHours: dailyGoal
+      };
+      if (typeof setAppConfig === "function") setAppConfig(nextConfig);
+      else window.appConfig = nextConfig;
+      if (typeof persist === "function") persist();
+    }
+  }
   if (!widget.editInput || widget.editInput.disabled){
     toggleTimeEfficiencyEditPanel(widget, false);
+    refreshTimeEfficiencyWidgets();
     return;
   }
   const raw = widget.editInput.value;
@@ -4545,6 +4572,7 @@ function applyTimeEfficiencyEdit(widget){
     widget.customStartByRange?.delete(days);
     toggleTimeEfficiencyEditPanel(widget, false);
     refreshTimeEfficiencyWidget(widget);
+    refreshTimeEfficiencyWidgets();
     return;
   }
   const normalized = normalizeTimeEfficiencyStart(days, raw);
@@ -4559,6 +4587,7 @@ function applyTimeEfficiencyEdit(widget){
   }
   toggleTimeEfficiencyEditPanel(widget, false);
   refreshTimeEfficiencyWidget(widget);
+  refreshTimeEfficiencyWidgets();
 }
 
 function setupTimeEfficiencyWidget(root){
@@ -4595,7 +4624,8 @@ function setupTimeEfficiencyWidget(root){
     editInput: root.querySelector("[data-efficiency-start-input]"),
     applyBtn: root.querySelector("[data-efficiency-apply]") || root.querySelector("[data-efficiency-save]") || null,
     cancelBtn: root.querySelector("[data-efficiency-cancel]") || null,
-    editNote: root.querySelector("[data-efficiency-edit-note]") || null
+    editNote: root.querySelector("[data-efficiency-edit-note]") || null,
+    goalInput: root.querySelector("[data-efficiency-goal-input]") || null
   };
   toggles.forEach(btn => {
     btn.addEventListener("click", ()=> selectTimeEfficiencyRange(widget, btn));
@@ -10571,6 +10601,7 @@ function renderCosts(){
   const content = document.getElementById("content");
   if (!content) return;
   const previousModal = document.getElementById("costDataCenterModal");
+  const previousEfficiencyModal = document.getElementById("efficiencySnapshotModal");
   const wasDataCenterOpen = Boolean(previousModal && !previousModal.hasAttribute("hidden"));
   let pendingDataCenterScrollTop = null;
   if (previousModal instanceof HTMLElement && wasDataCenterOpen){
@@ -10581,6 +10612,10 @@ function renderCosts(){
   }
   if (previousModal && previousModal.parentElement === document.body){
     previousModal.remove();
+    document.body.classList.remove("cost-data-center-open");
+  }
+  if (previousEfficiencyModal && previousEfficiencyModal.parentElement === document.body){
+    previousEfficiencyModal.remove();
     document.body.classList.remove("cost-data-center-open");
   }
   const existingReceiptModal = document.getElementById("costReceiptModal");
@@ -10630,6 +10665,7 @@ function renderCosts(){
   setupCostTimeframeModal(model);
   setupJobCategoryWindow(model);
   setupWeeklyReportWindow(model);
+  setupEfficiencyCalculator(model);
   setupMaintenanceDataCenterActions({ openImmediately: wasDataCenterOpen });
 
   function focusCalendarAtOccurrence(taskId, dateISO){
@@ -11651,6 +11687,233 @@ function renderCosts(){
     }
   }
 
+  function setupEfficiencyCalculator(currentModel){
+    const openSnapshotBtns = Array.from(content.querySelectorAll("[data-open-efficiency-snapshot]"));
+    const closeSnapshot = ()=>{
+      const modal = document.getElementById("efficiencySnapshotModal");
+      if (!(modal instanceof HTMLElement)) return;
+      modal.hidden = true;
+      document.body.classList.remove("cost-data-center-open");
+      if (typeof window !== "undefined") window.__efficiencySnapshotModalOpen = false;
+      if (typeof window !== "undefined") window.__efficiencyCalculatorDraft = null;
+    };
+    const openSnapshot = ()=>{
+      const modal = document.getElementById("efficiencySnapshotModal");
+      if (!(modal instanceof HTMLElement)) return;
+      modal.hidden = false;
+      if (modal.parentElement !== document.body) document.body.appendChild(modal);
+      document.body.classList.add("cost-data-center-open");
+      if (typeof window !== "undefined") window.__efficiencySnapshotModalOpen = true;
+      const panelEl = modal.querySelector(".cost-data-center-panel");
+      if (panelEl instanceof HTMLElement && panelEl.dataset.efficiencyBubbleBound !== "1"){
+        const stopEvent = (event)=>{
+          event.stopPropagation();
+        };
+        panelEl.addEventListener("click", stopEvent);
+        panelEl.addEventListener("mousedown", stopEvent);
+        panelEl.dataset.efficiencyBubbleBound = "1";
+      }
+    };
+    openSnapshotBtns.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", (event)=>{
+        event.preventDefault();
+        event.stopPropagation();
+        if (typeof event.stopImmediatePropagation === "function") event.stopImmediatePropagation();
+        openSnapshot();
+      });
+    });
+    const closeSnapshotBtns = Array.from(document.querySelectorAll("[data-close-efficiency-snapshot]"))
+      .filter(btn => !(btn instanceof HTMLElement) ? false : !btn.classList.contains("cost-data-center-backdrop"));
+    closeSnapshotBtns.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", closeSnapshot);
+    });
+
+    const panel = content.querySelector("[data-efficiency-calc]");
+    if (!(panel instanceof HTMLElement)) return;
+    const snapshot = currentModel && currentModel.efficiencySnapshot ? currentModel.efficiencySnapshot : {};
+    const rows = Array.isArray(snapshot.rows) ? snapshot.rows : [];
+    const defaults = snapshot.calculatorDefaults || {};
+    const chargeInput = panel.querySelector("[data-efficiency-calc-charge]");
+    const costInput = panel.querySelector("[data-efficiency-calc-cost]");
+    const resetBtn = panel.querySelector("[data-efficiency-calc-reset]");
+    const rangeSelect = panel.querySelector("[data-efficiency-calc-range-select]");
+    const rangeLabelEl = panel.querySelector("[data-efficiency-calc-range-label]");
+    const totalEl = panel.querySelector("[data-efficiency-calc-total]");
+    const avgEl = panel.querySelector("[data-efficiency-calc-average]");
+    const goJobsBtn = panel.querySelector("[data-go-jobs-history]");
+    if (!(chargeInput instanceof HTMLInputElement) || !(costInput instanceof HTMLInputElement)) return;
+
+    const formatUsd = (value)=> new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: Math.abs(Number(value) || 0) < 1000 ? 2 : 0,
+      maximumFractionDigits: Math.abs(Number(value) || 0) < 1000 ? 2 : 0
+    }).format(Number.isFinite(Number(value)) ? Number(value) : 0);
+    const asNumber = (value, fallback = 0)=>{
+      const num = Number(value);
+      return Number.isFinite(num) ? num : fallback;
+    };
+    const normalizeToTwo = (inputEl, fallback)=>{
+      if (!(inputEl instanceof HTMLInputElement)) return fallback;
+      const raw = asNumber(inputEl.value, fallback);
+      const safe = Math.max(0, raw);
+      const normalized = Math.round(safe * 100) / 100;
+      inputEl.value = normalized.toFixed(2);
+      return normalized;
+    };
+    const draft = (typeof window !== "undefined" && window.__efficiencyCalculatorDraft && typeof window.__efficiencyCalculatorDraft === "object")
+      ? window.__efficiencyCalculatorDraft
+      : null;
+    const defaultCharge = Math.max(0, asNumber(draft?.chargeRate, asNumber(defaults.chargeRate, asNumber(chargeInput.value, 0))));
+    const defaultCost = Math.max(0, asNumber(draft?.costRate, asNumber(defaults.costRate, asNumber(costInput.value, 0))));
+    chargeInput.value = String(defaultCharge);
+    costInput.value = String(defaultCost);
+    let activeRange = "1m";
+
+    const getRangeStart = (rangeKey)=>{
+      const now = new Date();
+      now.setHours(23, 59, 59, 999);
+      const start = new Date(now);
+      start.setHours(0, 0, 0, 0);
+      if (rangeKey === "all") return null;
+      if (rangeKey === "ytd"){
+        return new Date(start.getFullYear(), 0, 1);
+      }
+      const monthMap = { "1m": 1, "2m": 2, "3m": 3, "6m": 6, "1y": 12 };
+      const monthsBack = monthMap[rangeKey];
+      if (!monthsBack) return null;
+      return new Date(start.getFullYear(), start.getMonth() - monthsBack, start.getDate());
+    };
+    const parseRowDate = (row)=>{
+      const raw = String(row?.dateLabel || "");
+      if (!raw) return null;
+      const parsed = new Date(`${raw}T00:00:00`);
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
+    };
+    const withinRange = (row, rangeKey)=>{
+      if (rangeKey === "all") return true;
+      const rowDate = parseRowDate(row);
+      if (!(rowDate instanceof Date)) return false;
+      const start = getRangeStart(rangeKey);
+      if (!(start instanceof Date)) return true;
+      return rowDate >= start;
+    };
+    const updateRangeButtons = ()=>{
+      if (rangeSelect instanceof HTMLSelectElement) rangeSelect.value = activeRange;
+      const labels = {
+        "1m": "Range: past 1 month from central data table rows.",
+        "2m": "Range: past 2 months from central data table rows.",
+        "3m": "Range: past 3 months from central data table rows.",
+        "6m": "Range: past 6 months from central data table rows.",
+        "1y": "Range: past 1 year from central data table rows.",
+        ytd: "Range: year to date from central data table rows.",
+        all: "Range: all time from central data table rows."
+      };
+      if (rangeLabelEl instanceof HTMLElement){
+        rangeLabelEl.textContent = labels[activeRange] || labels["1m"];
+      }
+    };
+
+    const recalc = ()=>{
+      const chargeRate = Math.max(0, asNumber(chargeInput.value, defaultCharge));
+      const costRate = Math.max(0, asNumber(costInput.value, defaultCost));
+      if (typeof window !== "undefined"){
+        window.__efficiencyCalculatorDraft = { chargeRate, costRate };
+      }
+      const visibleRows = rows.filter(row => withinRange(row, activeRange));
+      const totals = visibleRows.reduce((acc, row)=>{
+        const hours = Math.max(0, asNumber(row?.hoursValue, 0));
+        const material = Math.max(0, asNumber(row?.materialValue ?? row?.materialCostValue, 0));
+        acc.rows += 1;
+        acc.net += (hours * (chargeRate - costRate)) - material;
+        return acc;
+      }, { rows: 0, net: 0 });
+      if (totalEl) totalEl.textContent = formatUsd(totals.net);
+      if (avgEl) avgEl.textContent = formatUsd(totals.rows ? (totals.net / totals.rows) : 0);
+      const summaryTotalEl = document.querySelector("[data-efficiency-summary-total]");
+      const summaryAvgEl = document.querySelector("[data-efficiency-summary-average]");
+      if (summaryTotalEl) summaryTotalEl.textContent = formatUsd(totals.net);
+      if (summaryAvgEl) summaryAvgEl.textContent = formatUsd(totals.rows ? (totals.net / totals.rows) : 0);
+      const tableRows = Array.from(document.querySelectorAll("[data-efficiency-row]"));
+      tableRows.forEach(tr => {
+        const rowId = String(tr.getAttribute("data-efficiency-id") || "");
+        const rowObj = rows.find(row => String(row?.id || "") === rowId) || null;
+        const show = rowObj ? withinRange(rowObj, activeRange) : false;
+        tr.hidden = !show;
+        if (!show) return;
+        const hours = Math.max(0, asNumber(tr.getAttribute("data-efficiency-hours"), asNumber(rowObj?.hoursValue, 0)));
+        const material = Math.max(0, asNumber(tr.getAttribute("data-efficiency-material"), asNumber(rowObj?.materialValue ?? rowObj?.materialCostValue, 0)));
+        const labor = hours * costRate;
+        const totalCost = labor + material;
+        const net = (hours * (chargeRate - costRate)) - material;
+        const laborCell = tr.querySelector("[data-efficiency-labor-cell]");
+        const totalCostCell = tr.querySelector("[data-efficiency-total-cost-cell]");
+        const profitCell = tr.querySelector("[data-efficiency-profit-cell]");
+        if (laborCell) laborCell.textContent = formatUsd(labor);
+        if (totalCostCell) totalCostCell.textContent = formatUsd(totalCost);
+        if (profitCell) profitCell.textContent = formatUsd(net);
+      });
+    };
+
+    chargeInput.addEventListener("input", recalc);
+    costInput.addEventListener("input", recalc);
+    chargeInput.addEventListener("blur", ()=>{ normalizeToTwo(chargeInput, defaultCharge); recalc(); });
+    costInput.addEventListener("blur", ()=>{ normalizeToTwo(costInput, defaultCost); recalc(); });
+    if (rangeSelect instanceof HTMLSelectElement){
+      rangeSelect.addEventListener("change", ()=>{
+        activeRange = String(rangeSelect.value || "1m");
+        updateRangeButtons();
+        recalc();
+      });
+    }
+    if (resetBtn instanceof HTMLElement){
+      resetBtn.addEventListener("click", ()=>{
+        chargeInput.value = String(defaultCharge);
+        costInput.value = String(defaultCost);
+        activeRange = "1m";
+        recalc();
+        updateRangeButtons();
+      });
+    }
+    if (typeof window !== "undefined"){
+      if (typeof window.__efficiencySnapshotEscHandler === "function"){
+        document.removeEventListener("keydown", window.__efficiencySnapshotEscHandler);
+      }
+      window.__efficiencySnapshotEscHandler = (event)=>{
+        if (event.key !== "Escape") return;
+        const modal = document.getElementById("efficiencySnapshotModal");
+        if (modal instanceof HTMLElement && !modal.hidden) closeSnapshot();
+      };
+      document.addEventListener("keydown", window.__efficiencySnapshotEscHandler);
+    }
+    if (goJobsBtn instanceof HTMLElement){
+      goJobsBtn.addEventListener("click", ()=>{
+        closeSnapshot();
+        goToJobsHistory();
+      });
+    }
+    const openJobBtns = Array.from(document.querySelectorAll("[data-efficiency-open-job]"));
+    openJobBtns.forEach(btn => {
+      if (!(btn instanceof HTMLElement)) return;
+      btn.addEventListener("click", ()=>{
+        const id = String(btn.getAttribute("data-efficiency-open-job") || "");
+        if (!id) return;
+        if (typeof window !== "undefined"){
+          window.pendingJobFocus = { type: "jobRow", id };
+        }
+        closeSnapshot();
+        goToJobsHistory();
+      });
+    });
+    updateRangeButtons();
+    recalc();
+    if (typeof window !== "undefined" && window.__efficiencySnapshotModalOpen){
+      openSnapshot();
+    }
+  }
+
   function setupJobCategoryWindow(currentModel){
     const panel = content.querySelector("[data-cost-job-categories]");
     if (!panel) return;
@@ -12079,7 +12342,6 @@ function renderCosts(){
   };
 
   wireJobsHistoryShortcut(content.querySelector("[data-cost-jobs-history]"));
-  wireJobsHistoryShortcut(content.querySelector("[data-cost-cutting-card]"));
   wireJobsHistoryShortcut(content.querySelector(".cost-chart-toggle-link"));
 
   const normalizeHistoryDate = (value)=>{
@@ -14387,6 +14649,8 @@ function computeCostModel(){
       ...report,
       totalCutCostLabel: formatterCurrency(report.totalCutCost, { showPlus: true, decimals: Math.abs(report.totalCutCost) < 1000 ? 2 : 0 }),
       totalMaintenanceCostLabel: formatterCurrency(report.totalMaintenanceCost, { decimals: report.totalMaintenanceCost < 1000 ? 2 : 0 }),
+      totalCutProfitLabel: formatterCurrency(report.totalCutCost, { showPlus: true, decimals: Math.abs(report.totalCutCost) < 1000 ? 2 : 0 }),
+      totalMaintenanceLossLabel: formatterCurrency(-Math.abs(report.totalMaintenanceCost), { showPlus: true, decimals: report.totalMaintenanceCost < 1000 ? 2 : 0 }),
       totalCutHoursLabel: formatHours(report.totalCutHours),
       weekLabel: `${formatDateLabelShort(new Date(report.weekStartISO))} - ${formatDateLabelShort(new Date(report.weekEndISO))}`
     }));
@@ -14944,8 +15208,10 @@ function computeCostModel(){
     const costRate = Number.isFinite(costRateRaw) && costRateRaw >= 0 ? costRateRaw : JOB_BASE_COST_PER_HOUR;
     const materialCost = Number(job?.materialCost);
     const materialQty = Number(job?.materialQty);
-    const materialCostValue = Number.isFinite(materialCost) ? materialCost : 0;
-    const totalProfit = ((chargeRate * hours) - (costRate * hours)) - materialCostValue;
+    const materialCostValue = Number.isFinite(materialCost) && materialCost >= 0 ? materialCost : 0;
+    const laborCostValue = Math.max(0, hours) * costRate;
+    const totalCostValue = materialCostValue + laborCostValue;
+    const totalProfitValue = (Math.max(0, hours) * chargeRate) - totalCostValue;
     const completedISO = typeof job?.completedAtISO === "string" && job.completedAtISO ? job.completedAtISO : "";
     return {
       id: job?.id != null ? String(job.id) : `completed_job_${index}`,
@@ -14958,17 +15224,106 @@ function computeCostModel(){
       materialType: String(job?.material || "—"),
       materialCostLabel: Number.isFinite(materialCost) ? formatterCurrency(materialCost, { decimals: 2 }) : "—",
       materialQtyLabel: Number.isFinite(materialQty) ? String(materialQty) : "—",
-      totalProfitLabel: formatterCurrency(totalProfit, { decimals: 2 }),
       startDateLabel: job?.startISO || "—",
       dueDateLabel: job?.dueISO || "—",
       completedDateLabel: completedISO ? String(completedISO).slice(0, 10) : "—",
+      completedDateISO: completedISO ? String(completedISO).slice(0, 10) : "",
       projectNumber: String(job?.projectNumber || "—"),
       notes: String(job?.notes || "").trim() || "—",
       priorityLabel: Number.isFinite(Number(job?.priority)) ? String(Math.max(1, Math.floor(Number(job.priority)))) : "—",
       cumulativeCutNumberLabel: `#${Math.max(1, totalCompletedJobs - index)}`,
-      categoryCutNumberLabel: `#${categoryCutCount}`
+      categoryCutNumberLabel: `#${categoryCutCount}`,
+      hoursValue: hours,
+      chargeRateValue: chargeRate,
+      costRateValue: costRate,
+      materialCostValue,
+      laborCostValue,
+      totalCostValue,
+      totalProfitValue,
+      settingsLink: job?.id != null ? `#/settings?jobId=${encodeURIComponent(String(job.id))}` : ""
     };
   });
+
+  const efficiencyRows = cuttingJobsDataTable
+    .filter(row => {
+      const hasDate = typeof row?.completedDateISO === "string" && row.completedDateISO.trim().length > 0;
+      const hasTaskName = typeof row?.name === "string" && row.name.trim().length > 0;
+      const hasSettingsLink = typeof row?.settingsLink === "string" && /^#\/settings\?jobId=/.test(row.settingsLink);
+      return hasDate && hasTaskName && hasSettingsLink;
+    })
+    .sort((a, b) => String(b?.completedDateISO || "").localeCompare(String(a?.completedDateISO || "")))
+    .map((row, index) => ({
+      id: row?.id != null ? String(row.id) : `efficiency_row_${index}`,
+      taskName: row?.name || "Completed task",
+      dateLabel: row?.completedDateISO || "—",
+      hoursLabel: formatHoursValue(Number(row?.hoursValue) || 0),
+      partCostLabel: formatterCurrency(Number(row?.materialCostValue) || 0, { decimals: 2 }),
+      laborCostLabel: formatterCurrency(Number(row?.laborCostValue) || 0, { decimals: 2 }),
+      totalCostLabel: formatterCurrency(Number(row?.totalCostValue) || 0, { decimals: 2 }),
+      totalProfitLabel: formatterCurrency(Number(row?.totalProfitValue) || 0, { decimals: 2, showPlus: true }),
+      hoursValue: Number(row?.hoursValue) || 0,
+      chargeRateValue: Number(row?.chargeRateValue) || 0,
+      costRateValue: Number(row?.costRateValue) || 0,
+      revenueValue: Math.max(0, (Number(row?.hoursValue) || 0) * (Number(row?.chargeRateValue) || 0)),
+      netGainLabel: formatterCurrency(Number(row?.totalProfitValue) || 0, { decimals: 2, showPlus: true }),
+      materialValue: Math.max(0, Number(row?.materialCostValue) || 0),
+      laborValue: Math.max(0, Number(row?.laborCostValue) || 0),
+      totalCostValue: Number(row?.totalCostValue) || 0,
+      totalProfitValue: Number(row?.totalProfitValue) || 0,
+      formulaTitle: "Source: Central data table completed cutting jobs row. Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost.",
+      settingsLink: row?.settingsLink || ""
+    }));
+  const efficiencyTotals = efficiencyRows.reduce((acc, row) => {
+    if (Number.isFinite(row?.hoursValue)) acc.hours += Math.max(0, Number(row.hoursValue));
+    if (Number.isFinite(row?.revenueValue)) acc.revenue += Math.max(0, Number(row.revenueValue));
+    if (Number.isFinite(row?.materialValue)) acc.material += Math.max(0, Number(row.materialValue));
+    if (Number.isFinite(row?.laborValue)) acc.labor += Math.max(0, Number(row.laborValue));
+    if (Number.isFinite(row?.totalCostValue)) acc.cost += Math.max(0, Number(row.totalCostValue));
+    if (Number.isFinite(row?.totalProfitValue)) acc.profit += Number(row.totalProfitValue);
+    return acc;
+  }, { hours: 0, revenue: 0, material: 0, labor: 0, cost: 0, profit: 0 });
+  const efficiencyCount = efficiencyRows.length;
+  const efficiencySnapshot = {
+    countLabel: String(efficiencyCount),
+    totalHoursLabel: formatHoursValue(efficiencyTotals.hours),
+    totalCostLabel: formatterCurrency(efficiencyTotals.cost, { decimals: efficiencyTotals.cost < 1000 ? 2 : 0 }),
+    averageCostLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.cost / efficiencyCount) : 0, { decimals: 2 }),
+    totalProfitLabel: formatterCurrency(efficiencyTotals.profit, { decimals: Math.abs(efficiencyTotals.profit) < 1000 ? 2 : 0, showPlus: true }),
+    averageProfitLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.profit / efficiencyCount) : 0, { decimals: 2, showPlus: true }),
+    totalNetGainLabel: formatterCurrency(efficiencyTotals.profit, { decimals: Math.abs(efficiencyTotals.profit) < 1000 ? 2 : 0, showPlus: true }),
+    averageNetGainLabel: formatterCurrency(efficiencyCount ? (efficiencyTotals.profit / efficiencyCount) : 0, { decimals: 2, showPlus: true }),
+    sourceLabel: "Source: central data table completed cutting jobs rows.",
+    formulaLabel: "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost",
+    disclaimerLabel: "Uses central data table values only.",
+    rows: efficiencyRows,
+    emptyMessage: "No valid completed cutting tasks with settings links were found in the central data table."
+  };
+  const efficiencyMathDetails = `Net gain = (Hours × (Charge Rate - Cost Rate)) - Material. Revenue ${formatterCurrency(efficiencyTotals.revenue, { decimals: 0 })}, Run cost (cost/hr × hours) ${formatterCurrency(efficiencyTotals.labor, { decimals: 0 })}, Material ${formatterCurrency(efficiencyTotals.material, { decimals: 0 })}, Net ${formatterCurrency(efficiencyTotals.profit, { decimals: 0, showPlus: true })}.`;
+  efficiencySnapshot.mathDetailsLabel = efficiencyMathDetails;
+  const totalCalcHours = efficiencyTotals.hours > 0 ? efficiencyTotals.hours : 0;
+  const defaultChargeRateForCalc = totalCalcHours > 0 ? (efficiencyTotals.revenue / totalCalcHours) : JOB_RATE_PER_HOUR;
+  const defaultCostRateForCalc = totalCalcHours > 0 ? (efficiencyTotals.labor / totalCalcHours) : JOB_BASE_COST_PER_HOUR;
+  efficiencySnapshot.calculatorDefaults = {
+    chargeRate: Number.isFinite(defaultChargeRateForCalc) ? defaultChargeRateForCalc : JOB_RATE_PER_HOUR,
+    costRate: Number.isFinite(defaultCostRateForCalc) ? defaultCostRateForCalc : JOB_BASE_COST_PER_HOUR
+  };
+  const efficiencyDisplayProfit = efficiencyTotals.profit;
+  const efficiencyDisplayAverage = efficiencyCount ? (efficiencyDisplayProfit / efficiencyCount) : 0;
+  const cuttingCard = Array.isArray(summaryCards) ? summaryCards.find(card => card && card.key === "cuttingJobs") : null;
+  if (cuttingCard){
+    cuttingCard.value = formatterCurrency(efficiencyDisplayProfit, { decimals: 0, showPlus: true });
+    cuttingCard.hint = efficiencyCount
+      ? `Average net gain ${formatterCurrency(efficiencyDisplayAverage, { decimals: 0, showPlus: true })} across ${efficiencyCount} completed job${efficiencyCount===1?"":"s"} (source: central data table).`
+      : "No cutting jobs logged yet.";
+    cuttingCard.tooltip = `Source: central data table completed rows. ${efficiencyMathDetails}`;
+  }
+  const combinedCard = Array.isArray(summaryCards) ? summaryCards.find(card => card && card.key === "combinedImpact") : null;
+  if (combinedCard){
+    combinedCard.value = formatterCurrency(efficiencyDisplayProfit - predictedAnnual, { decimals: 0, showPlus: true });
+  }
+  jobSummary.countLabel = efficiencyCount ? `${efficiencyCount} completed` : "0";
+  jobSummary.totalLabel = formatterCurrency(efficiencyDisplayProfit, { decimals: 0, showPlus: true });
+  jobSummary.averageLabel = formatterCurrency(efficiencyDisplayAverage, { decimals: 0, showPlus: true });
 
   const taskById = new Map();
   [Array.isArray(intervalTasksAll) ? intervalTasksAll : [], Array.isArray(asReqTasksAll) ? asReqTasksAll : []].forEach(list => {
@@ -15105,6 +15460,7 @@ function computeCostModel(){
     orderRequestSummary,
     maintenanceDataTable,
     cuttingJobsDataTable,
+    efficiencySnapshot,
     chartColors: COST_CHART_COLORS,
     maintenanceSeries,
     jobSeries,

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -4398,12 +4398,16 @@ function normalizeTimeEfficiencyStart(days, value){
 
 function describeTimeEfficiencyEdit(days){
   if (days === 7){
-    return "Weekly range automatically runs Monday through Sunday.";
+    return "Weekly range automatically runs Monday through Sunday. Goal mode sets whether we compare against average/day or dashboard max/day.";
   }
   if (days > 35){
-    return "Choose the start date you'd like to measure from.";
+    return "Choose the start date you'd like to measure from. Goal mode sets average/day vs max/day target math.";
   }
-  return "Choose a start date. It will snap to the first day of that month.";
+  return "Choose a start date. It will snap to the first day of that month. Goal mode sets average/day vs max/day target math.";
+}
+
+function normalizeTimeEfficiencyGoalMode(value){
+  return value === "average" ? "average" : "maximum";
 }
 
 function refreshTimeEfficiencyWidget(widget){
@@ -4441,6 +4445,30 @@ function refreshTimeEfficiencyWidget(widget){
       zeroLabel: "Goal met",
       fallback: "Goal met"
     });
+  }
+  const targetTooltip = data.goalMode === "average"
+    ? "Target-to-date from your average cut hours/day multiplied by elapsed days in this window."
+    : "Target-to-date from your dashboard max daily-hours goal multiplied by elapsed days in this window.";
+  const goalTooltip = data.goalMode === "average"
+    ? "End goal from your average cut hours/day multiplied by total eligible days in this window."
+    : "End goal from your dashboard max daily-hours goal multiplied by total eligible days in this window.";
+  const gapTargetTooltip = "Actual hours minus target-to-date hours in this window.";
+  const gapGoalTooltip = "Actual hours minus full-window end-goal hours.";
+  if (widget.metrics.target){
+    widget.metrics.target.dataset.efficiencyTooltip = targetTooltip;
+    widget.metrics.target.setAttribute("title", targetTooltip);
+  }
+  if (widget.metrics.goal){
+    widget.metrics.goal.dataset.efficiencyTooltip = goalTooltip;
+    widget.metrics.goal.setAttribute("title", goalTooltip);
+  }
+  if (widget.metrics.diffTarget){
+    widget.metrics.diffTarget.dataset.efficiencyTooltip = gapTargetTooltip;
+    widget.metrics.diffTarget.setAttribute("title", gapTargetTooltip);
+  }
+  if (widget.metrics.diffGoal){
+    widget.metrics.diffGoal.dataset.efficiencyTooltip = gapGoalTooltip;
+    widget.metrics.diffGoal.setAttribute("title", gapGoalTooltip);
   }
   if (widget.root){
     const trend = determineTimeEfficiencyTrend(data);
@@ -4513,13 +4541,8 @@ function updateTimeEfficiencyEditPanel(widget){
     }
   }
   if (widget.goalInput){
-    const configuredDaily = (typeof getConfiguredDailyHours === "function")
-      ? Number(getConfiguredDailyHours())
-      : Number(CUTTING_BASELINE_DAILY_HOURS || 0);
-    const weeklyGoal = Number.isFinite(configuredDaily) && configuredDaily > 0
-      ? configuredDaily * 7
-      : 56;
-    widget.goalInput.value = weeklyGoal.toFixed(1);
+    const modeFromConfig = normalizeTimeEfficiencyGoalMode(window?.appConfig?.timeEfficiencyGoalMode);
+    widget.goalInput.value = modeFromConfig;
   }
 }
 
@@ -4546,21 +4569,17 @@ function applyTimeEfficiencyEdit(widget){
   if (!widget) return;
   const days = Number(widget.currentDays) || Number(widget.defaultDays) || 7;
   if (widget.goalInput){
-    const weeklyGoal = Number(widget.goalInput.value);
-    if (Number.isFinite(weeklyGoal) && weeklyGoal > 0){
-      const dailyGoal = Math.max(0.1, Math.round((weeklyGoal / 7) * 100) / 100);
-      const currentConfig = (typeof normalizeAppConfig === "function")
-        ? normalizeAppConfig(window.appConfig)
-        : (window.appConfig || {});
-      const nextConfig = {
-        ...currentConfig,
-        predictionMode: "fixed",
-        dailyHours: dailyGoal
-      };
-      if (typeof setAppConfig === "function") setAppConfig(nextConfig);
-      else window.appConfig = nextConfig;
-      if (typeof persist === "function") persist();
-    }
+    const selectedMode = normalizeTimeEfficiencyGoalMode(widget.goalInput.value);
+    const currentConfig = (typeof normalizeAppConfig === "function")
+      ? normalizeAppConfig(window.appConfig)
+      : (window.appConfig || {});
+    const nextConfig = {
+      ...currentConfig,
+      timeEfficiencyGoalMode: selectedMode
+    };
+    if (typeof setAppConfig === "function") setAppConfig(nextConfig);
+    else window.appConfig = nextConfig;
+    if (typeof persist === "function") persist();
   }
   if (!widget.editInput || widget.editInput.disabled){
     toggleTimeEfficiencyEditPanel(widget, false);
@@ -4726,7 +4745,7 @@ function setupTimeEfficiencyWidget(root){
     applyBtn: root.querySelector("[data-efficiency-apply]") || root.querySelector("[data-efficiency-save]") || null,
     cancelBtn: root.querySelector("[data-efficiency-cancel]") || null,
     editNote: root.querySelector("[data-efficiency-edit-note]") || null,
-    goalInput: root.querySelector("[data-efficiency-goal-input]") || null
+    goalInput: root.querySelector("[data-efficiency-goal-mode-input]") || null
   };
   toggles.forEach(btn => {
     btn.addEventListener("click", ()=> selectTimeEfficiencyRange(widget, btn));

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -4542,7 +4542,7 @@ function toggleTimeEfficiencyEditPanel(widget, show){
   }
 }
 
-  function applyTimeEfficiencyEdit(widget){
+function applyTimeEfficiencyEdit(widget){
   if (!widget) return;
   const days = Number(widget.currentDays) || Number(widget.defaultDays) || 7;
   if (widget.goalInput){
@@ -4590,10 +4590,111 @@ function toggleTimeEfficiencyEditPanel(widget, show){
   refreshTimeEfficiencyWidgets();
 }
 
+let timeEfficiencyTooltipEl = null;
+let activeTimeEfficiencyTooltipTarget = null;
+let timeEfficiencyTooltipViewportBound = false;
+
+function ensureTimeEfficiencyTooltip(){
+  if (timeEfficiencyTooltipEl instanceof HTMLElement && document.body.contains(timeEfficiencyTooltipEl)){
+    return timeEfficiencyTooltipEl;
+  }
+  const el = document.createElement("div");
+  el.className = "time-efficiency-tooltip";
+  el.setAttribute("role", "tooltip");
+  el.hidden = true;
+  document.body.appendChild(el);
+  timeEfficiencyTooltipEl = el;
+  if (!timeEfficiencyTooltipViewportBound){
+    const handleViewportChange = ()=>{
+      if (activeTimeEfficiencyTooltipTarget instanceof HTMLElement){
+        positionTimeEfficiencyTooltip(activeTimeEfficiencyTooltipTarget);
+      }
+    };
+    window.addEventListener("scroll", handleViewportChange, true);
+    window.addEventListener("resize", handleViewportChange);
+    timeEfficiencyTooltipViewportBound = true;
+  }
+  return el;
+}
+
+function hideTimeEfficiencyTooltip(){
+  if (timeEfficiencyTooltipEl instanceof HTMLElement){
+    timeEfficiencyTooltipEl.hidden = true;
+    timeEfficiencyTooltipEl.textContent = "";
+    delete timeEfficiencyTooltipEl.dataset.visible;
+    delete timeEfficiencyTooltipEl.dataset.placement;
+  }
+  if (activeTimeEfficiencyTooltipTarget instanceof HTMLElement){
+    activeTimeEfficiencyTooltipTarget.removeAttribute("aria-describedby");
+  }
+  activeTimeEfficiencyTooltipTarget = null;
+}
+
+function positionTimeEfficiencyTooltip(target){
+  if (!(target instanceof HTMLElement)) return;
+  const tooltip = ensureTimeEfficiencyTooltip();
+  const rect = target.getBoundingClientRect();
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+  const gap = 10;
+  tooltip.hidden = false;
+  tooltip.style.left = "0px";
+  tooltip.style.top = "0px";
+  const tipRect = tooltip.getBoundingClientRect();
+  const centerX = rect.left + (rect.width / 2);
+  let left = centerX - (tipRect.width / 2);
+  left = Math.max(8, Math.min(left, Math.max(8, viewportWidth - tipRect.width - 8)));
+  const hasSpaceAbove = rect.top >= (tipRect.height + gap + 6);
+  const placement = hasSpaceAbove ? "above" : "below";
+  const top = hasSpaceAbove
+    ? (rect.top - tipRect.height - gap)
+    : (rect.bottom + gap);
+  tooltip.style.left = `${Math.round(left)}px`;
+  tooltip.style.top = `${Math.round(Math.max(8, Math.min(top, Math.max(8, viewportHeight - tipRect.height - 8))))}px`;
+  tooltip.dataset.visible = "true";
+  tooltip.dataset.placement = placement;
+}
+
+function showTimeEfficiencyTooltip(target){
+  if (!(target instanceof HTMLElement)) return;
+  const message = String(target.dataset.efficiencyTooltip || target.getAttribute("title") || "").trim();
+  if (!message) return;
+  const tooltip = ensureTimeEfficiencyTooltip();
+  if (!tooltip.id){
+    tooltip.id = "timeEfficiencyTooltip";
+  }
+  activeTimeEfficiencyTooltipTarget = target;
+  target.setAttribute("aria-describedby", tooltip.id);
+  tooltip.textContent = message;
+  positionTimeEfficiencyTooltip(target);
+}
+
+function bindTimeEfficiencyMetricTooltips(root){
+  if (!(root instanceof HTMLElement)) return;
+  const metricEls = Array.from(root.querySelectorAll("[data-efficiency-tooltip]"));
+  metricEls.forEach(el => {
+    if (!(el instanceof HTMLElement) || el.dataset.efficiencyTooltipBound === "1") return;
+    const show = ()=> showTimeEfficiencyTooltip(el);
+    const hide = ()=> hideTimeEfficiencyTooltip();
+    const update = ()=> {
+      if (activeTimeEfficiencyTooltipTarget === el){
+        positionTimeEfficiencyTooltip(el);
+      }
+    };
+    el.addEventListener("mouseenter", show);
+    el.addEventListener("focus", show);
+    el.addEventListener("mouseleave", hide);
+    el.addEventListener("blur", hide);
+    el.addEventListener("mousemove", update);
+    el.dataset.efficiencyTooltipBound = "1";
+  });
+}
+
 function setupTimeEfficiencyWidget(root){
   if (!(root instanceof HTMLElement)) return;
   if (root.dataset.timeEfficiencyBound === "1"){
     refreshTimeEfficiencyWidgets();
+    bindTimeEfficiencyMetricTooltips(root);
     return;
   }
   const toggles = Array.from(root.querySelectorAll("[data-efficiency-range]"));
@@ -4642,6 +4743,7 @@ function setupTimeEfficiencyWidget(root){
   if (widget.cancelBtn){
     widget.cancelBtn.addEventListener("click", ()=> toggleTimeEfficiencyEditPanel(widget, false));
   }
+  bindTimeEfficiencyMetricTooltips(root);
   timeEfficiencyWidgets.push(widget);
   root.dataset.timeEfficiencyBound = "1";
   refreshTimeEfficiencyWidget(widget);

--- a/js/views.js
+++ b/js/views.js
@@ -165,31 +165,31 @@ function viewDashboard(){
           <div class="time-efficiency-metrics" role="status" aria-live="polite">
             <div class="time-efficiency-metric">
               <span class="label">Actual hours</span>
-              <span class="value" data-efficiency-actual title="Sum of logged cutting hours in the selected date window.">—</span>
+              <span class="value" data-efficiency-actual data-efficiency-tooltip="Sum of logged cutting hours in the selected date window." title="Sum of logged cutting hours in the selected date window.">—</span>
             </div>
             <div class="time-efficiency-metric">
               <span class="label">Current target</span>
-              <span class="value" data-efficiency-target title="Target-to-date: weekly goal converted to daily goal and multiplied by elapsed days in this window.">—</span>
+              <span class="value" data-efficiency-target data-efficiency-tooltip="Target-to-date: weekly goal converted to daily goal and multiplied by elapsed days in this window." title="Target-to-date: weekly goal converted to daily goal and multiplied by elapsed days in this window.">—</span>
             </div>
             <div class="time-efficiency-metric">
               <span class="label">Gap vs target</span>
-                <span class="value" data-efficiency-gap-target title="Actual hours minus target-to-date hours in this window.">—</span>
+                <span class="value" data-efficiency-gap-target data-efficiency-tooltip="Actual hours minus target-to-date hours in this window." title="Actual hours minus target-to-date hours in this window.">—</span>
             </div>
             <div class="time-efficiency-metric">
               <span class="label">End goal</span>
-                <span class="value" data-efficiency-goal title="End goal: full-window goal hours using your configured weekly goal.">—</span>
+                <span class="value" data-efficiency-goal data-efficiency-tooltip="End goal: full-window goal hours using your configured weekly goal." title="End goal: full-window goal hours using your configured weekly goal.">—</span>
             </div>
             <div class="time-efficiency-metric">
               <span class="label">Avg usage/day</span>
-                <span class="value" data-efficiency-average title="Average logged cutting hours per day across the selected window.">—</span>
+                <span class="value" data-efficiency-average data-efficiency-tooltip="Average logged cutting hours per day across the selected window." title="Average logged cutting hours per day across the selected window.">—</span>
             </div>
             <div class="time-efficiency-metric">
               <span class="label">Gap vs goal</span>
-                <span class="value" data-efficiency-gap-goal title="Actual hours minus full-window goal hours.">—</span>
+                <span class="value" data-efficiency-gap-goal data-efficiency-tooltip="Actual hours minus full-window goal hours." title="Actual hours minus full-window goal hours.">—</span>
             </div>
             <div class="time-efficiency-metric">
               <span class="label">Efficiency (to date)</span>
-                <span class="value" data-efficiency-percent title="Efficiency to date: actual hours divided by target-to-date hours.">—</span>
+                <span class="value" data-efficiency-percent data-efficiency-tooltip="Efficiency to date: actual hours divided by target-to-date hours." title="Efficiency to date: actual hours divided by target-to-date hours.">—</span>
             </div>
           </div>
           <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
@@ -2326,13 +2326,13 @@ function viewCosts(model){
             <p class="small muted time-efficiency-edit-note" data-efficiency-edit-note></p>
           </div>
           <div class="time-efficiency-metrics" role="status" aria-live="polite">
-            <div class="time-efficiency-metric"><span class="label">Actual hours</span><span class="value" data-efficiency-actual title="Sum of logged cutting hours in the selected date window.">—</span></div>
-            <div class="time-efficiency-metric"><span class="label">Current target</span><span class="value" data-efficiency-target title="Target-to-date: weekly goal converted to daily goal and multiplied by elapsed days in this window.">—</span></div>
-            <div class="time-efficiency-metric"><span class="label">Gap vs target</span><span class="value" data-efficiency-gap-target title="Actual hours minus target-to-date hours in this window.">—</span></div>
-            <div class="time-efficiency-metric"><span class="label">End goal</span><span class="value" data-efficiency-goal title="End goal: full-window goal hours using your configured weekly goal.">—</span></div>
-            <div class="time-efficiency-metric"><span class="label">Avg usage/day</span><span class="value" data-efficiency-average title="Average logged cutting hours per day across the selected window.">—</span></div>
-            <div class="time-efficiency-metric"><span class="label">Gap vs goal</span><span class="value" data-efficiency-gap-goal title="Actual hours minus full-window goal hours.">—</span></div>
-            <div class="time-efficiency-metric"><span class="label">Efficiency (to date)</span><span class="value" data-efficiency-percent title="Efficiency to date: actual hours divided by target-to-date hours.">—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Actual hours</span><span class="value" data-efficiency-actual data-efficiency-tooltip="Sum of logged cutting hours in the selected date window." title="Sum of logged cutting hours in the selected date window.">—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Current target</span><span class="value" data-efficiency-target data-efficiency-tooltip="Target-to-date: weekly goal converted to daily goal and multiplied by elapsed days in this window." title="Target-to-date: weekly goal converted to daily goal and multiplied by elapsed days in this window.">—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Gap vs target</span><span class="value" data-efficiency-gap-target data-efficiency-tooltip="Actual hours minus target-to-date hours in this window." title="Actual hours minus target-to-date hours in this window.">—</span></div>
+            <div class="time-efficiency-metric"><span class="label">End goal</span><span class="value" data-efficiency-goal data-efficiency-tooltip="End goal: full-window goal hours using your configured weekly goal." title="End goal: full-window goal hours using your configured weekly goal.">—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Avg usage/day</span><span class="value" data-efficiency-average data-efficiency-tooltip="Average logged cutting hours per day across the selected window." title="Average logged cutting hours per day across the selected window.">—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Gap vs goal</span><span class="value" data-efficiency-gap-goal data-efficiency-tooltip="Actual hours minus full-window goal hours." title="Actual hours minus full-window goal hours.">—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Efficiency (to date)</span><span class="value" data-efficiency-percent data-efficiency-tooltip="Efficiency to date: actual hours divided by target-to-date hours." title="Efficiency to date: actual hours divided by target-to-date hours.">—</span></div>
           </div>
           <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
           <p class="small muted">How this works: <strong>Target</strong> = your weekly goal prorated by elapsed days in the selected window. <strong>End goal</strong> = full-window goal. So you can be ahead of target today while still behind the full-window goal.</p>

--- a/js/views.js
+++ b/js/views.js
@@ -152,8 +152,11 @@ function viewDashboard(){
                   <input type="date" data-efficiency-start-input>
                 </label>
                 <label class="time-efficiency-edit-field">
-                  <span class="time-efficiency-edit-label">Goal / week (hr, drives target)</span>
-                  <input type="number" min="1" step="0.5" data-efficiency-goal-input>
+                  <span class="time-efficiency-edit-label">Weekly goal mode</span>
+                  <select data-efficiency-goal-mode-input>
+                    <option value="average">Go off average</option>
+                    <option value="maximum">Go off maximum</option>
+                  </select>
                 </label>
                 <div class="time-efficiency-edit-actions">
                 <button type="button" class="time-efficiency-edit-apply" data-efficiency-apply>Apply</button>
@@ -193,7 +196,7 @@ function viewDashboard(){
             </div>
           </div>
           <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
-          <p class="small muted">How this works: <strong>Target</strong> = your weekly goal prorated by elapsed days in the selected window. <strong>End goal</strong> = full-window goal. So you can be ahead of target today while still behind the full-window goal.</p>
+          <p class="small muted">How this works: <strong>Go off average</strong> uses your average cut hours/day. <strong>Go off maximum</strong> uses your dashboard daily-hours goal (default 8 hr/day) and respects the weekend include/exclude setting.</p>
           <p class="small muted">Baseline adapts to your average logged hours per day.</p>
         </div>
       </div>
@@ -2315,8 +2318,11 @@ function viewCosts(model){
                 <input type="date" data-efficiency-start-input>
               </label>
               <label class="time-efficiency-edit-field">
-                <span class="time-efficiency-edit-label">Goal / week (hr, drives target)</span>
-                <input type="number" min="1" step="0.5" data-efficiency-goal-input>
+                <span class="time-efficiency-edit-label">Weekly goal mode</span>
+                <select data-efficiency-goal-mode-input>
+                  <option value="average">Go off average</option>
+                  <option value="maximum">Go off maximum</option>
+                </select>
               </label>
               <div class="time-efficiency-edit-actions">
                 <button type="button" class="time-efficiency-edit-apply" data-efficiency-apply>Apply</button>
@@ -2335,7 +2341,7 @@ function viewCosts(model){
             <div class="time-efficiency-metric"><span class="label">Efficiency (to date)</span><span class="value" data-efficiency-percent data-efficiency-tooltip="Efficiency to date: actual hours divided by target-to-date hours." title="Efficiency to date: actual hours divided by target-to-date hours.">—</span></div>
           </div>
           <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
-          <p class="small muted">How this works: <strong>Target</strong> = your weekly goal prorated by elapsed days in the selected window. <strong>End goal</strong> = full-window goal. So you can be ahead of target today while still behind the full-window goal.</p>
+          <p class="small muted">How this works: <strong>Go off average</strong> uses your average cut hours/day. <strong>Go off maximum</strong> uses your dashboard daily-hours goal (default 8 hr/day) and respects the weekend include/exclude setting.</p>
           <p class="small muted">Baseline adapts to your average logged hours per day.</p>
         </div>
         <div class="cost-efficiency-calculator" data-efficiency-calc>

--- a/js/views.js
+++ b/js/views.js
@@ -142,7 +142,7 @@ function viewDashboard(){
               <div class="time-efficiency-toggles" role="tablist">
                 ${efficiencyButtons}
               </div>
-              <button type="button" class="time-efficiency-edit-btn" data-efficiency-edit>Edit range</button>
+              <button type="button" class="time-efficiency-edit-btn" data-efficiency-edit>Edit tracking</button>
             </div>
           </div>
           <div class="time-efficiency-edit" data-efficiency-edit-panel hidden>
@@ -2308,7 +2308,7 @@ function viewCosts(model){
               <div class="time-efficiency-toggles" role="tablist">
                 ${efficiencyButtons}
               </div>
-              <button type="button" class="time-efficiency-edit-btn" data-efficiency-edit>Edit range</button>
+              <button type="button" class="time-efficiency-edit-btn" data-efficiency-edit>Edit tracking</button>
             </div>
           </div>
           <div class="time-efficiency-edit" data-efficiency-edit-panel hidden>
@@ -2381,8 +2381,8 @@ function viewCosts(model){
           <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
           <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Total net gain</span><span data-efficiency-summary-total>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</span></div>
           <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Avg net gain / row</span><span data-efficiency-summary-average>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
-          <div><span class="label">Total run cost</span><span>${esc(efficiencySnapshot.totalCostLabel || "$0.00")}</span></div>
-          <div><span class="label">Avg run cost / row</span><span>${esc(efficiencySnapshot.averageCostLabel || "$0.00")}</span></div>
+          <div><span class="label">Total run cost</span><span data-efficiency-summary-cost>${esc(efficiencySnapshot.totalCostLabel || "$0.00")}</span></div>
+          <div><span class="label">Avg run cost / row</span><span data-efficiency-summary-cost-average>${esc(efficiencySnapshot.averageCostLabel || "$0.00")}</span></div>
         </div>
         <p class="small muted" title="${esc(`${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || "Uses central data table values only."}`)}" data-efficiency-source-note>${esc(efficiencySnapshot.sourceLabel || "Source: central data table completed cutting jobs rows.")} ${esc(efficiencySnapshot.disclaimerLabel || "Uses central data table values only.")}</p>
         <div class="cost-weekly-table-wrap">

--- a/js/views.js
+++ b/js/views.js
@@ -152,7 +152,7 @@ function viewDashboard(){
                   <input type="date" data-efficiency-start-input>
                 </label>
                 <label class="time-efficiency-edit-field">
-                  <span class="time-efficiency-edit-label">Goal / week (hr)</span>
+                  <span class="time-efficiency-edit-label">Goal / week (hr, drives target)</span>
                   <input type="number" min="1" step="0.5" data-efficiency-goal-input>
                 </label>
                 <div class="time-efficiency-edit-actions">
@@ -193,6 +193,7 @@ function viewDashboard(){
             </div>
           </div>
           <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
+          <p class="small muted">How this works: <strong>Target</strong> = your weekly goal prorated by elapsed days in the selected window. <strong>End goal</strong> = full-window goal. So you can be ahead of target today while still behind the full-window goal.</p>
           <p class="small muted">Baseline adapts to your average logged hours per day.</p>
         </div>
       </div>
@@ -2314,7 +2315,7 @@ function viewCosts(model){
                 <input type="date" data-efficiency-start-input>
               </label>
               <label class="time-efficiency-edit-field">
-                <span class="time-efficiency-edit-label">Goal / week (hr)</span>
+                <span class="time-efficiency-edit-label">Goal / week (hr, drives target)</span>
                 <input type="number" min="1" step="0.5" data-efficiency-goal-input>
               </label>
               <div class="time-efficiency-edit-actions">
@@ -2334,17 +2335,18 @@ function viewCosts(model){
             <div class="time-efficiency-metric"><span class="label">Efficiency (to date)</span><span class="value" data-efficiency-percent>—</span></div>
           </div>
           <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
+          <p class="small muted">How this works: <strong>Target</strong> = your weekly goal prorated by elapsed days in the selected window. <strong>End goal</strong> = full-window goal. So you can be ahead of target today while still behind the full-window goal.</p>
           <p class="small muted">Baseline adapts to your average logged hours per day.</p>
         </div>
         <div class="cost-efficiency-calculator" data-efficiency-calc>
           <div class="cost-efficiency-calculator-row">
             <label>
               <span class="label">Charge / hr (temporary)</span>
-              <input type="number" step="1" min="0" value="${esc(String(Number(calculatorDefaults.chargeRate) || 0))}" data-efficiency-calc-charge>
+              <input type="number" step="1" min="0" value="${esc((Number.isFinite(Number(calculatorDefaults.chargeRate)) ? Number(calculatorDefaults.chargeRate) : 0).toFixed(2))}" data-efficiency-calc-charge>
             </label>
             <label>
               <span class="label">Cost / hr (temporary)</span>
-              <input type="number" step="1" min="0" value="${esc(String(Number(calculatorDefaults.costRate) || 0))}" data-efficiency-calc-cost>
+              <input type="number" step="1" min="0" value="${esc((Number.isFinite(Number(calculatorDefaults.costRate)) ? Number(calculatorDefaults.costRate) : 0).toFixed(2))}" data-efficiency-calc-cost>
             </label>
             <label>
               <span class="label">Time range</span>

--- a/js/views.js
+++ b/js/views.js
@@ -165,31 +165,31 @@ function viewDashboard(){
           <div class="time-efficiency-metrics" role="status" aria-live="polite">
             <div class="time-efficiency-metric">
               <span class="label">Actual hours</span>
-              <span class="value" data-efficiency-actual>—</span>
+              <span class="value" data-efficiency-actual title="Sum of logged cutting hours in the selected date window.">—</span>
             </div>
             <div class="time-efficiency-metric">
               <span class="label">Current target</span>
-              <span class="value" data-efficiency-target>—</span>
+              <span class="value" data-efficiency-target title="Target-to-date: weekly goal converted to daily goal and multiplied by elapsed days in this window.">—</span>
             </div>
             <div class="time-efficiency-metric">
               <span class="label">Gap vs target</span>
-              <span class="value" data-efficiency-gap-target>—</span>
+                <span class="value" data-efficiency-gap-target title="Actual hours minus target-to-date hours in this window.">—</span>
             </div>
             <div class="time-efficiency-metric">
               <span class="label">End goal</span>
-              <span class="value" data-efficiency-goal>—</span>
+                <span class="value" data-efficiency-goal title="End goal: full-window goal hours using your configured weekly goal.">—</span>
             </div>
             <div class="time-efficiency-metric">
               <span class="label">Avg usage/day</span>
-              <span class="value" data-efficiency-average>—</span>
+                <span class="value" data-efficiency-average title="Average logged cutting hours per day across the selected window.">—</span>
             </div>
             <div class="time-efficiency-metric">
               <span class="label">Gap vs goal</span>
-              <span class="value" data-efficiency-gap-goal>—</span>
+                <span class="value" data-efficiency-gap-goal title="Actual hours minus full-window goal hours.">—</span>
             </div>
             <div class="time-efficiency-metric">
               <span class="label">Efficiency (to date)</span>
-              <span class="value" data-efficiency-percent>—</span>
+                <span class="value" data-efficiency-percent title="Efficiency to date: actual hours divided by target-to-date hours.">—</span>
             </div>
           </div>
           <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
@@ -2326,13 +2326,13 @@ function viewCosts(model){
             <p class="small muted time-efficiency-edit-note" data-efficiency-edit-note></p>
           </div>
           <div class="time-efficiency-metrics" role="status" aria-live="polite">
-            <div class="time-efficiency-metric"><span class="label">Actual hours</span><span class="value" data-efficiency-actual>—</span></div>
-            <div class="time-efficiency-metric"><span class="label">Current target</span><span class="value" data-efficiency-target>—</span></div>
-            <div class="time-efficiency-metric"><span class="label">Gap vs target</span><span class="value" data-efficiency-gap-target>—</span></div>
-            <div class="time-efficiency-metric"><span class="label">End goal</span><span class="value" data-efficiency-goal>—</span></div>
-            <div class="time-efficiency-metric"><span class="label">Avg usage/day</span><span class="value" data-efficiency-average>—</span></div>
-            <div class="time-efficiency-metric"><span class="label">Gap vs goal</span><span class="value" data-efficiency-gap-goal>—</span></div>
-            <div class="time-efficiency-metric"><span class="label">Efficiency (to date)</span><span class="value" data-efficiency-percent>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Actual hours</span><span class="value" data-efficiency-actual title="Sum of logged cutting hours in the selected date window.">—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Current target</span><span class="value" data-efficiency-target title="Target-to-date: weekly goal converted to daily goal and multiplied by elapsed days in this window.">—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Gap vs target</span><span class="value" data-efficiency-gap-target title="Actual hours minus target-to-date hours in this window.">—</span></div>
+            <div class="time-efficiency-metric"><span class="label">End goal</span><span class="value" data-efficiency-goal title="End goal: full-window goal hours using your configured weekly goal.">—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Avg usage/day</span><span class="value" data-efficiency-average title="Average logged cutting hours per day across the selected window.">—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Gap vs goal</span><span class="value" data-efficiency-gap-goal title="Actual hours minus full-window goal hours.">—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Efficiency (to date)</span><span class="value" data-efficiency-percent title="Efficiency to date: actual hours divided by target-to-date hours.">—</span></div>
           </div>
           <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
           <p class="small muted">How this works: <strong>Target</strong> = your weekly goal prorated by elapsed days in the selected window. <strong>End goal</strong> = full-window goal. So you can be ahead of target today while still behind the full-window goal.</p>

--- a/js/views.js
+++ b/js/views.js
@@ -146,12 +146,16 @@ function viewDashboard(){
             </div>
           </div>
           <div class="time-efficiency-edit" data-efficiency-edit-panel hidden>
-            <div class="time-efficiency-edit-row">
-              <label class="time-efficiency-edit-field">
-                <span class="time-efficiency-edit-label">Start date</span>
-                <input type="date" data-efficiency-start-input>
-              </label>
-              <div class="time-efficiency-edit-actions">
+              <div class="time-efficiency-edit-row">
+                <label class="time-efficiency-edit-field">
+                  <span class="time-efficiency-edit-label">Start date</span>
+                  <input type="date" data-efficiency-start-input>
+                </label>
+                <label class="time-efficiency-edit-field">
+                  <span class="time-efficiency-edit-label">Goal / week (hr)</span>
+                  <input type="number" min="1" step="0.5" data-efficiency-goal-input>
+                </label>
+                <div class="time-efficiency-edit-actions">
                 <button type="button" class="time-efficiency-edit-apply" data-efficiency-apply>Apply</button>
                 <button type="button" class="time-efficiency-edit-cancel" data-efficiency-cancel>Cancel</button>
               </div>
@@ -1175,28 +1179,17 @@ function ensureTaskCategories(){
 function viewCosts(model){
   const data = model || {};
   const esc = (str)=> String(str ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
-  const efficiencyWindows = (Array.isArray(TIME_EFFICIENCY_WINDOWS) && TIME_EFFICIENCY_WINDOWS.length)
-    ? TIME_EFFICIENCY_WINDOWS
-    : [
-        { key: "7d", label: "1W", days: 7, description: "Past 7 days" },
-        { key: "30d", label: "1M", days: 30, description: "Past 30 days" },
-        { key: "90d", label: "3M", days: 90, description: "Past 3 months" },
-        { key: "182d", label: "6M", days: 182, description: "Past 6 months" },
-        { key: "365d", label: "1Y", days: 365, description: "Past year" }
-      ];
-  const efficiencyButtons = efficiencyWindows.map((win, index) => {
-    const days = Number(win?.days) || 0;
-    const label = esc(win?.label ?? `${days || ""}`);
-    const description = esc(win?.description ?? (days ? `Past ${days} days` : "Selected window"));
-    const isActive = index === 0;
-    return `
-      <button type="button" class="time-efficiency-toggle${isActive ? " is-active" : ""}" data-efficiency-range="${esc(String(days))}" data-efficiency-range-label="${description}" aria-pressed="${isActive ? "true" : "false"}" title="${description}">
-        ${label}
-      </button>
-    `;
-  }).join("");
+  const efficiencyWindows = [
+    { key: "7d", label: "1W", days: 7, description: "Past 7 days" },
+    { key: "30d", label: "1M", days: 30, description: "Past 30 days" },
+    { key: "90d", label: "3M", days: 90, description: "Past 3 months" },
+    { key: "182d", label: "6M", days: 182, description: "Past 6 months" },
+    { key: "365d", label: "1Y", days: 365, description: "Past year" }
+  ];
+  const efficiencyButtons = efficiencyWindows.map((win, index) => `
+    <button type="button" class="time-efficiency-toggle${index === 0 ? " is-active" : ""}" data-efficiency-range="${esc(String(win.days))}" data-efficiency-range-label="${esc(win.description)}" aria-pressed="${index === 0 ? "true" : "false"}" title="${esc(win.description)}">${esc(win.label)}</button>
+  `).join("");
   const defaultEfficiencyDescription = esc(efficiencyWindows[0]?.description || "Past 7 days");
-
   const cards = Array.isArray(data.summaryCards) ? data.summaryCards : [];
   const timeframeRows = Array.isArray(data.timeframeRows) ? data.timeframeRows : [];
   const historyRows = Array.isArray(data.historyRows) ? data.historyRows : [];
@@ -1229,6 +1222,9 @@ function viewCosts(model){
       .filter(Boolean)
   )).sort((a, b) => a.localeCompare(b));
   const cuttingJobsDataTable = Array.isArray(data.cuttingJobsDataTable) ? data.cuttingJobsDataTable : [];
+  const efficiencySnapshot = data.efficiencySnapshot || {};
+  const efficiencyRows = Array.isArray(efficiencySnapshot.rows) ? efficiencySnapshot.rows : [];
+  const calculatorDefaults = efficiencySnapshot.calculatorDefaults || {};
   const cuttingJobCategoryOptions = Array.from(new Set(
     cuttingJobsDataTable
       .map(row => ({ id: String(row?.categoryId || ""), label: String(row?.categoryLabel || "") }))
@@ -1564,16 +1560,20 @@ function viewCosts(model){
     if (key){
       attrParts.push(`data-card-key="${esc(key)}"`);
     }
+    if (card && card.tooltip){
+      attrParts.push(`title="${esc(card.tooltip)}"`);
+    }
     if (isForecast){
       attrParts.push("role=\"button\"");
       attrParts.push("tabindex=\"0\"");
     }
     if (isCutting){
       attrParts.push("data-cost-cutting-card=\"\"");
-      attrParts.push("role=\"link\"");
-      attrParts.push("tabindex=\"0\"");
     }
     const attr = attrParts.join(" ");
+    const cuttingOpenBtn = isCutting
+      ? `<button type="button" class="btn secondary" data-open-efficiency-snapshot>Open calculator</button>`
+      : "";
     return `
               <div ${attr}>
                 <div class="cost-card-icon">${esc(card.icon || "")}</div>
@@ -1581,6 +1581,7 @@ function viewCosts(model){
                   <div class="cost-card-title">${esc(card.title || "")}</div>
                   <div class="cost-card-value">${esc(card.value || "")}</div>
                   <div class="cost-card-hint">${esc(card.hint || "")}</div>
+                  ${cuttingOpenBtn}
                 </div>
               </div>
             `;
@@ -2051,6 +2052,7 @@ function viewCosts(model){
               <div class="cost-data-center-tabs" role="tablist" aria-label="Data center tables">
                 <button type="button" class="cost-data-center-tab is-active" data-dc-tab="maintenance" role="tab" aria-selected="true">Maintenance Tasks</button>
                 <button type="button" class="cost-data-center-tab" data-dc-tab="cutting" role="tab" aria-selected="false">Completed Cutting Jobs</button>
+                <button type="button" class="cost-data-center-tab" data-dc-tab="efficiency" role="tab" aria-selected="false">Efficiency Metrics</button>
               </div>
               <div class="cost-data-center-panel-content" data-dc-panel="maintenance">
               <div class="cost-data-center-search">
@@ -2187,6 +2189,32 @@ function viewCosts(model){
                 </table>
                 ` : `<p class="small muted">No completed cutting jobs yet.</p>`}
               </div>
+              <div class="cost-data-center-panel-content" data-dc-panel="efficiency" hidden>
+                ${efficiencyRows.length ? `
+                <div class="cost-jobs-summary">
+                  <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
+                  <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
+                  <div><span class="label">Total net gain</span><span>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</span></div>
+                  <div><span class="label">Avg net gain / row</span><span>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
+                </div>
+                <table class="cost-table" style="margin-top:10px">
+                  <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Run cost</th><th>Total cost</th><th>Net gain</th></tr></thead>
+                  <tbody>
+                    ${efficiencyRows.map(row => `
+                      <tr>
+                        <td>${esc(row.taskName || "Completed task")}</td>
+                        <td>${esc(row.dateLabel || "—")}</td>
+                        <td>${esc(row.hoursLabel || "0 hr")}</td>
+                        <td>${esc(row.partCostLabel || "$0.00")}</td>
+                        <td>${esc(row.laborCostLabel || "$0.00")}</td>
+                        <td>${esc(row.totalCostLabel || "$0.00")}</td>
+                        <td>${esc(row.netGainLabel || "$0.00")}</td>
+                      </tr>
+                    `).join("")}
+                  </tbody>
+                </table>
+                ` : `<p class="small muted">No efficiency rows found in the central data table.</p>`}
+              </div>
             </div>
           </div>
         </div>
@@ -2222,15 +2250,15 @@ function viewCosts(model){
             <button type="button" class="btn secondary" data-cost-weekly-export ${selectedWeeklyReport ? "" : "disabled"}>Export week (Excel)</button>
           </div>
           <div class="cost-weekly-summary">
-            <div><span class="label">Cuts total</span><span>${esc(selectedWeeklyReport?.totalCutCostLabel || "$0")}</span></div>
-            <div><span class="label">Maintenance total</span><span>${esc(selectedWeeklyReport?.totalMaintenanceCostLabel || "$0")}</span></div>
+            <div><span class="label">Cuts total profit</span><span>${esc(selectedWeeklyReport?.totalCutProfitLabel || selectedWeeklyReport?.totalCutCostLabel || "$0")}</span></div>
+            <div><span class="label">Maintenance total loss</span><span>${esc(selectedWeeklyReport?.totalMaintenanceLossLabel || selectedWeeklyReport?.totalMaintenanceCostLabel || "$0")}</span></div>
             <div><span class="label">Cutting time</span><span>${esc(selectedWeeklyReport?.totalCutHoursLabel || "0 hr")}</span></div>
           </div>
           <div class="cost-weekly-grid">
             <details class="cost-weekly-section" open>
               <summary>Cuts completed</summary>
               <div class="cost-weekly-section-totals">
-                <span><strong>Cuts related total:</strong> ${esc(selectedWeeklyReport?.totalCutCostLabel || "$0")}</span>
+                <span><strong>Cuts related total profit:</strong> ${esc(selectedWeeklyReport?.totalCutProfitLabel || selectedWeeklyReport?.totalCutCostLabel || "$0")}</span>
                 <span><strong>Total cut time:</strong> ${esc(selectedWeeklyReport?.totalCutHoursLabel || "0 hr")}</span>
               </div>
               <div class="cost-weekly-table-wrap">
@@ -2243,7 +2271,7 @@ function viewCosts(model){
             <details class="cost-weekly-section" open>
               <summary>Maintenance completed</summary>
               <div class="cost-weekly-section-totals">
-                <span><strong>Maintenance related total:</strong> ${esc(selectedWeeklyReport?.totalMaintenanceCostLabel || "$0")}</span>
+                <span><strong>Maintenance related total loss:</strong> ${esc(selectedWeeklyReport?.totalMaintenanceLossLabel || selectedWeeklyReport?.totalMaintenanceCostLabel || "$0")}</span>
               </div>
               <div class="cost-weekly-table-wrap">
                 <table class="cost-table">
@@ -2257,94 +2285,134 @@ function viewCosts(model){
         </div>
       </div>
 
-      <div class="dashboard-window" data-cost-window="efficiency">
-        <div class="block" data-cost-jobs-history role="link" tabindex="0">
-          <h3>Cutting Job Efficiency Snapshot</h3>
-          <div class="time-efficiency-inline" id="costTimeEfficiency">
-            <div class="time-efficiency-inline-header">
-              <span class="time-efficiency-inline-title">Cutting time efficiency</span>
-              <div class="time-efficiency-controls">
-                <div class="time-efficiency-toggles" role="tablist">
-                  ${efficiencyButtons}
-                </div>
-                <button type="button" class="time-efficiency-edit-btn" data-efficiency-edit>Edit range</button>
+
+    </div>
+  </div>
+
+  <div class="cost-data-center-modal" id="efficiencySnapshotModal" data-efficiency-snapshot-modal hidden>
+    <div class="cost-data-center-backdrop" data-close-efficiency-snapshot></div>
+    <div class="cost-data-center-panel" role="dialog" aria-modal="true" aria-label="Cutting Job Efficiency Snapshot" style="max-width:1100px;border-radius:16px;">
+      <div class="cost-data-center-header" style="border-radius:16px 16px 0 0;">
+        <h4>Cutting Job Efficiency Snapshot</h4>
+        <button type="button" class="btn ghost" data-close-efficiency-snapshot>Close</button>
+      </div>
+      <div class="cost-data-center-body">
+        <div class="time-efficiency-inline" id="costTimeEfficiency">
+          <div class="time-efficiency-inline-header">
+            <span class="time-efficiency-inline-title">Cutting time efficiency</span>
+            <div class="time-efficiency-controls">
+              <div class="time-efficiency-toggles" role="tablist">
+                ${efficiencyButtons}
               </div>
+              <button type="button" class="time-efficiency-edit-btn" data-efficiency-edit>Edit range</button>
             </div>
-            <div class="time-efficiency-edit" data-efficiency-edit-panel hidden>
-              <div class="time-efficiency-edit-row">
-                <label class="time-efficiency-edit-field">
-                  <span class="time-efficiency-edit-label">Start date</span>
-                  <input type="date" data-efficiency-start-input>
-                </label>
-                <div class="time-efficiency-edit-actions">
-                  <button type="button" class="time-efficiency-edit-apply" data-efficiency-apply>Apply</button>
-                  <button type="button" class="time-efficiency-edit-cancel" data-efficiency-cancel>Cancel</button>
-                </div>
-              </div>
-              <p class="small muted time-efficiency-edit-note" data-efficiency-edit-note></p>
-            </div>
-            <div class="time-efficiency-metrics" role="status" aria-live="polite">
-              <div class="time-efficiency-metric">
-                <span class="label">Actual hours</span>
-                <span class="value" data-efficiency-actual>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">Current target</span>
-                <span class="value" data-efficiency-target>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">Gap vs target</span>
-                <span class="value" data-efficiency-gap-target>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">End goal</span>
-                <span class="value" data-efficiency-goal>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-              <span class="label">Avg usage/day</span>
-                <span class="value" data-efficiency-average>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">Gap vs goal</span>
-                <span class="value" data-efficiency-gap-goal>—</span>
-              </div>
-              <div class="time-efficiency-metric">
-                <span class="label">Efficiency (to date)</span>
-                <span class="value" data-efficiency-percent>—</span>
-              </div>
-            </div>
-            <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
-            <p class="small muted">Baseline adapts to your average logged hours per day.</p>
           </div>
-          <div class="cost-jobs-summary">
-            <div><span class="label">Jobs tracked</span><span>—</span></div>
-            <div><span class="label">Total gain / loss</span><span>—</span></div>
-            <div><span class="label">Avg per job</span><span>—</span></div>
-            <div><span class="label">Rolling avg (chart)</span><span>—</span></div>
+          <div class="time-efficiency-edit" data-efficiency-edit-panel hidden>
+            <div class="time-efficiency-edit-row">
+              <label class="time-efficiency-edit-field">
+                <span class="time-efficiency-edit-label">Start date</span>
+                <input type="date" data-efficiency-start-input>
+              </label>
+              <label class="time-efficiency-edit-field">
+                <span class="time-efficiency-edit-label">Goal / week (hr)</span>
+                <input type="number" min="1" step="0.5" data-efficiency-goal-input>
+              </label>
+              <div class="time-efficiency-edit-actions">
+                <button type="button" class="time-efficiency-edit-apply" data-efficiency-apply>Apply</button>
+                <button type="button" class="time-efficiency-edit-cancel" data-efficiency-cancel>Cancel</button>
+              </div>
+            </div>
+            <p class="small muted time-efficiency-edit-note" data-efficiency-edit-note></p>
           </div>
+          <div class="time-efficiency-metrics" role="status" aria-live="polite">
+            <div class="time-efficiency-metric"><span class="label">Actual hours</span><span class="value" data-efficiency-actual>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Current target</span><span class="value" data-efficiency-target>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Gap vs target</span><span class="value" data-efficiency-gap-target>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">End goal</span><span class="value" data-efficiency-goal>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Avg usage/day</span><span class="value" data-efficiency-average>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Gap vs goal</span><span class="value" data-efficiency-gap-goal>—</span></div>
+            <div class="time-efficiency-metric"><span class="label">Efficiency (to date)</span><span class="value" data-efficiency-percent>—</span></div>
+          </div>
+          <p class="small muted" data-efficiency-window-label>${defaultEfficiencyDescription}</p>
+          <p class="small muted">Baseline adapts to your average logged hours per day.</p>
+        </div>
+        <div class="cost-efficiency-calculator" data-efficiency-calc>
+          <div class="cost-efficiency-calculator-row">
+            <label>
+              <span class="label">Charge / hr (temporary)</span>
+              <input type="number" step="1" min="0" value="${esc(String(Number(calculatorDefaults.chargeRate) || 0))}" data-efficiency-calc-charge>
+            </label>
+            <label>
+              <span class="label">Cost / hr (temporary)</span>
+              <input type="number" step="1" min="0" value="${esc(String(Number(calculatorDefaults.costRate) || 0))}" data-efficiency-calc-cost>
+            </label>
+            <label>
+              <span class="label">Time range</span>
+              <select data-efficiency-calc-range-select>
+                <option value="1m">Past 1 month</option>
+                <option value="2m">Past 2 months</option>
+                <option value="3m">Past 3 months</option>
+                <option value="6m">Past 6 months</option>
+                <option value="1y">Past 1 year</option>
+                <option value="ytd">Year to date</option>
+                <option value="all">All time</option>
+              </select>
+            </label>
+            <button type="button" class="btn secondary" data-efficiency-calc-reset>Reset</button>
+            <button type="button" class="btn secondary" data-go-jobs-history>Go to cutting jobs</button>
+          </div>
+          <p class="small muted" data-efficiency-calc-range-label>Range: past 1 month from central data table rows.</p>
+          <p class="small muted">Temporary calculator only. Refresh resets values to central data table defaults.</p>
+          <p class="small muted" data-efficiency-calc-result>
+            Net total gain (calculator): <strong data-efficiency-calc-total>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</strong>
+            · Avg / row: <strong data-efficiency-calc-average>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</strong>
+          </p>
+        </div>
+        <div class="cost-jobs-summary">
+          <div><span class="label">Rows tracked</span><span>${esc(efficiencySnapshot.countLabel || "0")}</span></div>
+          <div><span class="label">Total hours</span><span>${esc(efficiencySnapshot.totalHoursLabel || "0 hr")}</span></div>
+          <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Total net gain</span><span data-efficiency-summary-total>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</span></div>
+          <div title="${esc(`${efficiencySnapshot.mathDetailsLabel || ""} ${efficiencySnapshot.disclaimerLabel || ""} Source: ${efficiencySnapshot.sourceLabel || "central data table completed cutting jobs rows."} ${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"}`.trim())}"><span class="label">Avg net gain / row</span><span data-efficiency-summary-average>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
+          <div><span class="label">Total run cost</span><span>${esc(efficiencySnapshot.totalCostLabel || "$0.00")}</span></div>
+          <div><span class="label">Avg run cost / row</span><span>${esc(efficiencySnapshot.averageCostLabel || "$0.00")}</span></div>
+        </div>
+        <p class="small muted" title="${esc(`${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || "Uses central data table values only."}`)}" data-efficiency-source-note>${esc(efficiencySnapshot.sourceLabel || "Source: central data table completed cutting jobs rows.")} ${esc(efficiencySnapshot.disclaimerLabel || "Uses central data table values only.")}</p>
+        <div class="cost-weekly-table-wrap">
           <table class="cost-table">
-            <thead><tr><th>Job</th><th>Milestone</th><th>Status</th><th>Cost impact</th></tr></thead>
+            <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Labor cost</th><th>Total cost</th><th title="${esc(`${efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" aria-label="Net gain calculation">Net gain</th><th>Task link</th></tr></thead>
             <tbody>
-              <tr>
-                <td colspan="4" class="cost-table-placeholder">Job history visualization coming soon.</td>
-              </tr>
+              ${efficiencyRows.length ? efficiencyRows.map(row => `
+                <tr data-efficiency-row data-efficiency-id="${esc(row.id || "")}" data-efficiency-date="${esc(row.dateLabel || "")}" data-efficiency-hours="${esc(String(Number(row.hoursValue) || 0))}" data-efficiency-material="${esc(String(Number(row.materialValue || 0)))}">
+                  <td>${esc(row.taskName || "Completed task")}</td>
+                  <td>${esc(row.dateLabel || "—")}</td>
+                  <td>${esc(row.hoursLabel || "0 hr")}</td>
+                  <td>${esc(row.partCostLabel || "$0.00")}</td>
+                  <td data-efficiency-labor-cell>${esc(row.laborCostLabel || "$0.00")}</td>
+                  <td data-efficiency-total-cost-cell>${esc(row.totalCostLabel || "$0.00")}</td>
+                  <td title="${esc(`${row.formulaTitle || efficiencySnapshot.formulaLabel || "Net gain = (Hours × (Charge Rate - Cost Rate)) - Material Cost"} ${efficiencySnapshot.disclaimerLabel || ""}`.trim())}" data-efficiency-profit-cell>${esc(row.netGainLabel || "$0.00")}</td>
+                  <td>${row.settingsLink ? `<button type="button" class="btn secondary" data-efficiency-open-job="${esc(row.id || "")}">Open job</button>` : "Invalid link"}</td>
+                </tr>
+              `).join("") : `
+                <tr>
+                  <td colspan="8" class="cost-table-placeholder">${esc(efficiencySnapshot.emptyMessage || "No valid completed rows available from the central data table.")}</td>
+                </tr>
+              `}
             </tbody>
           </table>
-          <div class="cost-window-insight">
-            <div class="chart-info">
-              <button type="button" class="chart-info-button" aria-describedby="costEfficiencyInsight" aria-label="Explain Cutting Job Efficiency Snapshot">
-                <span aria-hidden="true">?</span>
-                <span class="sr-only">Show how the Cutting Job Efficiency Snapshot reveals margin trends</span>
-              </button>
-              <div class="chart-info-bubble" id="costEfficiencyInsight" role="tooltip">
-                <p>${esc(efficiencyInsight)}</p>
-              </div>
+        </div>
+        <div class="cost-window-insight">
+          <div class="chart-info">
+            <button type="button" class="chart-info-button" aria-describedby="costEfficiencyInsight" aria-label="Explain Cutting Job Efficiency Snapshot">
+              <span aria-hidden="true">?</span>
+              <span class="sr-only">Show how the Cutting Job Efficiency Snapshot reveals margin trends</span>
+            </button>
+            <div class="chart-info-bubble" id="costEfficiencyInsight" role="tooltip">
+              <p>${esc(efficiencyInsight)}</p>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </div>`;
+    </div></div>`;
 }
 
 function viewJobs(){

--- a/style.css
+++ b/style.css
@@ -4397,7 +4397,9 @@ th { background: linear-gradient(135deg, rgba(9, 68, 165, 0.85), rgba(33, 182, 2
   color: #0a1f3f;
 }
 
-.time-efficiency-edit-field input[type="date"] {
+.time-efficiency-edit-field input[type="date"],
+.time-efficiency-edit-field input[type="number"],
+.time-efficiency-edit-field select {
   border: 1px solid #cbd6ee;
   border-radius: 8px;
   padding: 6px 10px;
@@ -4405,9 +4407,12 @@ th { background: linear-gradient(135deg, rgba(9, 68, 165, 0.85), rgba(33, 182, 2
   color: #0a1f3f;
   transition: border-color 0.18s ease, box-shadow 0.18s ease;
   min-width: 180px;
+  background:#fff;
 }
 
-.time-efficiency-edit-field input[type="date"]:focus {
+.time-efficiency-edit-field input[type="date"]:focus,
+.time-efficiency-edit-field input[type="number"]:focus,
+.time-efficiency-edit-field select:focus {
   border-color: #0a63c2;
   box-shadow: 0 0 0 2px rgba(10, 99, 194, 0.18);
   outline: none;

--- a/style.css
+++ b/style.css
@@ -537,6 +537,34 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
   color:#000;
 }
 body.cost-data-center-open{ overflow:hidden; }
+.time-efficiency-tooltip{
+  position:fixed;
+  z-index:100100;
+  pointer-events:none;
+  background:#0f172a;
+  color:#f8fafc;
+  border-radius:8px;
+  padding:8px 10px;
+  font-size:12px;
+  line-height:1.35;
+  max-width:min(300px, calc(100vw - 16px));
+  box-shadow:0 16px 34px rgba(2, 8, 20, 0.45);
+  opacity:0;
+  transform:translateY(0);
+  transition:opacity 120ms ease, transform 120ms ease;
+}
+.time-efficiency-tooltip[data-visible="true"]{
+  opacity:1;
+}
+.time-efficiency-tooltip[data-placement="above"][data-visible="true"]{
+  transform:translateY(-2px);
+}
+.time-efficiency-tooltip[data-placement="below"][data-visible="true"]{
+  transform:translateY(2px);
+}
+.time-efficiency-tooltip[hidden]{
+  display:none;
+}
 
 .cost-receipt-modal{ position:fixed; inset:0; z-index:1600; display:flex; align-items:center; justify-content:center; padding:24px 20px; }
 .cost-receipt-modal[hidden]{ display:none; }


### PR DESCRIPTION
### Motivation
- Provide a dedicated Efficiency Snapshot and a temporary calculator to analyze cutting-job margins derived from the central data table. 
- Allow configuring a weekly time/efficiency goal directly from the time-efficiency edit panel and persist it to the app configuration.
- Surface efficiency rows in the Maintenance Data Center and update summary/weekly labels to reflect profit/loss semantics.

### Description
- Introduces a new efficiency snapshot modal and panel UI (`efficiencySnapshotModal`) and adds an "Open calculator" control on the cutting jobs summary card; view markup updated in `views.js` to include modal, data-center tab, calculator inputs, and table rows for efficiency rows.
- Adds `setupEfficiencyCalculator` in `renderers.js` to power the calculator UI (range selection, temporary charge/cost inputs, row filtering, recalculation, keyboard handlers, and open/close behavior) and wires open/close buttons and row links.
- Extends `computeCostModel` to build `efficiencySnapshot` from the central `cuttingJobsDataTable`, computing per-row and aggregated metrics (hours, labor, material, cost, profit), default calculator rates, and to adjust summary cards and weekly report labels; also replaces earlier job profit/cost calculations with clearer `materialCostValue`, `laborCostValue`, `totalCostValue`, and `totalProfitValue` fields.
- Enhances the time-efficiency widget: adds a `goalInput` (weekly hours) to the edit panel, populates it from configured `dailyHours` (or baseline), and when applied updates `window.appConfig` via `setAppConfig`/`normalizeAppConfig` and calls `persist`; the widget code also refreshes widgets after edits and binds the new input in `setupTimeEfficiencyWidget`.
- Minor UI/UX fixes: remove duplicate modal when rendering, add tooltips for summary cards, and update weekly report labels to show "Cuts total profit" and "Maintenance total loss".

### Testing
- Ran the project lint and unit test scripts (`npm run lint` and `npm test`) against the modified code and they completed without failures.
- Built the front-end bundle (`npm run build`) to validate template changes and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d331f9488325b327039d9137edf0)