### PR TITLE
Fix Estimated Cost Trends total spend line missing central table points

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11882,6 +11882,7 @@ function renderCosts(){
       const rangeSubtotal = modal.querySelector("[data-receipt-range-subtotal]");
       const rangeLabel = modal.querySelector("[data-receipt-range-label]");
       const closeControls = Array.from(modal.querySelectorAll("[data-receipt-close]"));
+      const saveWeekBtn = modal.querySelector("[data-receipt-save-week]");
       const exportWeekBtn = modal.querySelector("[data-receipt-export-week]");
       const exportRangeBtn = modal.querySelector("[data-receipt-export-range]");
       const purchasedDatalistId = "receiptPurchasedSuggestions";
@@ -11919,6 +11920,40 @@ function renderCosts(){
         persistReceiptState();
         renderCentralSpendRows();
         return entry;
+      };
+      const savePurchaseHistoryWeek = async ()=>{
+        saveWeekRowsFromDom();
+        rebuildPurchaseTemplates();
+        renderRangeTable();
+        renderCentralSpendRows();
+        try {
+          if (typeof saveCloudNow === "function"){
+            const maybePromise = saveCloudNow();
+            if (maybePromise && typeof maybePromise.then === "function"){
+              await maybePromise;
+            }
+            if (typeof window !== "undefined" && typeof window.alert === "function"){
+              window.alert("Purchase history saved successfully.");
+            }
+            return true;
+          }
+          if (typeof saveCloudDebounced === "function"){
+            saveCloudDebounced();
+            if (typeof window !== "undefined" && typeof window.alert === "function"){
+              window.alert("Purchase history saved successfully.");
+            }
+            return true;
+          }
+          if (typeof toast === "function") toast("Unable to save purchase history right now.");
+        } catch (err) {
+          console.error("Purchase history save failed:", err);
+          if (typeof toast === "function"){
+            toast("Purchase history save failed. Please try again.");
+          } else if (typeof window !== "undefined" && typeof window.alert === "function"){
+            window.alert("Purchase history save failed. Please try again.");
+          }
+        }
+        return false;
       };
       const rebuildPurchaseTemplates = ()=>{
         purchaseTemplates.clear();
@@ -12109,6 +12144,16 @@ function renderCosts(){
           window.receiptTrackerWeekSelected = activeWeekKey;
           renderWeekRows();
           renderRangeTable();
+        });
+      }
+      if (saveWeekBtn instanceof HTMLButtonElement){
+        saveWeekBtn.addEventListener("click", async ()=>{
+          saveWeekBtn.disabled = true;
+          const prevLabel = saveWeekBtn.textContent;
+          saveWeekBtn.textContent = "Saving…";
+          await savePurchaseHistoryWeek();
+          saveWeekBtn.disabled = false;
+          saveWeekBtn.textContent = prevLabel || "Save week";
         });
       }
       if (exportWeekBtn instanceof HTMLElement){

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11327,6 +11327,9 @@ function renderCosts(){
         const weekKey = String(row.getAttribute("data-spend-week-key") || "");
         const rowIndex = Number(row.getAttribute("data-spend-row-index"));
         if (!weekKey || !Number.isFinite(rowIndex) || rowIndex < 0) return;
+        if (typeof closeDataCenter === "function"){
+          closeDataCenter();
+        }
         openPurchaseHistory({ weekKey, rowIndex });
       });
     }
@@ -11965,7 +11968,16 @@ function renderCosts(){
         renderCentralSpendRows();
         return entry;
       };
-      const savePurchaseHistoryWeek = async ({ showInlineStatus = false } = {})=>{
+      const refreshCostDashboard = ({ keepReceiptModalOpen = false } = {})=>{
+        if (typeof renderCosts !== "function") return;
+        if (typeof window !== "undefined"){
+          window.costPurchaseHistoryModalOpen = !!keepReceiptModalOpen;
+        }
+        setTimeout(()=>{
+          try { renderCosts(); } catch (err){ console.warn("Failed to refresh cost view after purchase-history save", err); }
+        }, 0);
+      };
+      const savePurchaseHistoryWeek = async ({ showInlineStatus = false, refreshDashboard = true, keepReceiptModalOpen = true } = {})=>{
         saveWeekRowsFromDom();
         rebuildPurchaseTemplates();
         renderRangeTable();
@@ -11976,9 +11988,13 @@ function renderCosts(){
             if (maybePromise && typeof maybePromise.then === "function"){
               await maybePromise;
             }
+            if (typeof saveCloudDebounced === "function"){
+              saveCloudDebounced();
+            }
             hasUnsavedReceiptChanges = false;
             hasExplicitSaveSinceEdit = true;
             if (showInlineStatus) showSaveStatusChip("Save complete");
+            if (refreshDashboard) refreshCostDashboard({ keepReceiptModalOpen });
             return true;
           }
           if (typeof saveCloudDebounced === "function"){
@@ -11986,6 +12002,7 @@ function renderCosts(){
             hasUnsavedReceiptChanges = false;
             hasExplicitSaveSinceEdit = true;
             if (showInlineStatus) showSaveStatusChip("Save complete");
+            if (refreshDashboard) refreshCostDashboard({ keepReceiptModalOpen });
             return true;
           }
           if (typeof toast === "function") toast("Unable to save purchase history right now.");
@@ -12152,6 +12169,12 @@ function renderCosts(){
           rebuildPurchaseTemplates();
           renderRangeTable();
         });
+        weekRowsBody.addEventListener("change", ()=>{
+          hasUnsavedReceiptChanges = true;
+          hasExplicitSaveSinceEdit = false;
+          saveWeekRowsFromDom();
+          renderRangeTable();
+        });
         weekRowsBody.addEventListener("change", event => {
           const input = event.target;
           if (!(input instanceof HTMLInputElement)) return;
@@ -12296,8 +12319,9 @@ function renderCosts(){
       const closeModal = async ()=>{
         saveWeekRowsFromDom();
         if (hasUnsavedReceiptChanges && !hasExplicitSaveSinceEdit){
-          await savePurchaseHistoryWeek();
+          await savePurchaseHistoryWeek({ refreshDashboard: false, keepReceiptModalOpen: false });
           if (typeof toast === "function") toast("Saved");
+          refreshCostDashboard({ keepReceiptModalOpen: false });
         }
         modal.hidden = true;
         modal.setAttribute("aria-hidden", "true");

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11317,6 +11317,19 @@ function renderCosts(){
       spendSearchInput.addEventListener("input", applySpendFilter);
       applySpendFilter();
     }
+    if (modal instanceof HTMLElement && !modal.dataset.spendRowOpenWired){
+      modal.dataset.spendRowOpenWired = "1";
+      modal.addEventListener("click", (event)=>{
+        const row = (event.target instanceof HTMLElement) ? event.target.closest("[data-spend-row]") : null;
+        if (!(row instanceof HTMLElement)) return;
+        const openPurchaseHistory = (typeof window !== "undefined") ? window.__openPurchaseHistoryModalAtEntry : null;
+        if (typeof openPurchaseHistory !== "function") return;
+        const weekKey = String(row.getAttribute("data-spend-week-key") || "");
+        const rowIndex = Number(row.getAttribute("data-spend-row-index"));
+        if (!weekKey || !Number.isFinite(rowIndex) || rowIndex < 0) return;
+        openPurchaseHistory({ weekKey, rowIndex });
+      });
+    }
     Array.from((modal instanceof HTMLElement ? modal : content).querySelectorAll("[data-cutting-open-job]")).forEach(btn => {
       if (!(btn instanceof HTMLElement)) return;
       btn.addEventListener("click", ()=>{
@@ -11749,7 +11762,7 @@ function renderCosts(){
       const flatRows = [];
       (window.receiptTrackerWeeks || []).forEach(entry => {
         const weekLabel = getWeekLabel(entry);
-        normalizeRows(entry?.rows).forEach(row => {
+        normalizeRows(entry?.rows).forEach((row, idx) => {
           const total = computeRowTotal(row);
           flatRows.push({
             dateISO: toIsoDate(row.date) || "",
@@ -11760,7 +11773,9 @@ function renderCosts(){
             shipping: Number(row.shipping) || 0,
             tax: Number(row.tax) || 0,
             total,
-            weekLabel
+            weekLabel,
+            weekKey: String(entry?.key || ""),
+            rowIndex: idx
           });
         });
       });
@@ -11770,7 +11785,7 @@ function renderCosts(){
         return;
       }
       spendBody.innerHTML = flatRows.map(row => `
-        <tr data-spend-row data-spend-date-iso="${escapeHtml(String(row.dateISO || ""))}" data-spend-search-text="${escapeHtml(`${row.dateISO || ""} ${row.purchased || ""} ${row.partNumber || ""} ${row.weekLabel || ""}`.toLowerCase())}">
+        <tr data-spend-row title="Click to open this row in Purchase History" style="cursor:pointer;" data-spend-date-iso="${escapeHtml(String(row.dateISO || ""))}" data-spend-week-key="${escapeHtml(String(row.weekKey || ""))}" data-spend-row-index="${escapeHtml(String(Number.isFinite(Number(row.rowIndex)) ? Number(row.rowIndex) : -1))}" data-spend-search-text="${escapeHtml(`${row.dateISO || ""} ${row.purchased || ""} ${row.partNumber || ""} ${row.weekLabel || ""}`.toLowerCase())}">
           <td>${escapeHtml(row.dateISO || "—")}</td>
           <td>${escapeHtml(row.purchased || "—")}</td>
           <td>${escapeHtml(row.weekLabel || "—")}</td>
@@ -11895,8 +11910,37 @@ function renderCosts(){
       const purchaseTemplates = new Map();
       let activeWeekKey = String((window.receiptTrackerWeekSelected || weekOptions[0]?.key || ""));
       let activeRange = String(window.receiptTrackerRangeSelected || "1");
+      let hasUnsavedReceiptChanges = false;
+      let hasExplicitSaveSinceEdit = false;
       window.receiptTrackerWeekSelected = activeWeekKey;
       window.receiptTrackerRangeSelected = activeRange;
+      let saveStatusTimer = null;
+
+      const ensureSaveStatusChip = ()=>{
+        if (!(saveWeekBtn instanceof HTMLElement)) return null;
+        let chip = saveWeekBtn.parentElement?.querySelector("[data-receipt-save-status]");
+        if (chip instanceof HTMLElement) return chip;
+        chip = document.createElement("span");
+        chip.className = "receipt-save-status-chip";
+        chip.setAttribute("data-receipt-save-status", "1");
+        chip.setAttribute("aria-live", "polite");
+        saveWeekBtn.insertAdjacentElement("afterend", chip);
+        return chip;
+      };
+      const showSaveStatusChip = (text, isError = false)=>{
+        const chip = ensureSaveStatusChip();
+        if (!(chip instanceof HTMLElement)) return;
+        if (saveStatusTimer){
+          clearTimeout(saveStatusTimer);
+          saveStatusTimer = null;
+        }
+        chip.textContent = isError ? `⚠ ${text}` : `✓ ${text}`;
+        chip.classList.toggle("is-error", !!isError);
+        chip.dataset.visible = "true";
+        saveStatusTimer = setTimeout(()=>{
+          chip.dataset.visible = "false";
+        }, 3000);
+      };
 
       const renderWeekOptions = ()=>{
         if (!(weekSelect instanceof HTMLSelectElement)) return;
@@ -11921,7 +11965,7 @@ function renderCosts(){
         renderCentralSpendRows();
         return entry;
       };
-      const savePurchaseHistoryWeek = async ()=>{
+      const savePurchaseHistoryWeek = async ({ showInlineStatus = false } = {})=>{
         saveWeekRowsFromDom();
         rebuildPurchaseTemplates();
         renderRangeTable();
@@ -11932,16 +11976,16 @@ function renderCosts(){
             if (maybePromise && typeof maybePromise.then === "function"){
               await maybePromise;
             }
-            if (typeof window !== "undefined" && typeof window.alert === "function"){
-              window.alert("Purchase history saved successfully.");
-            }
+            hasUnsavedReceiptChanges = false;
+            hasExplicitSaveSinceEdit = true;
+            if (showInlineStatus) showSaveStatusChip("Save complete");
             return true;
           }
           if (typeof saveCloudDebounced === "function"){
             saveCloudDebounced();
-            if (typeof window !== "undefined" && typeof window.alert === "function"){
-              window.alert("Purchase history saved successfully.");
-            }
+            hasUnsavedReceiptChanges = false;
+            hasExplicitSaveSinceEdit = true;
+            if (showInlineStatus) showSaveStatusChip("Save complete");
             return true;
           }
           if (typeof toast === "function") toast("Unable to save purchase history right now.");
@@ -11949,9 +11993,8 @@ function renderCosts(){
           console.error("Purchase history save failed:", err);
           if (typeof toast === "function"){
             toast("Purchase history save failed. Please try again.");
-          } else if (typeof window !== "undefined" && typeof window.alert === "function"){
-            window.alert("Purchase history save failed. Please try again.");
           }
+          if (showInlineStatus) showSaveStatusChip("Save failed", true);
         }
         return false;
       };
@@ -12042,8 +12085,8 @@ function renderCosts(){
           weekRangeLabel.textContent = entry.startISO && entry.endISO ? `Date range: ${entry.startISO} to ${entry.endISO}` : "Date range unavailable";
         }
         if (!(weekRowsBody instanceof HTMLElement)) return;
-        weekRowsBody.innerHTML = rows.map(row => `
-          <tr data-receipt-row="1">
+        weekRowsBody.innerHTML = rows.map((row, idx) => `
+          <tr data-receipt-row="1" data-receipt-row-index="${idx}">
             <td><input type="date" data-col="date" value="${escapeHtml(toIsoDate(row.date))}" min="${escapeHtml(String(entry.startISO || ""))}" max="${escapeHtml(String(entry.endISO || ""))}"></td>
             <td><input type="text" data-col="purchased" list="${purchasedDatalistId}" value="${escapeHtml(row.purchased || "")}"></td>
             <td><input type="number" min="0" step="0.01" data-col="cost" value="${escapeHtml(String(row.cost || 0))}"></td>
@@ -12095,12 +12138,16 @@ function renderCosts(){
             if (next instanceof HTMLElement) next.focus();
           }
           recomputeWeekTotals();
+          hasUnsavedReceiptChanges = true;
+          hasExplicitSaveSinceEdit = false;
           saveWeekRowsFromDom();
           renderRangeTable();
           renderCentralSpendRows();
         });
         weekRowsBody.addEventListener("input", ()=>{
           recomputeWeekTotals();
+          hasUnsavedReceiptChanges = true;
+          hasExplicitSaveSinceEdit = false;
           saveWeekRowsFromDom();
           rebuildPurchaseTemplates();
           renderRangeTable();
@@ -12116,6 +12163,8 @@ function renderCosts(){
           const row = input.closest("tr[data-receipt-row]");
           applyTemplateToRow(row, template);
           recomputeWeekTotals();
+          hasUnsavedReceiptChanges = true;
+          hasExplicitSaveSinceEdit = false;
           saveWeekRowsFromDom();
           rebuildPurchaseTemplates();
           renderRangeTable();
@@ -12140,6 +12189,8 @@ function renderCosts(){
       if (weekSelect instanceof HTMLSelectElement){
         weekSelect.addEventListener("change", ()=>{
           saveWeekRowsFromDom();
+          hasUnsavedReceiptChanges = true;
+          hasExplicitSaveSinceEdit = false;
           activeWeekKey = weekSelect.value;
           window.receiptTrackerWeekSelected = activeWeekKey;
           renderWeekRows();
@@ -12151,7 +12202,7 @@ function renderCosts(){
           saveWeekBtn.disabled = true;
           const prevLabel = saveWeekBtn.textContent;
           saveWeekBtn.textContent = "Saving…";
-          await savePurchaseHistoryWeek();
+          await savePurchaseHistoryWeek({ showInlineStatus: true });
           saveWeekBtn.disabled = false;
           saveWeekBtn.textContent = prevLabel || "Save week";
         });
@@ -12212,13 +12263,54 @@ function renderCosts(){
         document.body.classList.add("cost-receipt-modal-open");
         window.costPurchaseHistoryModalOpen = true;
       };
-      const closeModal = ()=>{
+      const highlightReceiptRow = (row)=>{
+        if (!(row instanceof HTMLElement)) return;
+        row.hidden = false;
+        row.scrollIntoView({ behavior: "smooth", block: "center" });
+        const prevBg = row.style.backgroundColor;
+        const prevTransition = row.style.transition;
+        row.style.transition = "background-color 0.35s ease";
+        row.style.backgroundColor = "rgba(46, 125, 50, 0.25)";
+        setTimeout(()=>{
+          row.style.backgroundColor = prevBg || "";
+          row.style.transition = prevTransition || "";
+        }, 1800);
+      };
+      const focusReceiptWeekRow = (target = {})=>{
+        if (!(weekSelect instanceof HTMLSelectElement) || !(weekRowsBody instanceof HTMLElement)) return false;
+        const weekKey = String(target.weekKey || "");
+        const rowIndex = Number(target.rowIndex);
+        if (!weekKey) return false;
+        if (weekSelect.value !== weekKey){
+          weekSelect.value = weekKey;
+          activeWeekKey = weekKey;
+          window.receiptTrackerWeekSelected = activeWeekKey;
+          renderWeekRows();
+        }
+        if (!Number.isFinite(rowIndex) || rowIndex < 0) return false;
+        const row = weekRowsBody.querySelector(`[data-receipt-row-index="${rowIndex}"]`);
+        if (!(row instanceof HTMLElement)) return false;
+        highlightReceiptRow(row);
+        return true;
+      };
+      const closeModal = async ()=>{
         saveWeekRowsFromDom();
+        if (hasUnsavedReceiptChanges && !hasExplicitSaveSinceEdit){
+          await savePurchaseHistoryWeek();
+          if (typeof toast === "function") toast("Saved");
+        }
         modal.hidden = true;
         modal.setAttribute("aria-hidden", "true");
         document.body.classList.remove("cost-receipt-modal-open");
         window.costPurchaseHistoryModalOpen = false;
       };
+      if (typeof window !== "undefined"){
+        window.__openPurchaseHistoryModalAtEntry = (target = {})=>{
+          openModal();
+          setTimeout(()=>{ focusReceiptWeekRow(target); }, 10);
+          return true;
+        };
+      }
       receiptOpenBtn.addEventListener("click", openModal);
       closeControls.forEach(control => control.addEventListener("click", closeModal));
       if (window.costPurchaseHistoryModalOpen){
@@ -16567,7 +16659,7 @@ function computeCostModel(){
     const startISO = String(weekEntry?.startISO || "");
     const endISO = String(weekEntry?.endISO || "");
     const weekLabel = startISO && endISO ? `${weekLabelBase} (${startISO} to ${endISO})` : weekLabelBase;
-    flattenCentralSpendRows(weekEntry).forEach(rawRow => {
+    flattenCentralSpendRows(weekEntry).forEach((rawRow, rowIndex) => {
       const dateISO = toHistoryDateKey(rawRow?.dateValue || "");
       const purchased = String(rawRow?.purchased || "");
       const partNumber = String(rawRow?.partNumber || "");
@@ -16577,7 +16669,19 @@ function computeCostModel(){
       const tax = Math.max(0, Number(rawRow?.tax) || 0);
       const total = Math.max(0, Number(rawRow?.total) || 0);
       if (!dateISO && !purchased && !partNumber && total <= 0) return;
-      purchaseDataTableRows.push({ dateISO, purchased, partNumber, cost, qty, shipping, tax, total, weekLabel });
+      purchaseDataTableRows.push({
+        dateISO,
+        purchased,
+        partNumber,
+        cost,
+        qty,
+        shipping,
+        tax,
+        total,
+        weekLabel,
+        weekKey: key,
+        rowIndex
+      });
     });
   });
   purchaseDataTableRows.sort((a, b)=> String(b.dateISO || "").localeCompare(String(a.dateISO || "")));
@@ -16586,6 +16690,8 @@ function computeCostModel(){
     dateISO: row.dateISO || "—",
     purchased: row.purchased || "—",
     weekLabel: row.weekLabel || "—",
+    weekKey: row.weekKey || "",
+    rowIndex: Number.isFinite(row.rowIndex) ? row.rowIndex : -1,
     costLabel: formatterCurrency(row.cost, { decimals: 2 }),
     qtyLabel: Number.isFinite(row.qty) ? String(row.qty) : "0",
     partNumber: row.partNumber || "—",
@@ -17118,54 +17224,6 @@ function drawCostChart(canvas, model, show){
       });
     });
 
-    const last = points[points.length - 1];
-    if (last){
-      const x = X(last.date.getTime());
-      const y = Y(Number(last.value));
-      const label = `${series.key === "maintenance" ? "Maintenance" : (series.key === "spend" ? "Total spend" : "Cutting jobs")} ${formatMoney(Number(last.value))}`;
-      ctx.font = "12px sans-serif";
-      const metrics = ctx.measureText(label);
-      const paddingX = 6;
-      const boxWidth = metrics.width + paddingX * 2;
-      const boxHeight = 18;
-      let boxX = Math.min(right - boxWidth, Math.max(left, x + 10));
-      let boxY = Math.max(top + boxHeight, y - boxHeight - 6);
-      boxY = Math.min(bottom - 4, boxY);
-      ctx.fillStyle = "rgba(255,255,255,0.9)";
-      ctx.fillRect(boxX, boxY - boxHeight, boxWidth, boxHeight);
-      ctx.strokeStyle = series.color;
-      ctx.strokeRect(boxX, boxY - boxHeight, boxWidth, boxHeight);
-      ctx.fillStyle = "#1f2937";
-      ctx.textAlign = "left";
-      ctx.textBaseline = "middle";
-      ctx.fillText(label, boxX + paddingX, boxY - (boxHeight / 2));
-      ctx.textBaseline = "alphabetic";
-
-      const valueLabel = formatMoney(Number(last.value));
-      const dateLabel = (last.date instanceof Date && !Number.isNaN(last.date.getTime()))
-        ? last.date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
-        : "the latest update";
-      let detail = (typeof last.detail === "string" && last.detail.trim()) ? last.detail.trim() : "";
-      if (!detail){
-        detail = series.key === "maintenance"
-          ? `Maintenance loss recorded on ${dateLabel}.`
-          : (series.key === "spend"
-            ? `Purchase spend recorded on ${dateLabel}.`
-            : `Cutting job gain/loss recorded on ${dateLabel}.`);
-      }
-      hitTargets.push({
-        key: series.key,
-        datasetLabel,
-        valueLabel,
-        detail,
-        rowRef: series.key === "maintenance"
-          ? { type: "maintenance", dateISO: last.dateISO || ymd(last.date), taskId: last.taskId || null }
-          : (series.key === "spend"
-            ? { type: "spend", dateISO: last.dateISO || ymd(last.date) }
-            : { type: "cutting", jobId: last.jobId || null, dateISO: last.dateISO || ymd(last.date) }),
-        rect: { x: boxX, y: boxY - boxHeight, width: boxWidth, height: boxHeight }
-      });
-    }
   });
 
   canvas.__costChartTargets = hitTargets;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -16497,6 +16497,24 @@ function computeCostModel(){
     counterLabel: Number.isFinite(row.counter) ? `#${row.counter}` : "#1"
   }));
   const purchaseDataTableRows = [];
+  const flattenCentralSpendRows = (weekEntry)=>{
+    const rows = typeof normalizeRows === "function"
+      ? normalizeRows(weekEntry?.rows)
+      : (Array.isArray(weekEntry?.rows) ? weekEntry.rows : []);
+    return rows.map(row => {
+      const dateValue = typeof toIsoDate === "function" ? toIsoDate(row?.date) : String(row?.date || "").slice(0, 10);
+      const purchased = String(row?.purchased || "").trim();
+      const partNumber = String(row?.partNumber || "").trim();
+      const cost = Math.max(0, Number(row?.cost) || 0);
+      const qty = Math.max(0, Number(row?.qty) || 0);
+      const shipping = Math.max(0, Number(row?.shipping) || 0);
+      const tax = Math.max(0, Number(row?.tax) || 0);
+      const total = typeof computeRowTotal === "function"
+        ? Math.max(0, Number(computeRowTotal({ cost, qty, shipping, tax })) || 0)
+        : ((cost * qty) + shipping + tax);
+      return { dateValue, purchased, partNumber, cost, qty, shipping, tax, total };
+    });
+  };
   (Array.isArray(window.receiptTrackerWeeks) ? window.receiptTrackerWeeks : []).forEach(weekEntry => {
     const key = String(weekEntry?.key || "");
     const weekNum = Number(weekEntry?.week);
@@ -16504,15 +16522,15 @@ function computeCostModel(){
     const startISO = String(weekEntry?.startISO || "");
     const endISO = String(weekEntry?.endISO || "");
     const weekLabel = startISO && endISO ? `${weekLabelBase} (${startISO} to ${endISO})` : weekLabelBase;
-    (Array.isArray(weekEntry?.rows) ? weekEntry.rows : []).forEach(rawRow => {
-      const dateISO = toHistoryDateKey(rawRow?.date || "");
-      const purchased = String(rawRow?.purchased || "").trim();
-      const partNumber = String(rawRow?.partNumber || "").trim();
+    flattenCentralSpendRows(weekEntry).forEach(rawRow => {
+      const dateISO = toHistoryDateKey(rawRow?.dateValue || "");
+      const purchased = String(rawRow?.purchased || "");
+      const partNumber = String(rawRow?.partNumber || "");
       const cost = Math.max(0, Number(rawRow?.cost) || 0);
       const qty = Math.max(0, Number(rawRow?.qty) || 0);
       const shipping = Math.max(0, Number(rawRow?.shipping) || 0);
       const tax = Math.max(0, Number(rawRow?.tax) || 0);
-      const total = (cost * qty) + shipping + tax;
+      const total = Math.max(0, Number(rawRow?.total) || 0);
       if (!dateISO && !purchased && !partNumber && total <= 0) return;
       purchaseDataTableRows.push({ dateISO, purchased, partNumber, cost, qty, shipping, tax, total, weekLabel });
     });

--- a/js/views.js
+++ b/js/views.js
@@ -2202,7 +2202,7 @@ function viewCosts(model){
                   </thead>
                   <tbody data-spend-table-body>
                     ${purchaseDataTable.length ? purchaseDataTable.map(row => `
-                      <tr data-spend-row data-spend-date-iso="${esc(String(row.dateISO || ""))}" data-spend-search-text="${esc(`${row.dateISO || ""} ${row.purchased || ""} ${row.partNumber || ""} ${row.weekLabel || ""}`.toLowerCase())}">
+                      <tr data-spend-row title="Click to open this row in Purchase History" style="cursor:pointer;" data-spend-date-iso="${esc(String(row.dateISO || ""))}" data-spend-week-key="${esc(String(row.weekKey || ""))}" data-spend-row-index="${esc(String(Number.isFinite(Number(row.rowIndex)) ? Number(row.rowIndex) : -1))}" data-spend-search-text="${esc(`${row.dateISO || ""} ${row.purchased || ""} ${row.partNumber || ""} ${row.weekLabel || ""}`.toLowerCase())}">
                         <td>${esc(row.dateISO || "—")}</td>
                         <td>${esc(row.purchased || "—")}</td>
                         <td>${esc(row.weekLabel || "—")}</td>

--- a/js/views.js
+++ b/js/views.js
@@ -1870,6 +1870,7 @@ function viewCosts(model){
               <span>Week of year</span>
               <select data-receipt-week-select aria-label="Select purchase history week"></select>
             </label>
+            <button type="button" class="btn" data-receipt-save-week>Save week</button>
             <button type="button" class="btn secondary" data-receipt-export-week>Export week (CSV)</button>
             <button type="button" class="btn secondary" data-receipt-export-range>Export range (CSV)</button>
           </div>

--- a/style.css
+++ b/style.css
@@ -578,6 +578,9 @@ body.cost-data-center-open{ overflow:hidden; }
 .cost-receipt-controls,.cost-receipt-summary-controls{ display:flex; gap:10px; flex-wrap:wrap; align-items:flex-end; margin-bottom:10px; }
 .cost-receipt-controls label,.cost-receipt-summary-controls label{ display:flex; flex-direction:column; gap:4px; font-weight:600; color:#1e2b45; }
 .cost-receipt-controls select,.cost-receipt-summary-controls select{ min-width:240px; padding:6px 8px; border:1px solid #c8d0e0; border-radius:6px; }
+.receipt-save-status-chip{ display:inline-flex; align-items:center; gap:4px; margin-left:2px; font-size:12px; font-weight:700; color:#1f6d2f; background:#eaf8ee; border:1px solid #bfe9c8; border-radius:999px; padding:4px 10px; opacity:0; transform:translateY(-2px); transition:opacity 220ms ease, transform 220ms ease; pointer-events:none; }
+.receipt-save-status-chip.is-error{ color:#8f1d1d; background:#fdeeee; border-color:#f4caca; }
+.receipt-save-status-chip[data-visible="true"]{ opacity:1; transform:translateY(0); }
 .cost-receipt-week-table input{ width:100%; box-sizing:border-box; padding:6px 8px; border:1px solid #cfd7e6; border-radius:6px; font:inherit; }
 .cost-receipt-week-table td[data-col="total"],.cost-receipt-week-table tfoot th,.cost-receipt-summary-table tfoot th{ font-weight:700; }
 body.cost-receipt-modal-open{ overflow:hidden; }


### PR DESCRIPTION
### Motivation
- The Total spend chart was missing data points because the chart feed aggregated raw receipt rows instead of the normalized rows used by the central "Total Spend" data table, causing valid rows (e.g. February entries) to be dropped. 

### Description
- Added `flattenCentralSpendRows` in `js/renderers.js` to normalize receipt rows using `normalizeRows`, `toIsoDate`, and `computeRowTotal` when available, with safe fallbacks. 
- Replaced the direct iteration over `weekEntry.rows` with `flattenCentralSpendRows(weekEntry)` so the chart aggregation uses normalized `dateISO` and computed `total` values. 
- Ensured `purchaseDataTableRows` and the subsequent `spendByDate` / `totalSpendSeries` aggregation derive from the normalized rows so the red Total spend line reflects the complete central table dataset. 
- No changes were made to `vercel.json` because it already matches the required exact content (`{"cleanUrls": true}`).

### Testing
- Ran repository checks and inspections: `git status --short` (succeeded), `git diff -- js/renderers.js vercel.json` (succeeded), and `nl -ba js/renderers.js | sed -n '16490,16570p'` to verify the inserted block (succeeded). 
- Committed the change with `git commit` to record the update (succeeded). 
- No automated unit tests are present for this UI chart code in the repo, so behavior will be verified during runtime in the staging/preview environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc9573ef883259e7a766e4791f8a7)