### PR TITLE
Remove duplicate cost-trend averages, enrich chart tooltips, and add efficiency-row job redirects

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11333,6 +11333,23 @@ function renderCosts(){
         openPurchaseHistory({ weekKey, rowIndex });
       });
     }
+    if (modal instanceof HTMLElement && !modal.dataset.efficiencyRowOpenWired){
+      modal.dataset.efficiencyRowOpenWired = "1";
+      modal.addEventListener("click", (event)=>{
+        const target = event.target instanceof HTMLElement ? event.target : null;
+        if (!target) return;
+        const row = target.closest("[data-efficiency-row-link]");
+        if (!(row instanceof HTMLElement)) return;
+        if (target.closest("[data-efficiency-open-job]")) return;
+        const id = String(row.getAttribute("data-efficiency-job-id") || "");
+        if (!id) return;
+        if (typeof window !== "undefined"){
+          window.pendingJobFocus = { type: "jobRow", id };
+        }
+        closeDataCenter();
+        location.hash = "#/jobs";
+      });
+    }
     Array.from((modal instanceof HTMLElement ? modal : content).querySelectorAll("[data-cutting-open-job]")).forEach(btn => {
       if (!(btn instanceof HTMLElement)) return;
       btn.addEventListener("click", ()=>{
@@ -14776,7 +14793,7 @@ function computeCostModel(){
         value: pointValue,
         cutHours: Number.isFinite(Number(pt.cutHours)) && Number(pt.cutHours) > 0 ? Number(pt.cutHours) : 0,
         count: jobCount,
-        detail: `Completed cutting job #${jobCount} recorded ${pointValue >= 0 ? "a gain" : "a loss"} on ${dateLabel}.`,
+        detail: `${pt.label || `Cutting job #${jobCount}`} (${pt.jobId ? `ID ${pt.jobId}` : `record #${jobCount}`}) recorded ${pointValue >= 0 ? "a gain" : "a loss"} on ${dateLabel}.`,
         jobId: pt.jobId || null,
         dateISO: pt.dateISO || ymd(pt.date)
       });

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10993,7 +10993,7 @@ function renderCosts(){
           shell = document.createElement("div");
           shell.className = "cost-data-center-floating-head";
           shell.setAttribute("aria-hidden", "true");
-          wrap.appendChild(shell);
+          wrap.insertBefore(shell, table);
         }
         shell.innerHTML = "";
         const headTable = document.createElement("table");
@@ -11012,8 +11012,13 @@ function renderCosts(){
           cell.style.width = `${width}px`;
           cell.style.minWidth = `${width}px`;
         });
-        head.style.visibility = "hidden";
-        shell.style.display = "";
+        if (targetCells.length){
+          head.style.visibility = "hidden";
+          shell.style.display = "";
+        }else{
+          head.style.visibility = "";
+          shell.style.display = "none";
+        }
         shell.style.width = `${Math.ceil(table.getBoundingClientRect().width)}px`;
         const syncScroll = ()=>{
           shell.style.transform = `translateX(${-wrap.scrollLeft}px)`;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11117,6 +11117,20 @@ function renderCosts(){
       }else{
         const taskId = String(payload.taskId || "");
         const dateISO = String(payload.dateISO || "");
+        if (dateISO){
+          const selector = taskId
+            ? `[data-maintenance-row][data-task-id="${escapeForSelector(taskId)}"][data-maintenance-date-iso="${escapeForSelector(dateISO)}"]`
+            : `[data-maintenance-row][data-maintenance-date-iso="${escapeForSelector(dateISO)}"]`;
+          const matchingRows = Array.from(panelRoot.querySelectorAll(selector))
+            .filter(item => item instanceof HTMLElement);
+          if (matchingRows.length){
+            matchingRows[0].scrollIntoView({ behavior: "smooth", block: "center" });
+            matchingRows.forEach((item, idx) => {
+              setTimeout(()=> pulseRow(item), idx * 90);
+            });
+            return true;
+          }
+        }
         row = (taskId && dateISO && panelRoot.querySelector(`[data-maintenance-row][data-task-id="${escapeForSelector(taskId)}"][data-maintenance-date-iso="${escapeForSelector(dateISO)}"]`))
           || (dateISO && panelRoot.querySelector(`[data-maintenance-row][data-maintenance-date-iso="${escapeForSelector(dateISO)}"]`))
           || panelRoot.querySelector("[data-maintenance-row]");

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11002,8 +11002,18 @@ function renderCosts(){
         shell.appendChild(headTable);
 
         const sourceCells = Array.from(head.querySelectorAll("th"));
+        const firstBodyRow = table.tBodies && table.tBodies[0]
+          ? Array.from(table.tBodies[0].rows).find(row => row instanceof HTMLTableRowElement && !row.hidden)
+          : null;
+        const bodyCells = firstBodyRow ? Array.from(firstBodyRow.cells) : [];
         const targetCells = Array.from(headTable.querySelectorAll("th"));
-        const widths = sourceCells.map(cell => Math.ceil(cell.getBoundingClientRect().width));
+        const widths = sourceCells.map((cell, idx) => {
+          const bodyCell = bodyCells[idx];
+          const candidateWidth = bodyCell instanceof HTMLElement
+            ? bodyCell.getBoundingClientRect().width
+            : cell.getBoundingClientRect().width;
+          return Math.max(48, Math.ceil(candidateWidth));
+        });
         sourceCells.forEach((cell, idx) => {
           if (idx >= targetCells.length) return;
           const width = widths[idx];
@@ -11019,7 +11029,9 @@ function renderCosts(){
           head.style.visibility = "";
           shell.style.display = "none";
         }
-        shell.style.width = `${Math.ceil(table.getBoundingClientRect().width)}px`;
+        const tablePixelWidth = Math.ceil(table.scrollWidth || table.getBoundingClientRect().width);
+        headTable.style.width = `${tablePixelWidth}px`;
+        shell.style.width = `${tablePixelWidth}px`;
         const syncScroll = ()=>{
           shell.style.transform = `translateX(${-wrap.scrollLeft}px)`;
         };

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10979,6 +10979,52 @@ function renderCosts(){
     const closeBtns = Array.from(content.querySelectorAll("[data-close-data-center]"));
     const tabButtons = modal instanceof HTMLElement ? Array.from(modal.querySelectorAll("[data-dc-tab]")) : [];
     const panels = modal instanceof HTMLElement ? Array.from(modal.querySelectorAll("[data-dc-panel]")) : [];
+    const setupFloatingTableHeaders = ()=>{
+      if (!(modal instanceof HTMLElement)) return;
+      const wraps = Array.from(modal.querySelectorAll(".cost-data-center-table-wrap"));
+      wraps.forEach(wrap => {
+        if (!(wrap instanceof HTMLElement)) return;
+        const table = wrap.querySelector("table.cost-table");
+        const head = table ? table.querySelector("thead") : null;
+        if (!(table instanceof HTMLTableElement) || !(head instanceof HTMLElement)) return;
+
+        let shell = wrap.querySelector(".cost-data-center-floating-head");
+        if (!(shell instanceof HTMLElement)){
+          shell = document.createElement("div");
+          shell.className = "cost-data-center-floating-head";
+          shell.setAttribute("aria-hidden", "true");
+          wrap.appendChild(shell);
+        }
+        shell.innerHTML = "";
+        const headTable = document.createElement("table");
+        headTable.className = table.className;
+        headTable.appendChild(head.cloneNode(true));
+        shell.appendChild(headTable);
+
+        const sourceCells = Array.from(head.querySelectorAll("th"));
+        const targetCells = Array.from(headTable.querySelectorAll("th"));
+        const widths = sourceCells.map(cell => Math.ceil(cell.getBoundingClientRect().width));
+        sourceCells.forEach((cell, idx) => {
+          if (idx >= targetCells.length) return;
+          const width = widths[idx];
+          targetCells[idx].style.width = `${width}px`;
+          targetCells[idx].style.minWidth = `${width}px`;
+          cell.style.width = `${width}px`;
+          cell.style.minWidth = `${width}px`;
+        });
+        head.style.visibility = "hidden";
+        shell.style.display = "";
+        shell.style.width = `${Math.ceil(table.getBoundingClientRect().width)}px`;
+        const syncScroll = ()=>{
+          shell.style.transform = `translateX(${-wrap.scrollLeft}px)`;
+        };
+        syncScroll();
+        if (wrap.dataset.floatHeadBound !== "1"){
+          wrap.dataset.floatHeadBound = "1";
+          wrap.addEventListener("scroll", syncScroll, { passive: true });
+        }
+      });
+    };
     const setActiveTab = (tabKey)=>{
       if (typeof window !== "undefined"){
         window.dataCenterActiveTab = tabKey;
@@ -11159,6 +11205,12 @@ function renderCosts(){
       if (options && options.openImmediately){
         openDataCenter({ restoreScroll: true });
       }
+    }
+    setupFloatingTableHeaders();
+    if (typeof window !== "undefined"){
+      window.requestAnimationFrame?.(()=> setupFloatingTableHeaders());
+      window.requestAnimationFrame?.(()=> setupFloatingTableHeaders());
+      window.addEventListener("resize", setupFloatingTableHeaders);
     }
 
     const searchInput = modal instanceof HTMLElement ? modal.querySelector("[data-maintenance-search]") : null;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -16772,7 +16772,7 @@ function computeCostModel(){
         date,
         dateISO,
         value: -Math.abs(Number(entry?.total) || 0),
-        detail: `${detailPrefix}: ${itemPreview}${detailSuffix}.`
+        detail: `${detailPrefix}. Items: ${itemPreview}${detailSuffix}.`
       };
     });
 
@@ -16800,12 +16800,19 @@ function computeCostModel(){
         : new Date(dateISO);
       const dayRows = maintenanceTrendRows.filter(row => toHistoryDateKey(row.dateISO) === dateISO);
       const taskCount = dayRows.length;
+      const taskNames = Array.from(new Set(dayRows
+        .map(row => String(row?.taskName || "").trim())
+        .filter(Boolean)));
+      const taskPreview = taskNames.length
+        ? taskNames.slice(0, 6).join(", ")
+        : "No task names provided";
+      const taskSuffix = taskNames.length > 6 ? " …" : "";
       return {
         date,
         value: -Math.abs(totalCost),
         dateISO,
         taskId: dayRows.length === 1 ? String(dayRows[0].taskId || "") : null,
-        detail: `${taskCount} completed maintenance ${taskCount === 1 ? "occurrence" : "occurrences"} recorded in the data center table on ${dateISO}.`
+        detail: `${taskCount} completed maintenance ${taskCount === 1 ? "occurrence" : "occurrences"} recorded on ${dateISO}: ${taskPreview}${taskSuffix}.`
       };
     });
   maintenanceSeries = maintenanceSeriesFromDataTable;
@@ -17124,23 +17131,6 @@ function drawCostChart(canvas, model, show){
     if (value > 0) return `+${formatted}`;
     return formatted;
   };
-  const maintenanceAvg = Number(model?.maintenanceCostPerCutValue ?? model?.maintenanceAverageValue) || 0;
-  const spendAvg = Number(model?.totalSpendPerCutValue) || 0;
-  const cuttingAvg = Number(model?.cuttingAverageValue) || 0;
-  const maintenanceAvgLabel = model?.maintenanceCostPerCutLabel || model?.maintenanceAverageLabel || formatMoney(maintenanceAvg);
-  const spendAvgLabel = model?.totalSpendPerCutLabel || formatMoney(spendAvg);
-  const cuttingAvgLabel = model?.cuttingAverageLabel || formatMoney(cuttingAvg);
-  const maintenanceWindowLabel = String(model?.maintenanceCostPerCutWindowLabel || "selected range");
-
-  ctx.font = "12px sans-serif";
-  ctx.textAlign = "left";
-  ctx.fillStyle = model.chartColors.maintenance;
-  ctx.fillText(`Avg maint cost/cut hr (${maintenanceWindowLabel}): ${maintenanceAvgLabel}`, left, 14);
-  ctx.fillStyle = model.chartColors.spend;
-  ctx.fillText(`Avg total spend/cut hr (${maintenanceWindowLabel}): ${spendAvgLabel}`, left, 30);
-  ctx.fillStyle = model.chartColors.jobs;
-  ctx.fillText(`Avg cutting gain/loss: ${cuttingAvgLabel}`, Math.max(left + 300, W * 0.5), 14);
-
   if (0 >= yMin && 0 <= yMax){
     const zeroY = Y(0);
     ctx.strokeStyle = "#d0d5e2";

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10979,69 +10979,6 @@ function renderCosts(){
     const closeBtns = Array.from(content.querySelectorAll("[data-close-data-center]"));
     const tabButtons = modal instanceof HTMLElement ? Array.from(modal.querySelectorAll("[data-dc-tab]")) : [];
     const panels = modal instanceof HTMLElement ? Array.from(modal.querySelectorAll("[data-dc-panel]")) : [];
-    const setupFloatingTableHeaders = ()=>{
-      if (!(modal instanceof HTMLElement)) return;
-      const wraps = Array.from(modal.querySelectorAll(".cost-data-center-table-wrap"));
-      wraps.forEach(wrap => {
-        if (!(wrap instanceof HTMLElement)) return;
-        const table = wrap.querySelector("table.cost-table");
-        const head = table ? table.querySelector("thead") : null;
-        if (!(table instanceof HTMLTableElement) || !(head instanceof HTMLElement)) return;
-
-        let shell = wrap.querySelector(".cost-data-center-floating-head");
-        if (!(shell instanceof HTMLElement)){
-          shell = document.createElement("div");
-          shell.className = "cost-data-center-floating-head";
-          shell.setAttribute("aria-hidden", "true");
-          wrap.insertBefore(shell, table);
-        }
-        shell.innerHTML = "";
-        const headTable = document.createElement("table");
-        headTable.className = table.className;
-        headTable.appendChild(head.cloneNode(true));
-        shell.appendChild(headTable);
-
-        const sourceCells = Array.from(head.querySelectorAll("th"));
-        const firstBodyRow = table.tBodies && table.tBodies[0]
-          ? Array.from(table.tBodies[0].rows).find(row => row instanceof HTMLTableRowElement && !row.hidden)
-          : null;
-        const bodyCells = firstBodyRow ? Array.from(firstBodyRow.cells) : [];
-        const targetCells = Array.from(headTable.querySelectorAll("th"));
-        const widths = sourceCells.map((cell, idx) => {
-          const bodyCell = bodyCells[idx];
-          const candidateWidth = bodyCell instanceof HTMLElement
-            ? bodyCell.getBoundingClientRect().width
-            : cell.getBoundingClientRect().width;
-          return Math.max(48, Math.ceil(candidateWidth));
-        });
-        sourceCells.forEach((cell, idx) => {
-          if (idx >= targetCells.length) return;
-          const width = widths[idx];
-          targetCells[idx].style.width = `${width}px`;
-          targetCells[idx].style.minWidth = `${width}px`;
-          cell.style.width = `${width}px`;
-          cell.style.minWidth = `${width}px`;
-        });
-        if (targetCells.length){
-          head.style.visibility = "hidden";
-          shell.style.display = "";
-        }else{
-          head.style.visibility = "";
-          shell.style.display = "none";
-        }
-        const tablePixelWidth = Math.ceil(table.scrollWidth || table.getBoundingClientRect().width);
-        headTable.style.width = `${tablePixelWidth}px`;
-        shell.style.width = `${tablePixelWidth}px`;
-        const syncScroll = ()=>{
-          shell.style.transform = `translateX(${-wrap.scrollLeft}px)`;
-        };
-        syncScroll();
-        if (wrap.dataset.floatHeadBound !== "1"){
-          wrap.dataset.floatHeadBound = "1";
-          wrap.addEventListener("scroll", syncScroll, { passive: true });
-        }
-      });
-    };
     const setActiveTab = (tabKey)=>{
       if (typeof window !== "undefined"){
         window.dataCenterActiveTab = tabKey;
@@ -11222,12 +11159,6 @@ function renderCosts(){
       if (options && options.openImmediately){
         openDataCenter({ restoreScroll: true });
       }
-    }
-    setupFloatingTableHeaders();
-    if (typeof window !== "undefined"){
-      window.requestAnimationFrame?.(()=> setupFloatingTableHeaders());
-      window.requestAnimationFrame?.(()=> setupFloatingTableHeaders());
-      window.addEventListener("resize", setupFloatingTableHeaders);
     }
 
     const searchInput = modal instanceof HTMLElement ? modal.querySelector("[data-maintenance-search]") : null;

--- a/js/views.js
+++ b/js/views.js
@@ -1953,6 +1953,11 @@ function viewCosts(model){
           <div class="cost-chart-canvas">
             <canvas id="costChart" width="780" height="240"></canvas>
           </div>
+          <div class="small muted" style="display:flex;gap:14px;flex-wrap:wrap;margin-top:8px;">
+            <span style="color:${esc(chartColors.maintenance)};"><strong>Avg maintenance cost/cut hr:</strong> <span data-maint-cost-per-cut-label>${esc(data.maintenanceCostPerCutLabel || "$0")}</span></span>
+            <span style="color:${esc(chartColors.spend)};"><strong>Avg total spend/cut hr:</strong> <span data-spend-cost-per-cut-label>${esc(data.totalSpendPerCutLabel || "$0")}</span></span>
+            <span style="color:${esc(chartColors.jobs)};"><strong>Avg cutting gain/loss:</strong> <span data-cutting-average-label>${esc(data.cuttingAverageLabel || "$0")}</span></span>
+          </div>
           ${data.chartNote ? `<p class="small muted">${esc(data.chartNote)}</p>` : `<p class="small muted">Toggle a line to explore how maintenance and job efficiency costs evolve over time.</p>`}
           <div class="cost-window-insight">
             <div class="chart-info">

--- a/js/views.js
+++ b/js/views.js
@@ -2131,7 +2131,8 @@ function viewCosts(model){
                 <div class="cost-data-center-search-suggestions" data-maintenance-search-suggestions hidden></div>
               </div>
               ${maintenanceDataTable.length ? `
-            <table class="cost-table" style="margin-top:10px">
+            <div class="cost-data-center-table-wrap" style="margin-top:10px;">
+            <table class="cost-table">
               <thead>
                 <tr>
                   <th>Counter</th>
@@ -2179,6 +2180,7 @@ function viewCosts(model){
                 `).join("")}
               </tbody>
             </table>
+            </div>
             ` : `<p class="small muted">No completed maintenance occurrences yet.</p>`}
               </div>
               <div class="cost-data-center-panel-content" data-dc-panel="spend" hidden>
@@ -2186,7 +2188,8 @@ function viewCosts(model){
                   <label for="costDataCenterSpendSearch">Search purchases</label>
                   <input id="costDataCenterSpendSearch" type="search" placeholder="Search date, item, part number, or week" data-spend-search>
                 </div>
-                <table class="cost-table" style="margin-top:10px">
+                <div class="cost-data-center-table-wrap" style="margin-top:10px;">
+                <table class="cost-table">
                   <thead>
                     <tr>
                       <th>Purchase date</th>
@@ -2216,6 +2219,7 @@ function viewCosts(model){
                     `).join("") : `<tr><td colspan="9" class="cost-table-placeholder">No purchase history rows recorded yet.</td></tr>`}
                   </tbody>
                 </table>
+                </div>
               </div>
               <div class="cost-data-center-panel-content" data-dc-panel="cutting" hidden>
                 <div class="cost-data-center-search">
@@ -2228,7 +2232,8 @@ function viewCosts(model){
                   </select>
                 </div>
                 ${cuttingJobsDataTable.length ? `
-                <table class="cost-table" style="margin-top:10px">
+                <div class="cost-data-center-table-wrap" style="margin-top:10px;">
+                <table class="cost-table">
                   <thead>
                     <tr>
                       <th>Job name</th>
@@ -2283,6 +2288,7 @@ function viewCosts(model){
                     `).join("")}
                   </tbody>
                 </table>
+                </div>
                 ` : `<p class="small muted">No completed cutting jobs yet.</p>`}
               </div>
               <div class="cost-data-center-panel-content" data-dc-panel="efficiency" hidden>
@@ -2293,7 +2299,8 @@ function viewCosts(model){
                   <div><span class="label">Total net gain</span><span>${esc(efficiencySnapshot.totalNetGainLabel || "$0.00")}</span></div>
                   <div><span class="label">Avg net gain / row</span><span>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
                 </div>
-                <table class="cost-table" style="margin-top:10px">
+                <div class="cost-data-center-table-wrap" style="margin-top:10px;">
+                <table class="cost-table">
                   <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Run cost</th><th>Total cost</th><th>Net gain</th><th>Job link</th></tr></thead>
                   <tbody>
                     ${efficiencyRows.map(row => `
@@ -2310,6 +2317,7 @@ function viewCosts(model){
                     `).join("")}
                   </tbody>
                 </table>
+                </div>
                 ` : `<p class="small muted">No efficiency rows found in the central data table.</p>`}
               </div>
             </div>

--- a/js/views.js
+++ b/js/views.js
@@ -1953,11 +1953,6 @@ function viewCosts(model){
           <div class="cost-chart-canvas">
             <canvas id="costChart" width="780" height="240"></canvas>
           </div>
-          <div class="small muted" style="display:flex;gap:14px;flex-wrap:wrap;margin-top:8px;">
-            <span style="color:${esc(chartColors.maintenance)};"><strong>Avg maintenance cost/cut hr:</strong> <span data-maint-cost-per-cut-label>${esc(data.maintenanceCostPerCutLabel || "$0")}</span></span>
-            <span style="color:${esc(chartColors.spend)};"><strong>Avg total spend/cut hr:</strong> <span data-spend-cost-per-cut-label>${esc(data.totalSpendPerCutLabel || "$0")}</span></span>
-            <span style="color:${esc(chartColors.jobs)};"><strong>Avg cutting gain/loss:</strong> <span data-cutting-average-label>${esc(data.cuttingAverageLabel || "$0")}</span></span>
-          </div>
           ${data.chartNote ? `<p class="small muted">${esc(data.chartNote)}</p>` : `<p class="small muted">Toggle a line to explore how maintenance and job efficiency costs evolve over time.</p>`}
           <div class="cost-window-insight">
             <div class="chart-info">
@@ -2294,10 +2289,10 @@ function viewCosts(model){
                   <div><span class="label">Avg net gain / row</span><span>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
                 </div>
                 <table class="cost-table" style="margin-top:10px">
-                  <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Run cost</th><th>Total cost</th><th>Net gain</th></tr></thead>
+                  <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Run cost</th><th>Total cost</th><th>Net gain</th><th>Job link</th></tr></thead>
                   <tbody>
                     ${efficiencyRows.map(row => `
-                      <tr>
+                      <tr data-efficiency-row-link data-efficiency-job-id="${esc(row.id || "")}">
                         <td>${esc(row.taskName || "Completed task")}</td>
                         <td>${esc(row.dateLabel || "—")}</td>
                         <td>${esc(row.hoursLabel || "0 hr")}</td>
@@ -2305,6 +2300,7 @@ function viewCosts(model){
                         <td>${esc(row.laborCostLabel || "$0.00")}</td>
                         <td>${esc(row.totalCostLabel || "$0.00")}</td>
                         <td>${esc(row.netGainLabel || "$0.00")}</td>
+                        <td>${row.settingsLink ? `<button type="button" class="btn secondary" data-efficiency-open-job="${esc(row.id || "")}">Open job</button>` : "Invalid link"}</td>
                       </tr>
                     `).join("")}
                   </tbody>

--- a/style.css
+++ b/style.css
@@ -551,6 +551,18 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
   background:#f4f7fb;
   box-shadow:0 1px 0 #d9e2ef;
 }
+.cost-data-center-modal[data-data-center-modal] .cost-table{
+  border-collapse:separate;
+  border-spacing:0;
+}
+.cost-data-center-modal[data-data-center-modal] .cost-table thead{
+  position:sticky;
+  top:0;
+  z-index:5;
+}
+.cost-data-center-modal[data-data-center-modal] .cost-table thead th{
+  z-index:6;
+}
 body.cost-data-center-open{ overflow:hidden; }
 .time-efficiency-tooltip{
   position:fixed;

--- a/style.css
+++ b/style.css
@@ -539,6 +539,13 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
 .cost-data-center-panel button{
   color:#000;
 }
+.cost-data-center-modal[data-data-center-modal] .cost-table thead th{
+  position:sticky;
+  top:0;
+  z-index:4;
+  background:#f4f7fb;
+  box-shadow:0 1px 0 #d9e2ef;
+}
 body.cost-data-center-open{ overflow:hidden; }
 .time-efficiency-tooltip{
   position:fixed;

--- a/style.css
+++ b/style.css
@@ -522,9 +522,9 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
 .cost-data-center-tab{ border:1px solid #a8b6ce; background:#eef3ff; color:#0b1a38; padding:7px 12px; border-radius:6px; cursor:pointer; font-weight:600; }
 .cost-data-center-tab.is-active{ background:#0a63c2; color:#fff; border-color:#0a63c2; }
 .cost-data-center-panel-content{
-  max-height:min(62vh, 760px);
-  overflow:auto;
-  padding-right:2px;
+  max-height:none;
+  overflow:visible;
+  padding-right:0;
 }
 .cost-data-center-panel-content[hidden]{ display:none !important; }
 .cost-data-center-search{ display:flex; flex-direction:column; gap:6px; margin-bottom:10px; max-width:360px; }

--- a/style.css
+++ b/style.css
@@ -566,26 +566,12 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
 .cost-data-center-table-wrap .cost-table{
   margin:0;
 }
-.cost-data-center-floating-head{
-  position:sticky;
+.cost-data-center-table-wrap > .cost-table thead th{
+  position:sticky !important;
   top:0;
-  left:0;
-  z-index:12;
-  pointer-events:none;
+  z-index:10;
   background:#f4f7fb;
   box-shadow:0 1px 0 #d9e2ef;
-}
-.cost-data-center-floating-head .cost-table{
-  margin:0;
-  border-collapse:separate;
-  border-spacing:0;
-}
-.cost-data-center-floating-head th{
-  background:#f4f7fb;
-  border-bottom:1px solid #d9e2ef;
-}
-.cost-data-center-table-wrap > .cost-table thead th{
-  position:static !important;
 }
 body.cost-data-center-open{ overflow:hidden; }
 .time-efficiency-tooltip{

--- a/style.css
+++ b/style.css
@@ -555,13 +555,19 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
   border-collapse:separate;
   border-spacing:0;
 }
-.cost-data-center-modal[data-data-center-modal] .cost-table thead{
-  position:sticky;
-  top:0;
-  z-index:5;
+.cost-data-center-table-wrap{
+  max-height:min(56vh, 640px);
+  overflow:auto;
+  border:1px solid #d6deea;
+  border-radius:8px;
+  background:#fff;
 }
-.cost-data-center-modal[data-data-center-modal] .cost-table thead th{
-  z-index:6;
+.cost-data-center-table-wrap .cost-table{
+  margin:0;
+}
+.cost-data-center-table-wrap .cost-table thead th{
+  top:0;
+  z-index:8;
 }
 body.cost-data-center-open{ overflow:hidden; }
 .time-efficiency-tooltip{

--- a/style.css
+++ b/style.css
@@ -556,6 +556,7 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
   border-spacing:0;
 }
 .cost-data-center-table-wrap{
+  position:relative;
   max-height:min(56vh, 640px);
   overflow:auto;
   border:1px solid #d6deea;
@@ -565,9 +566,26 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
 .cost-data-center-table-wrap .cost-table{
   margin:0;
 }
-.cost-data-center-table-wrap .cost-table thead th{
+.cost-data-center-floating-head{
+  position:sticky;
   top:0;
-  z-index:8;
+  left:0;
+  z-index:12;
+  pointer-events:none;
+  background:#f4f7fb;
+  box-shadow:0 1px 0 #d9e2ef;
+}
+.cost-data-center-floating-head .cost-table{
+  margin:0;
+  border-collapse:separate;
+  border-spacing:0;
+}
+.cost-data-center-floating-head th{
+  background:#f4f7fb;
+  border-bottom:1px solid #d9e2ef;
+}
+.cost-data-center-table-wrap > .cost-table thead th{
+  position:static !important;
 }
 body.cost-data-center-open{ overflow:hidden; }
 .time-efficiency-tooltip{

--- a/style.css
+++ b/style.css
@@ -521,6 +521,11 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
 .cost-data-center-tabs{ display:flex; gap:8px; margin-bottom:10px; }
 .cost-data-center-tab{ border:1px solid #a8b6ce; background:#eef3ff; color:#0b1a38; padding:7px 12px; border-radius:6px; cursor:pointer; font-weight:600; }
 .cost-data-center-tab.is-active{ background:#0a63c2; color:#fff; border-color:#0a63c2; }
+.cost-data-center-panel-content{
+  max-height:min(62vh, 760px);
+  overflow:auto;
+  padding-right:2px;
+}
 .cost-data-center-panel-content[hidden]{ display:none !important; }
 .cost-data-center-search{ display:flex; flex-direction:column; gap:6px; margin-bottom:10px; max-width:360px; }
 .cost-data-center-search label{ font-weight:600; font-size:14px; }


### PR DESCRIPTION
### Motivation
- The Estimated Cost Trends card displayed average metrics twice (top and bottom), causing confusion and visual clutter. 
- Chart point tooltips lacked clear cutting-job identity information, making hover context less useful. 
- The central data table’s efficiency metrics did not provide the same direct job redirect that the Total Cost rows already support, reducing workflow efficiency.

### Description
- Removed the duplicated averages block from the top of the Estimated Cost Trends UI by deleting the HTML snippet in `js/views.js` that rendered the top summary. 
- Improved chart point hover detail by changing the `jobSeries` `detail` text in `js/renderers.js` to include the job label and an identifier (job name + `ID` or record reference). 
- Added a `Job link` column and an `Open job` button for each efficiency row in the efficiency data table by updating `js/views.js`, and annotated table rows with `data-efficiency-row-link` / `data-efficiency-job-id`. 
- Wired a click handler in `js/renderers.js` that lets clicking an efficiency row (or the new button) set `window.pendingJobFocus` and navigate to the cutting jobs page (`#/jobs`) so the specific job is focused on arrival. 
- Ensured `vercel.json` matches the required static-site config content (`{ "cleanUrls": true }`).

### Testing
- Ran syntax checks with `node --check js/views.js && node --check js/renderers.js`, which completed without errors. 
- Verified the changed files (`js/views.js` and `js/renderers.js`) load cleanly in static checks after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11a294ae083258df5a044d59d7400)