### PR TITLE
Add data-safety guards, inventory transaction logging, and purchase-link repair UI

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -12,6 +12,14 @@
 
 /* =================== CONSTANTS / GLOBALS =================== */
 const APP_SCHEMA = 72;
+const DATA_SAFETY_FLAGS = Object.freeze({
+  ENABLE_INVENTORY_TRANSACTIONS: false,
+  ENABLE_INVENTORY_TRANSACTIONS_DRY_RUN: true,
+  ENABLE_SYNC_PROCESS_LOG: true,
+  ENABLE_SYNC_PROCESS_LOG_DRY_RUN: true,
+  ENABLE_MAINTENANCE_CONSUMES_INVENTORY: false,
+  ENABLE_PREVIEW_WRITE_TO_PROD: false
+});
 const DEFAULT_DAILY_HOURS = 8;
 let DAILY_HOURS = DEFAULT_DAILY_HOURS;
 const JOB_RATE_PER_HOUR = 250; // $/hr (default charge when a job doesn't set its own rate)
@@ -36,6 +44,53 @@ if (typeof window !== "undefined") {
   window.workspaceRef = null;
   window.workspaceDocRef = null;
   window.DEBUG_MODE = new URLSearchParams(window.location.search).get("debug") === "1";
+  window.DATA_SAFETY_FLAGS = { ...DATA_SAFETY_FLAGS, ...(window.DATA_SAFETY_FLAGS || {}) };
+}
+function getDataSafetyFlags(){
+  const runtime = (typeof window !== "undefined" && window.DATA_SAFETY_FLAGS && typeof window.DATA_SAFETY_FLAGS === "object")
+    ? window.DATA_SAFETY_FLAGS
+    : {};
+  return { ...DATA_SAFETY_FLAGS, ...runtime };
+}
+function isProductionWorkspaceTarget(){
+  return String(WORKSPACE_ID || "") === "github-prod";
+}
+function isProductionFirebaseProjectTarget(){
+  const cfg = (typeof window !== "undefined" && window.FIREBASE_CONFIG && typeof window.FIREBASE_CONFIG === "object")
+    ? window.FIREBASE_CONFIG
+    : {};
+  return String(cfg.projectId || "") === "omax-maintenance";
+}
+function canWriteWorkspace(reason = "unknown"){
+  const flags = getDataSafetyFlags();
+  const previewRuntime = isVercelPreviewRuntime();
+  const prodWorkspace = isProductionWorkspaceTarget();
+  if (previewRuntime && prodWorkspace && !flags.ENABLE_PREVIEW_WRITE_TO_PROD){
+    console.warn(`[DataSafety] Blocked Firestore write (${reason}) from preview runtime to production workspace.`);
+    return false;
+  }
+  return true;
+}
+function warnDataSafetyContext(){
+  const flags = getDataSafetyFlags();
+  const previewRuntime = isVercelPreviewRuntime();
+  const prodFirebase = isProductionFirebaseProjectTarget();
+  const prodWorkspace = isProductionWorkspaceTarget();
+  if (previewRuntime){
+    console.warn("[DataSafety] Vercel preview runtime detected.");
+  }
+  if (prodFirebase){
+    console.warn("[DataSafety] Firebase production project detected: omax-maintenance.");
+  }
+  if (prodWorkspace){
+    console.warn("[DataSafety] Production workspace detected: github-prod.");
+  }
+  if (previewRuntime && prodFirebase && prodWorkspace){
+    console.warn("[DataSafety] Preview runtime is connected to production Firebase/workspace routing.");
+  }
+  if (prodWorkspace && (flags.ENABLE_INVENTORY_TRANSACTIONS || flags.ENABLE_MAINTENANCE_CONSUMES_INVENTORY)){
+    console.warn("[DataSafety] Transaction-related flags are enabled while targeting production workspace.");
+  }
 }
 let CUTTING_BASELINE_WEEKLY_HOURS = 56;
 let CUTTING_BASELINE_DAILY_HOURS = CUTTING_BASELINE_WEEKLY_HOURS / 7;
@@ -583,6 +638,7 @@ function applyFirestoreSettings(db){
 
 async function initFirebase(){
   if (!window.firebase || !firebase.initializeApp){ console.warn("Firebase SDK not loaded."); return; }
+  try { warnDataSafetyContext(); } catch (_err) {}
   if (!window.FIREBASE_CONFIG){ console.warn("Missing FIREBASE_CONFIG."); return; }
   if (FB.ready) return;
   if (firebaseInitStarted) return;
@@ -1605,6 +1661,8 @@ if (!Array.isArray(window.cuttingJobs))  window.cuttingJobs  = [];   // [{id,nam
 if (!Array.isArray(window.completedCuttingJobs)) window.completedCuttingJobs = [];
 if (!Array.isArray(window.pendingNewJobFiles)) window.pendingNewJobFiles = [];
 if (!Array.isArray(window.orderRequests)) window.orderRequests = [];
+if (!Array.isArray(window.inventoryTransactions)) window.inventoryTransactions = [];
+if (!Array.isArray(window.syncProcessLog)) window.syncProcessLog = [];
 if (!Array.isArray(window.garnetCleanings)) window.garnetCleanings = [];
 if (!Array.isArray(window.dailyCutHours)) window.dailyCutHours = [];
 if (!Array.isArray(window.opportunityRollups)) window.opportunityRollups = [];
@@ -1627,6 +1685,8 @@ let cuttingJobs   = window.cuttingJobs;
 let completedCuttingJobs = window.completedCuttingJobs;
 let opportunityRollups = window.opportunityRollups;
 let orderRequests = window.orderRequests;
+let inventoryTransactions = window.inventoryTransactions;
+let syncProcessLog = window.syncProcessLog;
 let orderRequestTab = window.orderRequestTab;
 let garnetCleanings = window.garnetCleanings;
 let dailyCutHours = window.dailyCutHours;
@@ -1909,6 +1969,8 @@ window.defaultAsReqTasks = defaultAsReqTasks;
     if (!Array.isArray(sanitized.dailyCutHours) && Array.isArray(window.dailyCutHours)) sanitized.dailyCutHours = window.dailyCutHours.slice();
     if (!Array.isArray(sanitized.inventory) && Array.isArray(window.inventory)) sanitized.inventory = window.inventory.slice();
     if (!Array.isArray(sanitized.orderRequests) && Array.isArray(window.orderRequests)) sanitized.orderRequests = window.orderRequests.slice();
+    if (!Array.isArray(sanitized.inventoryTransactions) && Array.isArray(window.inventoryTransactions)) sanitized.inventoryTransactions = window.inventoryTransactions.slice();
+    if (!Array.isArray(sanitized.syncProcessLog) && Array.isArray(window.syncProcessLog)) sanitized.syncProcessLog = window.syncProcessLog.slice();
     if (!Array.isArray(sanitized.receiptTrackerWeeks) && Array.isArray(window.receiptTrackerWeeks)) sanitized.receiptTrackerWeeks = window.receiptTrackerWeeks.slice();
     if (!Array.isArray(sanitized.garnetCleanings) && Array.isArray(window.garnetCleanings)) sanitized.garnetCleanings = window.garnetCleanings.slice();
     if (!Array.isArray(sanitized.totalHistory) && Array.isArray(window.totalHistory)) sanitized.totalHistory = window.totalHistory.slice();
@@ -1930,6 +1992,8 @@ window.defaultAsReqTasks = defaultAsReqTasks;
     window.appConfig = appConfig;
     refreshDerivedDailyHours();
     if (!Array.isArray(window.orderRequests)) window.orderRequests = [];
+    if (!Array.isArray(window.inventoryTransactions)) window.inventoryTransactions = [];
+    if (!Array.isArray(window.syncProcessLog)) window.syncProcessLog = [];
     if (!Array.isArray(window.receiptTrackerWeeks)) window.receiptTrackerWeeks = [];
     if (!Array.isArray(window.garnetCleanings)) window.garnetCleanings = [];
     if (!Array.isArray(window.totalHistory)) window.totalHistory = [];
@@ -2085,6 +2149,8 @@ function snapshotState(){
     cuttingJobs: stripJobFileDataUrls(cuttingJobs),
     completedCuttingJobs: stripJobFileDataUrls(completedCuttingJobs),
     orderRequests,
+    inventoryTransactions: Array.isArray(window.inventoryTransactions) ? window.inventoryTransactions.map(entry => ({ ...entry })) : [],
+    syncProcessLog: Array.isArray(window.syncProcessLog) ? window.syncProcessLog.map(entry => ({ ...entry })) : [],
     receiptTrackerWeeks: Array.isArray(window.receiptTrackerWeeks)
       ? window.receiptTrackerWeeks.map(entry => ({ ...entry }))
       : [],
@@ -2990,6 +3056,7 @@ const saveCloudInternal = debounce(async ()=>{
     const snap = snapshotState();
     window.__lastSnapshot = snap;
     const writeRev = Number(snap?.syncMeta?.rev || 0);
+    if (!canWriteWorkspace("saveCloudInternal")) return;
     await FB.docRef.set(snap, { merge:true });
     if (writeRev > 0) lastAppliedCloudRevision = writeRev;
     if (window.DEBUG_MODE){
@@ -3007,7 +3074,7 @@ const saveCloudInternal = debounce(async ()=>{
   }
 }, 300);
 function saveCloudDebounced(){
-  if (isVercelPreviewRuntime()) return;
+  if (!canWriteWorkspace("saveCloudDebounced")) return;
   try {
     if (typeof setSettingsFolders === "function") setSettingsFolders(window.settingsFolders);
   } catch (err) {
@@ -3021,7 +3088,7 @@ function saveCloudDebounced(){
   saveCloudInternal();
 }
 function saveCloudNow(){
-  if (isVercelPreviewRuntime()) return;
+  if (!canWriteWorkspace("saveCloudNow")) return;
   try {
     if (typeof setSettingsFolders === "function") setSettingsFolders(window.settingsFolders);
   } catch (err) {
@@ -3112,7 +3179,9 @@ async function loadFromCloud(){
       const seededRev = Number(seeded?.syncMeta?.rev || 0);
       if (seededRev > 0) lastAppliedCloudRevision = seededRev;
       if (typeof resetHistoryToCurrent === "function") resetHistoryToCurrent();
-      await FB.docRef.set(seeded, { merge:true });
+      if (canWriteWorkspace("loadFromCloud:seeded-state")){
+        await FB.docRef.set(seeded, { merge:true });
+      }
       if (FB.workspaceDoc){
         await updateWorkspaceMetadata({
           workspaceId: WORKSPACE_ID,
@@ -3141,7 +3210,9 @@ async function migrateLegacyWorkspaceDoc(){
     delete stateData.createdAt;
     delete stateData.lastStateMigrationAt;
     delete stateData.lastStateDocPath;
-    await FB.docRef.set(stateData, { merge:true });
+    if (canWriteWorkspace("migrateLegacyWorkspaceDoc")){
+      await FB.docRef.set(stateData, { merge:true });
+    }
     const meta = {
       workspaceId: WORKSPACE_ID,
       lastStateMigrationAt: new Date().toISOString(),
@@ -3246,9 +3317,17 @@ function normalizeOrderItem(raw){
   const qtyNum = Number(raw.qty);
   const qty = Number.isFinite(qtyNum) && qtyNum > 0 ? qtyNum : 1;
   const priceNum = raw.price == null ? null : Number(raw.price);
+  const inventoryId = raw.inventoryId != null && String(raw.inventoryId).trim() ? String(raw.inventoryId) : null;
+  const isInventoryLinked = typeof raw.isInventoryLinked === "boolean" ? raw.isInventoryLinked : Boolean(inventoryId);
   return {
     id: raw.id || genId("order_item"),
-    inventoryId: raw.inventoryId || null,
+    inventoryId,
+    isInventoryLinked,
+    inventoryNameSnapshot: raw.inventoryNameSnapshot != null ? String(raw.inventoryNameSnapshot) : "",
+    pnSnapshot: raw.pnSnapshot != null ? String(raw.pnSnapshot) : "",
+    linkSnapshot: raw.linkSnapshot != null ? String(raw.linkSnapshot) : "",
+    unitCostSnapshot: raw.unitCostSnapshot == null ? null : (Number.isFinite(Number(raw.unitCostSnapshot)) ? Number(raw.unitCostSnapshot) : null),
+    unitSnapshot: raw.unitSnapshot != null ? String(raw.unitSnapshot) : "",
     name: raw.name || "",
     pn: raw.pn || "",
     link: raw.link || "",
@@ -3413,6 +3492,7 @@ async function clearAllAppData(){
 
   try {
     if (FB.ready && FB.docRef) {
+      if (!canWriteWorkspace("clearAllAppData")) return defaults;
       await FB.docRef.set(snapshotState());
     } else {
       saveCloudDebounced();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -21015,6 +21015,8 @@ function computeOrderRequestModel(){
     subtitle: draft.items.length ? `${draft.items.length} item${draft.items.length===1?"":"s"} ready for approval` : "Add parts from inventory to start a request.",
     items: draft.items.map(item => ({
       id: item.id,
+      inventoryId: item.inventoryId != null ? String(item.inventoryId) : null,
+      suggestedInventoryId: item.suggestedInventoryId != null ? String(item.suggestedInventoryId) : null,
       name: item.name || "",
       pn: item.pn || "",
       link: item.link || "",
@@ -21026,7 +21028,9 @@ function computeOrderRequestModel(){
     total: formatOrderCurrency(requestedTotal),
     selectionTotal: selectedTotal > 0 ? formatOrderCurrency(selectedTotal) : null,
     canApprove: draft.items.length > 0,
-    downloadLabel: "Download request (.csv)"
+    unlinkedCount: draft.items.filter(item => !item?.inventoryId).length,
+    downloadLabel: "Download request (.csv)",
+    unlinkedGroups: collectUnlinkedOrderGroups()
   };
 
   const historyRaw = Array.isArray(orderRequests)
@@ -21108,6 +21112,97 @@ function computeOrderRequestModel(){
   return { tab, active: activeModel, history, summary };
 }
 
+function collectUnlinkedOrderGroups(){
+  const groups = new Map();
+  (Array.isArray(orderRequests) ? orderRequests : []).forEach(req => {
+    const reqId = String(req?.id || "");
+    const reqCode = String(req?.code || reqId || "");
+    (Array.isArray(req?.items) ? req.items : []).forEach(item => {
+      if (!item || item.inventoryId) return;
+      const pn = String(item.pn || "").trim();
+      const key = pn ? `pn:${pn.toLowerCase()}` : `item:${reqId}:${String(item.id || "")}`;
+      if (!groups.has(key)){
+        groups.set(key, { key, partNumber: pn || "", items: [], names: new Set() });
+      }
+      const row = groups.get(key);
+      row.items.push({
+        requestId: reqId,
+        requestCode: reqCode,
+        requestDate: req?.createdAt || null,
+        itemId: String(item.id || ""),
+        name: String(item.name || ""),
+        pn: pn || "",
+        qty: Number(item.qty) || 0,
+        price: item.price == null ? null : Number(item.price),
+        status: String(item.status || "pending"),
+        link: String(item.link || "")
+      });
+      if (item.name) row.names.add(String(item.name));
+    });
+  });
+  return Array.from(groups.values()).map(group => ({ ...group, names: Array.from(group.names) }));
+}
+
+function createInventoryItemFromPurchaseLink(input){
+  const baseItem = {
+    id: genId("inventory"),
+    name: input.name,
+    qtyNew: 0,
+    qtyOld: 0,
+    unit: input.unit || "pcs",
+    pn: input.pn || "",
+    link: input.link || "",
+    price: input.price == null ? null : Number(input.price),
+    note: "Created from purchase-history link repair",
+    folderId: input.folderId || null
+  };
+  const item = typeof normalizeInventoryItem === "function" ? normalizeInventoryItem(baseItem) : { ...baseItem, qty: 0 };
+  inventory.unshift(item);
+  window.inventory = inventory;
+  return item;
+}
+
+function linkPurchaseGroupToInventory(group, inventoryItem, options = {}){
+  if (!group || !inventoryItem) return 0;
+  const nowIso = new Date().toISOString();
+  const actor = (FB && FB.user && (FB.user.email || FB.user.uid)) ? (FB.user.email || FB.user.uid) : "system";
+  const finalName = options.finalName || inventoryItem.name || "";
+  let affected = 0;
+  const affectedIds = [];
+  group.items.forEach(meta => {
+    const req = orderRequests.find(r => r && String(r.id) === String(meta.requestId));
+    if (!req || !Array.isArray(req.items)) return;
+    const line = req.items.find(it => it && String(it.id) === String(meta.itemId));
+    if (!line) return;
+    line.inventoryId = inventoryItem.id;
+    line.isInventoryLinked = true;
+    line.inventoryNameSnapshot = inventoryItem.name || finalName || "";
+    line.pnSnapshot = inventoryItem.pn || line.pn || "";
+    line.linkSnapshot = inventoryItem.link || line.link || "";
+    line.unitCostSnapshot = inventoryItem.price != null ? Number(inventoryItem.price) : (line.price != null ? Number(line.price) : null);
+    line.unitSnapshot = inventoryItem.unit || line.unit || "pcs";
+    line.linkedAtISO = nowIso;
+    line.linkedBy = actor;
+    line.linkSource = "manual_part_number_group";
+    line.name = finalName || line.name;
+    affected += 1;
+    affectedIds.push(String(line.id || ""));
+  });
+  appendSyncProcessLog({
+    sourceArea: "orderRequests",
+    eventType: "purchase_inventory_link_repaired",
+    partNumber: group.partNumber || "",
+    affectedOrderItemIds: affectedIds,
+    affectedCount: affected,
+    inventoryId: inventoryItem.id,
+    finalName,
+    qtyDelta: 0,
+    status: "historical_link_repaired_no_qty_change",
+    message: "Historical purchase links repaired. Inventory quantity was not changed."
+  });
+  return affected;
+}
+
 function updateOrderTotalsUI(card, request){
   if (!card || !request) return;
   const total = request.items.reduce((sum, item)=> sum + orderItemLineTotal(item), 0);
@@ -21140,6 +21235,12 @@ function addInventoryItemToOrder(inventoryId){
   const newItem = {
     id: genId("order_item"),
     inventoryId,
+    isInventoryLinked: true,
+    inventoryNameSnapshot: item.name || "",
+    pnSnapshot: item.pn || "",
+    linkSnapshot: item.link || "",
+    unitCostSnapshot: item.price != null ? Number(item.price) : null,
+    unitSnapshot: item.unit || "",
     name: item.name || "",
     pn: item.pn || "",
     link: item.link || "",
@@ -21152,6 +21253,32 @@ function addInventoryItemToOrder(inventoryId){
   saveCloudDebounced();
   toast("Added to order request");
   if (location.hash === "#/order-request" || location.hash === "#order-request"){ renderOrderRequest(); }
+}
+
+function suggestInventoryMatchForOrderLine(line){
+  if (!line || line.inventoryId) return null;
+  const pn = String(line.pn || "").trim().toLowerCase();
+  const name = String(line.name || "").trim().toLowerCase();
+  const link = String(line.link || "").trim();
+  let match = null;
+  let reason = "";
+  let confidence = 0;
+  if (pn){
+    const byPn = inventory.filter(item => String(item?.pn || "").trim().toLowerCase() === pn);
+    if (byPn.length === 1){ match = byPn[0]; reason = "pn_exact"; confidence = 0.95; }
+  }
+  if (!match && name){
+    const byName = inventory.filter(item => String(item?.name || "").trim().toLowerCase() === name);
+    if (byName.length === 1){ match = byName[0]; reason = "name_exact"; confidence = 0.8; }
+  }
+  if (!match && link){
+    const byLink = inventory.filter(item => String(item?.link || "").trim() === link);
+    if (byLink.length === 1){ match = byLink[0]; reason = "link_exact"; confidence = 0.85; }
+  }
+  if (!match) return null;
+  const suggestion = { suggestedInventoryId: match.id, suggestedMatchReason: reason, suggestedMatchConfidence: confidence };
+  console.log("[PurchaseInventoryLink:SUGGESTED]", { orderItemId: line.id, ...suggestion });
+  return suggestion;
 }
 
 function findTasksLinkedToInventoryItem(item){
@@ -21430,21 +21557,161 @@ function downloadOrderRequestCSV(request){
   }, 0);
 }
 
-function applyInventoryForApprovedItems(items){
+function getDataSafetyFlagsRuntime(){
+  const defaults = {
+    ENABLE_INVENTORY_TRANSACTIONS: false,
+    ENABLE_INVENTORY_TRANSACTIONS_DRY_RUN: true,
+    ENABLE_SYNC_PROCESS_LOG: true,
+    ENABLE_SYNC_PROCESS_LOG_DRY_RUN: true,
+    ENABLE_MAINTENANCE_CONSUMES_INVENTORY: false,
+    ENABLE_PREVIEW_WRITE_TO_PROD: false
+  };
+  const runtime = (typeof window !== "undefined" && window.DATA_SAFETY_FLAGS && typeof window.DATA_SAFETY_FLAGS === "object")
+    ? window.DATA_SAFETY_FLAGS
+    : {};
+  return { ...defaults, ...runtime };
+}
+
+function appendSyncProcessLog(entry){
+  const flags = getDataSafetyFlagsRuntime();
+  if (!flags.ENABLE_SYNC_PROCESS_LOG) return false;
+  if (!Array.isArray(window.syncProcessLog)) window.syncProcessLog = [];
+  const payload = {
+    id: genId("sync_process"),
+    eventType: "",
+    sourceArea: "",
+    sourceId: null,
+    sourceItemId: null,
+    targetArea: "",
+    targetId: null,
+    inventoryId: null,
+    taskId: null,
+    orderId: null,
+    qtyDelta: null,
+    fieldChanges: {},
+    beforeSnapshot: null,
+    afterSnapshot: null,
+    status: "info",
+    dryRun: !!flags.ENABLE_SYNC_PROCESS_LOG_DRY_RUN,
+    message: "",
+    error: null,
+    createdAtISO: new Date().toISOString(),
+    actor: "system",
+    ...(entry && typeof entry === "object" ? entry : {})
+  };
+  if (payload.dryRun){
+    console.log("[SyncProcessLog:DRY_RUN]", payload);
+    return false;
+  }
+  window.syncProcessLog.push(payload);
+  console.log("[SyncProcessLog]", payload);
+  return true;
+}
+
+function hasInventoryTransactionIdempotencyKey(idempotencyKey){
+  if (!idempotencyKey || !Array.isArray(window.inventoryTransactions)) return false;
+  return window.inventoryTransactions.some(tx => tx && String(tx.idempotencyKey || "") === String(idempotencyKey));
+}
+
+function createInventoryTransactionCandidate(input = {}){
+  const type = String(input.type || "");
+  const supported = new Set(["purchase_receive", "maintenance_consume", "manual_adjust", "correction", "reversal"]);
+  if (!supported.has(type)) return null;
+  return {
+    id: genId("inventory_tx"),
+    inventoryId: input.inventoryId != null ? String(input.inventoryId) : null,
+    type,
+    qtyDelta: Number(input.qtyDelta) || 0,
+    unitCostSnapshot: input.unitCostSnapshot != null ? Number(input.unitCostSnapshot) : null,
+    sourceType: input.sourceType || null,
+    sourceId: input.sourceId || null,
+    sourceItemId: input.sourceItemId || null,
+    dateISO: input.dateISO || (typeof ymd === "function" ? ymd(new Date()) : new Date().toISOString().slice(0, 10)),
+    createdAtISO: new Date().toISOString(),
+    actor: input.actor || "system",
+    notes: input.notes || "",
+    reversalOfTransactionId: input.reversalOfTransactionId || null,
+    idempotencyKey: input.idempotencyKey || null,
+    legacyApplied: !!input.legacyApplied,
+    dryRun: !!input.dryRun
+  };
+}
+
+function recordInventoryTransaction(candidate){
+  if (!candidate) return { created: false, reason: "missing_candidate" };
+  const flags = getDataSafetyFlagsRuntime();
+  if (!Array.isArray(window.inventoryTransactions)) window.inventoryTransactions = [];
+  if (candidate.idempotencyKey && hasInventoryTransactionIdempotencyKey(candidate.idempotencyKey)){
+    console.warn("[InventoryTx] Duplicate idempotency key prevented:", candidate.idempotencyKey);
+    appendSyncProcessLog({ eventType: "inventory_transaction_duplicate", targetArea: "inventoryTransactions", status: "skipped_duplicate", dryRun: true, message: "Duplicate idempotency key prevented." });
+    return { created: false, reason: "duplicate_idempotency" };
+  }
+  const txDryRun = !flags.ENABLE_INVENTORY_TRANSACTIONS || flags.ENABLE_INVENTORY_TRANSACTIONS_DRY_RUN;
+  const tx = { ...candidate, dryRun: txDryRun };
+  if (txDryRun){
+    console.log("[InventoryTx:DRY_RUN]", tx);
+    appendSyncProcessLog({ eventType: "inventory_transaction_candidate", targetArea: "inventoryTransactions", inventoryId: tx.inventoryId || null, qtyDelta: tx.qtyDelta, status: "dry_run", dryRun: true, message: `Transaction candidate: ${tx.type}` });
+    return { created: false, reason: "dry_run", tx };
+  }
+  window.inventoryTransactions.push(tx);
+  console.log("[InventoryTx]", tx);
+  appendSyncProcessLog({ eventType: "inventory_transaction_created", targetArea: "inventoryTransactions", inventoryId: tx.inventoryId || null, qtyDelta: tx.qtyDelta, status: "created", dryRun: false, message: `Transaction created: ${tx.type}` });
+  return { created: true, tx };
+}
+
+function applyInventoryForApprovedItems(items, options = {}){
   if (!Array.isArray(items)) return;
+  const orderRequestId = options.orderRequestId != null ? String(options.orderRequestId) : "";
   items.forEach(item => {
     if (!item) return;
-    if (!item.inventoryId) return;
+    if (!item.inventoryId){
+      console.log("[PurchaseInventoryLink:UNLINKED]", { orderRequestId, orderItemId: item.id, name: item.name || "", pn: item.pn || "" });
+      const suggestion = suggestInventoryMatchForOrderLine(item);
+      appendSyncProcessLog({
+        eventType: "order_approval_inventory_skipped",
+        sourceArea: "orderRequests",
+        sourceId: orderRequestId || null,
+        sourceItemId: item.id != null ? String(item.id) : null,
+        targetArea: "inventory",
+        status: "skipped_unlinked_inventory",
+        dryRun: true,
+        message: suggestion ? "Unlinked line skipped; suggestion available." : "Unlinked line skipped."
+      });
+      if (suggestion){
+        item.suggestedInventoryId = suggestion.suggestedInventoryId;
+        item.suggestedMatchReason = suggestion.suggestedMatchReason;
+        item.suggestedMatchConfidence = suggestion.suggestedMatchConfidence;
+      }
+      return;
+    }
+    console.log("[PurchaseInventoryLink]", { orderRequestId, orderItemId: item.id, inventoryId: item.inventoryId });
     const inv = inventory.find(x => x.id === item.inventoryId);
     if (!inv) return;
     const qty = Number(item.qty);
     if (!Number.isFinite(qty) || qty <= 0) return;
+    const idempotencyKey = `purchase_receive:${orderRequestId || "unknown"}:${String(item.id || "line")}:${String(item.inventoryId || "")}`;
+    const txCandidate = createInventoryTransactionCandidate({
+      inventoryId: item.inventoryId,
+      type: "purchase_receive",
+      qtyDelta: qty,
+      unitCostSnapshot: item.price != null ? Number(item.price) : null,
+      sourceType: "orderRequests",
+      sourceId: orderRequestId || null,
+      sourceItemId: item.id != null ? String(item.id) : null,
+      idempotencyKey,
+      legacyApplied: true,
+      notes: "Order approval inventory increase"
+    });
+    const beforeQty = Number(inv.qty);
+    recordInventoryTransaction(txCandidate);
     const baseNew = Number(inv.qtyNew);
     const baseOld = Number(inv.qtyOld);
     const nextNew = (Number.isFinite(baseNew) ? baseNew : 0) + qty;
     inv.qtyNew = nextNew;
     inv.qtyOld = Number.isFinite(baseOld) && baseOld >= 0 ? baseOld : 0;
     inv.qty = nextNew + inv.qtyOld;
+    const afterQty = Number(inv.qty);
+    console.log("[InventoryTx:DRY_RUN] Legacy qty projection", { inventoryId: inv.id, beforeQty, qtyDelta: qty, afterQty });
     if (item.price != null && (inv.price == null || inv.price === "")){
       inv.price = Number(item.price) || inv.price;
     }
@@ -21458,7 +21725,7 @@ function finalizeOrderRequest(mode){
 
   if (mode === "approveAll"){
     draft.items.forEach(item => item.status = "approved");
-    applyInventoryForApprovedItems(draft.items);
+    applyInventoryForApprovedItems(draft.items, { orderRequestId: draft.id });
     draft.status = "approved";
     draft.resolvedAt = nowISO;
     draft.code = buildOrderRequestCode(nowISO, { excludeId: draft.id });
@@ -21488,7 +21755,7 @@ function finalizeOrderRequest(mode){
       }
     });
     if (approvedItems.length){
-      applyInventoryForApprovedItems(approvedItems);
+      applyInventoryForApprovedItems(approvedItems, { orderRequestId: draft.id });
     }
     draft.status = "partial";
     draft.resolvedAt = nowISO;
@@ -21515,6 +21782,90 @@ function renderOrderRequest(){
 
   const activeCard = content.querySelector(".order-card");
   const draft = ensureActiveOrderRequest();
+  const repairModal = content.querySelector("#orderRepairModal");
+  const repairGroupsBody = content.querySelector("[data-order-repair-groups]");
+  const repairDetailsBody = content.querySelector("[data-order-repair-details]");
+  const inventorySearchInput = content.querySelector("[data-order-repair-search]");
+  const inventoryResultsBody = content.querySelector("[data-order-repair-results]");
+  const closeRepairBtn = content.querySelector("[data-order-repair-close]");
+  const createInventoryBtn = content.querySelector("[data-order-repair-create-inventory]");
+  const applyExistingBtn = content.querySelector("[data-order-repair-link-existing]");
+  let selectedGroupKey = null;
+  let selectedInventoryId = null;
+  const getGroups = ()=> collectUnlinkedOrderGroups();
+  const findGroup = (key)=> getGroups().find(group => String(group.key) === String(key)) || null;
+  const findInventoryById = (id)=> inventory.find(item => item && String(item.id) === String(id)) || null;
+  const renderInventoryResults = ()=>{
+    if (!inventoryResultsBody) return;
+    const q = String(inventorySearchInput?.value || "").trim().toLowerCase();
+    const results = (Array.isArray(inventory) ? inventory : []).filter(item => {
+      if (!item) return false;
+      if (!q) return true;
+      const token = `${item.name || ""} ${item.pn || ""} ${item.link || ""}`.toLowerCase();
+      return token.includes(q);
+    });
+    inventoryResultsBody.innerHTML = results.map(item => `
+      <tr data-repair-result-row="${escapeHtml(String(item.id))}">
+        <td><input type="radio" name="repairInventoryPick" value="${escapeHtml(String(item.id))}" ${selectedInventoryId === String(item.id) ? "checked" : ""}></td>
+        <td>${escapeHtml(item.name || "Unnamed")}</td>
+        <td>${escapeHtml(item.pn || "—")}</td>
+        <td>${Number.isFinite(Number(item.qty)) ? Number(item.qty).toFixed(2) : "0"}</td>
+        <td>${escapeHtml(item.unit || "pcs")}</td>
+        <td>${escapeHtml(item.folderId || "—")}</td>
+        <td>${item.price != null ? `$${Number(item.price).toFixed(2)}` : "—"}</td>
+      </tr>
+    `).join("") || `<tr><td colspan="7" class="small muted">No inventory matches.</td></tr>`;
+  };
+  const renderRepairDetails = ()=>{
+    if (!repairDetailsBody) return;
+    const group = selectedGroupKey ? findGroup(selectedGroupKey) : null;
+    if (!group){ repairDetailsBody.innerHTML = `<tr><td colspan="7" class="small muted">Select a group to view records.</td></tr>`; return; }
+    repairDetailsBody.innerHTML = group.items.map(item => `
+      <tr>
+        <td>${escapeHtml(item.name || "Unnamed")}</td>
+        <td>${escapeHtml(formatOrderDate(item.requestDate) || "—")}</td>
+        <td>${escapeHtml(String(item.qty || 0))}</td>
+        <td>${item.price != null ? `$${Number(item.price).toFixed(2)}` : "—"}</td>
+        <td>${escapeHtml(item.status || "pending")}</td>
+        <td>${escapeHtml(item.requestCode || item.requestId || "—")}</td>
+        <td>${item.inventoryId ? "Linked" : "Unlinked"}</td>
+      </tr>
+    `).join("");
+  };
+  const renderRepairGroups = ()=>{
+    if (!repairGroupsBody) return;
+    const groups = getGroups();
+    repairGroupsBody.innerHTML = groups.map(group => {
+      const qtyTotal = group.items.reduce((sum, item)=> sum + (Number(item.qty) || 0), 0);
+      const dates = group.items.map(item => item.requestDate).filter(Boolean).sort();
+      const dateRange = dates.length ? `${formatOrderDate(dates[0])} → ${formatOrderDate(dates[dates.length-1])}` : "—";
+      const suggestion = group.items.length ? suggestInventoryMatchForOrderLine(group.items[0]) : null;
+      return `<tr data-repair-group-row="${escapeHtml(group.key)}" class="${selectedGroupKey===group.key ? "is-selected" : ""}">
+        <td>${escapeHtml(group.partNumber || "—")}</td>
+        <td>${escapeHtml(group.names.join(", ") || "Unnamed")}</td>
+        <td>${group.items.length}</td>
+        <td>${qtyTotal}</td>
+        <td>${escapeHtml(dateRange)}</td>
+        <td>${suggestion ? escapeHtml(`${suggestion.suggestedInventoryId} (${suggestion.suggestedMatchReason})`) : "—"}</td>
+        <td><button type="button" data-repair-select-group="${escapeHtml(group.key)}">View Records</button></td>
+      </tr>`;
+    }).join("") || `<tr><td colspan="7" class="small muted">No unlinked purchase items found.</td></tr>`;
+    renderRepairDetails();
+  };
+  const openRepairModal = ()=>{
+    if (!repairModal) return;
+    selectedGroupKey = null;
+    selectedInventoryId = null;
+    renderRepairGroups();
+    renderInventoryResults();
+    repairModal.hidden = false;
+    repairModal.setAttribute("aria-hidden", "false");
+  };
+  const closeRepairModal = ()=>{
+    if (!repairModal) return;
+    repairModal.hidden = true;
+    repairModal.setAttribute("aria-hidden", "true");
+  };
 
   content.querySelectorAll("[data-order-tab]").forEach(btn => {
     btn.addEventListener("click", ()=>{
@@ -21567,6 +21918,11 @@ function renderOrderRequest(){
   });
 
   activeCard?.addEventListener("click", (e)=>{
+    const repairBtn = e.target.closest("[data-order-repair-links]");
+    if (repairBtn){
+      openRepairModal();
+      return;
+    }
     const removeBtn = e.target.closest("[data-order-remove]");
     if (removeBtn){
       const id = removeBtn.getAttribute("data-order-remove");
@@ -21614,6 +21970,57 @@ function renderOrderRequest(){
       if (confirmed) finalizeOrderRequest("deny");
       return;
     }
+  });
+  closeRepairBtn?.addEventListener("click", closeRepairModal);
+  repairModal?.addEventListener("click", (event)=>{ if (event.target === repairModal) closeRepairModal(); });
+  repairGroupsBody?.addEventListener("click", (event)=>{
+    const btn = event.target.closest("[data-repair-select-group]");
+    if (!btn) return;
+    selectedGroupKey = btn.getAttribute("data-repair-select-group");
+    renderRepairGroups();
+  });
+  inventorySearchInput?.addEventListener("input", ()=> renderInventoryResults());
+  inventoryResultsBody?.addEventListener("change", (event)=>{
+    const radio = event.target.closest("input[name='repairInventoryPick']");
+    if (!radio) return;
+    selectedInventoryId = radio.value;
+  });
+  applyExistingBtn?.addEventListener("click", ()=>{
+    if (!selectedGroupKey){ toast("Select a group first."); return; }
+    if (!selectedInventoryId){ toast("Select an inventory item first."); return; }
+    const group = findGroup(selectedGroupKey);
+    const targetInventory = findInventoryById(selectedInventoryId);
+    if (!group || !targetInventory){ toast("Unable to link selected group."); return; }
+    const hasNameConflict = (group.names || []).length > 1 || !(group.names || []).includes(String(targetInventory.name || ""));
+    if (hasNameConflict){
+      const ok = window.confirm("This part number appears under multiple names in purchase history. Linking this group will standardize those purchase lines to the selected inventory item name. Dates, quantities, prices, and statuses will remain unchanged.");
+      if (!ok) return;
+    }
+    const affected = linkPurchaseGroupToInventory(group, targetInventory, { finalName: targetInventory.name || "" });
+    if (affected > 0){ toast(`Linked ${affected} purchase item(s). No qty change applied.`); saveCloudDebounced(); renderOrderRequest(); }
+  });
+  createInventoryBtn?.addEventListener("click", ()=>{
+    if (!selectedGroupKey){ toast("Select a group first."); return; }
+    const group = findGroup(selectedGroupKey);
+    if (!group) return;
+    const nameSelect = content.querySelector("[data-repair-create-name]");
+    const customNameInput = content.querySelector("[data-repair-create-custom-name]");
+    const unitInput = content.querySelector("[data-repair-create-unit]");
+    const folderSelect = content.querySelector("[data-repair-create-folder]");
+    const priceInput = content.querySelector("[data-repair-create-price]");
+    const linkInput = content.querySelector("[data-repair-create-link]");
+    const nameChosen = (customNameInput?.value || nameSelect?.value || "").trim();
+    if (!nameChosen){ toast("Choose a final standardized name."); return; }
+    const targetInventory = createInventoryItemFromPurchaseLink({
+      name: nameChosen,
+      pn: group.partNumber || "",
+      link: String(linkInput?.value || group.items[0]?.link || ""),
+      price: priceInput?.value === "" ? (group.items[0]?.price ?? null) : Number(priceInput?.value),
+      unit: String(unitInput?.value || "pcs"),
+      folderId: String(folderSelect?.value || "") || null
+    });
+    const affected = linkPurchaseGroupToInventory(group, targetInventory, { finalName: nameChosen });
+    if (affected > 0){ toast(`Created inventory + linked ${affected} record(s). No qty change applied.`); saveCloudDebounced(); renderOrderRequest(); }
   });
 
   content.querySelectorAll("[data-order-download-history]").forEach(btn => {

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -21721,6 +21721,15 @@ function applyInventoryForApprovedItems(items, options = {}){
 function finalizeOrderRequest(mode){
   const draft = ensureActiveOrderRequest();
   if (!draft.items.length){ toast("Add at least one item to the request."); return; }
+  const unlinkedDraftItems = draft.items.filter(item => !item?.inventoryId);
+  if (unlinkedDraftItems.length){
+    console.warn("[PurchaseInventoryLink:UNLINKED]", {
+      orderRequestId: draft.id,
+      unlinkedCount: unlinkedDraftItems.length,
+      message: "Unlinked lines will not update inventory until repaired."
+    });
+    toast(`${unlinkedDraftItems.length} unlinked line(s) detected. They will be skipped for inventory updates until linked.`);
+  }
   const nowISO = new Date().toISOString();
 
   if (mode === "approveAll"){

--- a/js/views.js
+++ b/js/views.js
@@ -4902,7 +4902,7 @@ function viewOrderRequest(model){
               ${active.items.map(item => `
                 <tr>
                   <td><input type="checkbox" data-order-approve="${esc(item.id)}" ${item.selected ? "checked" : ""}></td>
-                  <td class="order-item-name">${esc(item.name || "Unnamed item")}</td>
+                  <td class="order-item-name">${esc(item.name || "Unnamed item")}<div class="small muted">${item.inventoryId ? "Linked to inventory" : (item.suggestedInventoryId ? "Suggested inventory match" : "Not linked to inventory")}</div></td>
                   <td>${esc(item.pn || "—")}</td>
                   <td><input type="number" step="0.01" min="0" data-order-price="${esc(item.id)}" value="${esc(item.priceInput || "")}" placeholder="0.00"></td>
                   <td><input type="number" min="1" step="1" data-order-qty="${esc(item.id)}" value="${esc(item.qtyInput || "1")}"></td>
@@ -4921,6 +4921,7 @@ function viewOrderRequest(model){
           <div class="order-total small" data-order-selection-row ${active.selectionTotal ? "" : "hidden"}>Selected for approval: <strong data-order-selection-value>${esc(active.selectionTotal || "$0.00")}</strong></div>
         </div>
         <div class="order-actions">
+          <button type="button" data-order-repair-links ${active.unlinkedCount ? "" : "disabled"} title="Repair missing purchase-to-inventory links">⚠️ Missing links (${Number(active.unlinkedCount || 0)})</button>
           <button type="button" data-order-download>${downloadLabel}</button>
           <button type="button" class="primary" data-order-approve-all ${!active.canApprove ? "disabled" : ""}>Mark approved</button>
           <button type="button" data-order-partial ${!active.canApprove ? "disabled" : ""}>Save partial approval</button>
@@ -4987,6 +4988,35 @@ function viewOrderRequest(model){
         <span class="label">Last update</span>
         <span class="value">${esc(summary.lastUpdated || "—")}</span>
       </div>
+      </div>`;
+  const unlinkedGroups = Array.isArray(active.unlinkedGroups) ? active.unlinkedGroups : [];
+  const nameOptions = Array.from(new Set(unlinkedGroups.flatMap(group => Array.isArray(group.names) ? group.names : []))).filter(Boolean);
+  const folderOptions = (Array.isArray(window.inventoryFolders) ? window.inventoryFolders : []).map(folder => `<option value="${esc(folder.id)}">${esc(folder.name || folder.id || "Folder")}</option>`).join("");
+  const repairModal = `
+    <div class="modal-backdrop is-visible" id="orderRepairModal" hidden aria-hidden="true">
+      <div class="modal-card" style="max-width:1100px; width:min(96vw,1100px); max-height:90vh; overflow:auto;">
+        <h3>Unlinked Purchase Items</h3>
+        <table class="order-table"><thead><tr><th>Part #</th><th>Names</th><th>Records</th><th>Total Qty</th><th>Date Range</th><th>Suggested Match</th><th>Action</th></tr></thead><tbody data-order-repair-groups><tr><td colspan="7" class="small muted">No groups loaded.</td></tr></tbody></table>
+        <h4 style="margin-top:12px;">Group Records</h4>
+        <table class="order-table"><thead><tr><th>Name</th><th>Date</th><th>Qty</th><th>Price</th><th>Status</th><th>Request Ref</th><th>Link</th></tr></thead><tbody data-order-repair-details><tr><td colspan="7" class="small muted">Select a group to view records.</td></tr></tbody></table>
+        <h4 style="margin-top:12px;">Link Existing Inventory Item</h4>
+        <input type="search" data-order-repair-search placeholder="Search inventory by name, part #, or link" style="width:100%;margin-bottom:8px;">
+        <table class="order-table"><thead><tr><th></th><th>Name</th><th>Part #</th><th>Qty</th><th>Unit</th><th>Folder</th><th>Price</th></tr></thead><tbody data-order-repair-results><tr><td colspan="7" class="small muted">No inventory loaded.</td></tr></tbody></table>
+        <h4 style="margin-top:12px;">Create New Inventory Item</h4>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;">
+          <label>Choose existing name<select data-repair-create-name><option value="">-- Choose --</option>${nameOptions.map(name => `<option value="${esc(name)}">${esc(name)}</option>`).join("")}</select></label>
+          <label>Or type final name<input type="text" data-repair-create-custom-name placeholder="Final standardized name"></label>
+          <label>Unit<input type="text" data-repair-create-unit value="pcs"></label>
+          <label>Price<input type="number" min="0" step="0.01" data-repair-create-price></label>
+          <label>Store link<input type="url" data-repair-create-link></label>
+          <label>Folder / Location<select data-repair-create-folder><option value="">-- None --</option>${folderOptions}</select></label>
+        </div>
+        <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:12px;">
+          <button type="button" data-order-repair-close>Close</button>
+          <button type="button" data-order-repair-create-inventory>Create New Inventory Item</button>
+          <button type="button" class="primary" data-order-repair-link-existing>Link Existing Inventory Item</button>
+        </div>
+      </div>
     </div>`;
 
   return `
@@ -5003,7 +5033,8 @@ function viewOrderRequest(model){
           ${tab === "history" ? historyContent : activeContent}
         </div>
       </div>
-    </div>`;
+    </div>
+    ${repairModal}`;
 }
 
 function viewDeletedItems(model){


### PR DESCRIPTION
### Motivation
- Protect production workspace and Firebase writes from preview/runtime mistakes and provide configurable safety gates for inventory/transaction operations.
- Add auditable transaction logging and idempotent inventory transaction candidates to safely model historical and new inventory changes.
- Surface and repair unlinked purchase/order lines by linking them to inventory or creating canonical inventory items to clean up historical data.

### Description
- Introduces `DATA_SAFETY_FLAGS` and runtime helpers `getDataSafetyFlags`, `canWriteWorkspace`, `warnDataSafetyContext`, `isProductionWorkspaceTarget`, and `isProductionFirebaseProjectTarget` to gate writes and emit safety warnings.
- Prevents cloud writes in unsafe contexts by checking `canWriteWorkspace` in `saveCloudInternal`, `saveCloudDebounced`, `saveCloudNow`, `loadFromCloud` (seed-write), `migrateLegacyWorkspaceDoc`, and `clearAllAppData`.
- Adds new persistence arrays and state plumbing for `inventoryTransactions` and `syncProcessLog` in global initialization, `adoptState`, and `snapshotState` to include them in snapshots.
- Implements inventory transaction helpers: `createInventoryTransactionCandidate`, `recordInventoryTransaction`, `hasInventoryTransactionIdempotencyKey`; transactions support dry-run mode and idempotency keys.
- Adds sync/log utilities: `appendSyncProcessLog` and `getDataSafetyFlagsRuntime` for controlled verbose/auditable output and dry-run logging.
- Enhances order processing: `applyInventoryForApprovedItems` now creates transaction candidates (idempotent) and records legacy/dry-run projections and suggestions for unlinked items.
- Adds purchase-repair flow: `collectUnlinkedOrderGroups`, `suggestInventoryMatchForOrderLine`, `createInventoryItemFromPurchaseLink`, `linkPurchaseGroupToInventory` to group unlinked purchase lines, suggest matches, create new inventory entries, and link historical records without applying qty changes by default.
- UI additions in `renderers.js` and `views.js`: compute model fields for suggested matches, unlinked counts/groups, a modal UI to inspect groups, search inventory, link existing inventory items, or create new inventory items from purchase history, and event handlers to perform linking/creation actions.

### Testing
- Ran project build and lint checks with `npm run build` and `npm run lint` and verified they completed without errors.
- Executed existing automated test suite with `npm test`; the test run completed and all tests passed.
- Performed smoke validation of order-request rendering and repair modal interactions via automated UI snapshot/renderer checks which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12487f2cc832598d5f9106f22ae38)