### PR TITLE
Wire efficiency rows to open jobs, improve row focusing and detail text, adjust panel styling and chart labels

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11117,6 +11117,20 @@ function renderCosts(){
       }else{
         const taskId = String(payload.taskId || "");
         const dateISO = String(payload.dateISO || "");
+        if (dateISO){
+          const selector = taskId
+            ? `[data-maintenance-row][data-task-id="${escapeForSelector(taskId)}"][data-maintenance-date-iso="${escapeForSelector(dateISO)}"]`
+            : `[data-maintenance-row][data-maintenance-date-iso="${escapeForSelector(dateISO)}"]`;
+          const matchingRows = Array.from(panelRoot.querySelectorAll(selector))
+            .filter(item => item instanceof HTMLElement);
+          if (matchingRows.length){
+            matchingRows[0].scrollIntoView({ behavior: "smooth", block: "center" });
+            matchingRows.forEach((item, idx) => {
+              setTimeout(()=> pulseRow(item), idx * 90);
+            });
+            return true;
+          }
+        }
         row = (taskId && dateISO && panelRoot.querySelector(`[data-maintenance-row][data-task-id="${escapeForSelector(taskId)}"][data-maintenance-date-iso="${escapeForSelector(dateISO)}"]`))
           || (dateISO && panelRoot.querySelector(`[data-maintenance-row][data-maintenance-date-iso="${escapeForSelector(dateISO)}"]`))
           || panelRoot.querySelector("[data-maintenance-row]");
@@ -11331,6 +11345,23 @@ function renderCosts(){
           closeDataCenter();
         }
         openPurchaseHistory({ weekKey, rowIndex });
+      });
+    }
+    if (modal instanceof HTMLElement && !modal.dataset.efficiencyRowOpenWired){
+      modal.dataset.efficiencyRowOpenWired = "1";
+      modal.addEventListener("click", (event)=>{
+        const target = event.target instanceof HTMLElement ? event.target : null;
+        if (!target) return;
+        const row = target.closest("[data-efficiency-row-link]");
+        if (!(row instanceof HTMLElement)) return;
+        if (target.closest("[data-efficiency-open-job]")) return;
+        const id = String(row.getAttribute("data-efficiency-job-id") || "");
+        if (!id) return;
+        if (typeof window !== "undefined"){
+          window.pendingJobFocus = { type: "jobRow", id };
+        }
+        closeDataCenter();
+        location.hash = "#/jobs";
       });
     }
     Array.from((modal instanceof HTMLElement ? modal : content).querySelectorAll("[data-cutting-open-job]")).forEach(btn => {
@@ -14776,7 +14807,7 @@ function computeCostModel(){
         value: pointValue,
         cutHours: Number.isFinite(Number(pt.cutHours)) && Number(pt.cutHours) > 0 ? Number(pt.cutHours) : 0,
         count: jobCount,
-        detail: `Completed cutting job #${jobCount} recorded ${pointValue >= 0 ? "a gain" : "a loss"} on ${dateLabel}.`,
+        detail: `${pt.label || `Cutting job #${jobCount}`} (${pt.jobId ? `ID ${pt.jobId}` : `record #${jobCount}`}) recorded ${pointValue >= 0 ? "a gain" : "a loss"} on ${dateLabel}.`,
         jobId: pt.jobId || null,
         dateISO: pt.dateISO || ymd(pt.date)
       });
@@ -16755,7 +16786,7 @@ function computeCostModel(){
         date,
         dateISO,
         value: -Math.abs(Number(entry?.total) || 0),
-        detail: `${detailPrefix}: ${itemPreview}${detailSuffix}.`
+        detail: `${detailPrefix}. Items: ${itemPreview}${detailSuffix}.`
       };
     });
 
@@ -16783,12 +16814,19 @@ function computeCostModel(){
         : new Date(dateISO);
       const dayRows = maintenanceTrendRows.filter(row => toHistoryDateKey(row.dateISO) === dateISO);
       const taskCount = dayRows.length;
+      const taskNames = Array.from(new Set(dayRows
+        .map(row => String(row?.taskName || "").trim())
+        .filter(Boolean)));
+      const taskPreview = taskNames.length
+        ? taskNames.slice(0, 6).join(", ")
+        : "No task names provided";
+      const taskSuffix = taskNames.length > 6 ? " …" : "";
       return {
         date,
         value: -Math.abs(totalCost),
         dateISO,
         taskId: dayRows.length === 1 ? String(dayRows[0].taskId || "") : null,
-        detail: `${taskCount} completed maintenance ${taskCount === 1 ? "occurrence" : "occurrences"} recorded in the data center table on ${dateISO}.`
+        detail: `${taskCount} completed maintenance ${taskCount === 1 ? "occurrence" : "occurrences"} recorded on ${dateISO}: ${taskPreview}${taskSuffix}.`
       };
     });
   maintenanceSeries = maintenanceSeriesFromDataTable;
@@ -17107,23 +17145,6 @@ function drawCostChart(canvas, model, show){
     if (value > 0) return `+${formatted}`;
     return formatted;
   };
-  const maintenanceAvg = Number(model?.maintenanceCostPerCutValue ?? model?.maintenanceAverageValue) || 0;
-  const spendAvg = Number(model?.totalSpendPerCutValue) || 0;
-  const cuttingAvg = Number(model?.cuttingAverageValue) || 0;
-  const maintenanceAvgLabel = model?.maintenanceCostPerCutLabel || model?.maintenanceAverageLabel || formatMoney(maintenanceAvg);
-  const spendAvgLabel = model?.totalSpendPerCutLabel || formatMoney(spendAvg);
-  const cuttingAvgLabel = model?.cuttingAverageLabel || formatMoney(cuttingAvg);
-  const maintenanceWindowLabel = String(model?.maintenanceCostPerCutWindowLabel || "selected range");
-
-  ctx.font = "12px sans-serif";
-  ctx.textAlign = "left";
-  ctx.fillStyle = model.chartColors.maintenance;
-  ctx.fillText(`Avg maint cost/cut hr (${maintenanceWindowLabel}): ${maintenanceAvgLabel}`, left, 14);
-  ctx.fillStyle = model.chartColors.spend;
-  ctx.fillText(`Avg total spend/cut hr (${maintenanceWindowLabel}): ${spendAvgLabel}`, left, 30);
-  ctx.fillStyle = model.chartColors.jobs;
-  ctx.fillText(`Avg cutting gain/loss: ${cuttingAvgLabel}`, Math.max(left + 300, W * 0.5), 14);
-
   if (0 >= yMin && 0 <= yMax){
     const zeroY = Y(0);
     ctx.strokeStyle = "#d0d5e2";

--- a/js/views.js
+++ b/js/views.js
@@ -2294,10 +2294,10 @@ function viewCosts(model){
                   <div><span class="label">Avg net gain / row</span><span>${esc(efficiencySnapshot.averageNetGainLabel || "$0.00")}</span></div>
                 </div>
                 <table class="cost-table" style="margin-top:10px">
-                  <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Run cost</th><th>Total cost</th><th>Net gain</th></tr></thead>
+                  <thead><tr><th>Task</th><th>Date</th><th>Hours</th><th>Part cost</th><th>Run cost</th><th>Total cost</th><th>Net gain</th><th>Job link</th></tr></thead>
                   <tbody>
                     ${efficiencyRows.map(row => `
-                      <tr>
+                      <tr data-efficiency-row-link data-efficiency-job-id="${esc(row.id || "")}">
                         <td>${esc(row.taskName || "Completed task")}</td>
                         <td>${esc(row.dateLabel || "—")}</td>
                         <td>${esc(row.hoursLabel || "0 hr")}</td>
@@ -2305,6 +2305,7 @@ function viewCosts(model){
                         <td>${esc(row.laborCostLabel || "$0.00")}</td>
                         <td>${esc(row.totalCostLabel || "$0.00")}</td>
                         <td>${esc(row.netGainLabel || "$0.00")}</td>
+                        <td>${row.settingsLink ? `<button type="button" class="btn secondary" data-efficiency-open-job="${esc(row.id || "")}">Open job</button>` : "Invalid link"}</td>
                       </tr>
                     `).join("")}
                   </tbody>

--- a/style.css
+++ b/style.css
@@ -521,6 +521,11 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
 .cost-data-center-tabs{ display:flex; gap:8px; margin-bottom:10px; }
 .cost-data-center-tab{ border:1px solid #a8b6ce; background:#eef3ff; color:#0b1a38; padding:7px 12px; border-radius:6px; cursor:pointer; font-weight:600; }
 .cost-data-center-tab.is-active{ background:#0a63c2; color:#fff; border-color:#0a63c2; }
+.cost-data-center-panel-content{
+  max-height:none;
+  overflow:visible;
+  padding-right:0;
+}
 .cost-data-center-panel-content[hidden]{ display:none !important; }
 .cost-data-center-search{ display:flex; flex-direction:column; gap:6px; margin-bottom:10px; max-width:360px; }
 .cost-data-center-search label{ font-weight:600; font-size:14px; }


### PR DESCRIPTION
### Motivation
- Allow maintenance/efficiency rows in the Cost Data Center to open the related job in the Jobs view and to be focused by date/task identifiers. 
- Make series detail text more informative by including labels/IDs and item/task previews for cutting, spend, and maintenance series. 
- Fix layout issues in the data-center panel content and remove duplicated/overlapping average labels from the chart rendering.

### Description
- Added maintenance row focusing logic to `renderCosts` so maintenance rows can be located and pulsed when `dateISO` and/or `taskId` are provided. 
- Wired an efficiency-row click handler in `renderers.js` that sets `window.pendingJobFocus` and navigates to `#/jobs` while avoiding interference when an explicit "Open job" button is clicked. 
- Updated the efficiency panel HTML in `views.js` to add `data-efficiency-row-link`, `data-efficiency-job-id` on table rows and a new "Job link" column with a `data-efficiency-open-job` button. 
- Improved detail strings in `computeCostModel` for cutting job series, spend series, and maintenance series to include job IDs/labels and previews of item/task names. 
- Removed in-canvas average label text from the cost chart drawing to reduce visual clutter. 
- Added CSS rules for `.cost-data-center-panel-content` to prevent undesired clipping and ensure content overflow/scroll behavior is visible.

### Testing
- Ran the project's automated test suite with `npm test`, and the test run completed successfully. 
- Ran the linter with `npm run lint`, which passed without new warnings. 
- Built the frontend with `npm run build` to verify the bundle compiles successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11a294ae083258df5a044d59d7400)