### PR TITLE
Add Clear All and Undo to Purchase History modal

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11967,6 +11967,8 @@ function renderCosts(){
       const rangeLabel = modal.querySelector("[data-receipt-range-label]");
       const closeControls = Array.from(modal.querySelectorAll("[data-receipt-close]"));
       const saveWeekBtn = modal.querySelector("[data-receipt-save-week]");
+      const clearAllBtn = modal.querySelector("[data-receipt-clear-all]");
+      const undoClearBtn = modal.querySelector("[data-receipt-undo-clear]");
       const exportWeekBtn = modal.querySelector("[data-receipt-export-week]");
       const exportRangeBtn = modal.querySelector("[data-receipt-export-range]");
       const purchasedDatalistId = "receiptPurchasedSuggestions";
@@ -11981,6 +11983,7 @@ function renderCosts(){
       let activeRange = String(window.receiptTrackerRangeSelected || "1");
       let hasUnsavedReceiptChanges = false;
       let hasExplicitSaveSinceEdit = false;
+      let purchaseHistoryUndoSnapshot = null;
       window.receiptTrackerWeekSelected = activeWeekKey;
       window.receiptTrackerRangeSelected = activeRange;
       let saveStatusTimer = null;
@@ -12080,6 +12083,18 @@ function renderCosts(){
           if (showInlineStatus) showSaveStatusChip("Save failed", true);
         }
         return false;
+      };
+      const setUndoClearEnabled = (enabled)=>{
+        if (!(undoClearBtn instanceof HTMLButtonElement)) return;
+        undoClearBtn.disabled = !enabled;
+      };
+      const snapshotPurchaseHistory = ()=>{
+        return Array.isArray(window.receiptTrackerWeeks)
+          ? window.receiptTrackerWeeks.map(week => ({
+              ...week,
+              rows: normalizeRows(week?.rows).map(row => ({ ...row }))
+            }))
+          : [];
       };
       const rebuildPurchaseTemplates = ()=>{
         purchaseTemplates.clear();
@@ -12296,6 +12311,48 @@ function renderCosts(){
           saveWeekBtn.textContent = prevLabel || "Save week";
         });
       }
+      if (clearAllBtn instanceof HTMLButtonElement){
+        clearAllBtn.addEventListener("click", async ()=>{
+          purchaseHistoryUndoSnapshot = snapshotPurchaseHistory();
+          setUndoClearEnabled(Array.isArray(purchaseHistoryUndoSnapshot) && purchaseHistoryUndoSnapshot.length > 0);
+          if (Array.isArray(window.receiptTrackerWeeks)){
+            window.receiptTrackerWeeks = window.receiptTrackerWeeks.map(week => ({ ...week, rows: [] }));
+          } else {
+            window.receiptTrackerWeeks = [];
+          }
+          hasUnsavedReceiptChanges = true;
+          hasExplicitSaveSinceEdit = false;
+          persistReceiptState();
+          rebuildPurchaseTemplates();
+          renderWeekRows();
+          renderRangeTable();
+          renderCentralSpendRows();
+          await savePurchaseHistoryWeek({ showInlineStatus: true, refreshDashboard: true, keepReceiptModalOpen: true });
+          if (typeof toast === "function") toast("Purchase history cleared. Use Undo clear to restore.");
+        });
+      }
+      if (undoClearBtn instanceof HTMLButtonElement){
+        undoClearBtn.addEventListener("click", async ()=>{
+          if (!Array.isArray(purchaseHistoryUndoSnapshot)) return;
+          window.receiptTrackerWeeks = purchaseHistoryUndoSnapshot.map(week => ({
+            ...week,
+            rows: normalizeRows(week?.rows).map(row => ({ ...row }))
+          }));
+          purchaseHistoryUndoSnapshot = null;
+          setUndoClearEnabled(false);
+          hasUnsavedReceiptChanges = true;
+          hasExplicitSaveSinceEdit = false;
+          persistReceiptState();
+          rebuildPurchaseTemplates();
+          renderWeekOptions();
+          renderWeekRows();
+          renderRangeTable();
+          renderCentralSpendRows();
+          await savePurchaseHistoryWeek({ showInlineStatus: true, refreshDashboard: true, keepReceiptModalOpen: true });
+          if (typeof toast === "function") toast("Purchase history restore complete.");
+        });
+      }
+      setUndoClearEnabled(false);
       if (exportWeekBtn instanceof HTMLElement){
         exportWeekBtn.addEventListener("click", ()=>{
           const entry = saveWeekRowsFromDom();

--- a/js/views.js
+++ b/js/views.js
@@ -1871,6 +1871,8 @@ function viewCosts(model){
               <select data-receipt-week-select aria-label="Select purchase history week"></select>
             </label>
             <button type="button" class="btn" data-receipt-save-week>Save week</button>
+            <button type="button" class="btn secondary" data-receipt-clear-all>Clear all</button>
+            <button type="button" class="btn secondary" data-receipt-undo-clear disabled>Undo clear</button>
             <button type="button" class="btn secondary" data-receipt-export-week>Export week (CSV)</button>
             <button type="button" class="btn secondary" data-receipt-export-range>Export range (CSV)</button>
           </div>


### PR DESCRIPTION
### Motivation
- Provide a safe, modal-scoped way to clear purchase-history rows from the Purchase History popup in the Cost Analysis view without affecting maintenance or other datasets.
- Allow users to recover from accidental clears by offering an immediate `Undo clear` action.

### Description
- Added two controls to the Purchase History modal UI: a `Clear all` button (`data-receipt-clear-all`) and an `Undo clear` button (`data-receipt-undo-clear`) in `js/views.js`.
- Implemented modal-scoped logic in `js/renderers.js` that snapshots `window.receiptTrackerWeeks` via `snapshotPurchaseHistory()`, clears only the weekly purchase `rows`, and exposes `setUndoClearEnabled()` to toggle the undo button.
- On clear the code calls `persistReceiptState()`, `rebuildPurchaseTemplates()`, `renderWeekRows()`, `renderRangeTable()`, `renderCentralSpendRows()`, and runs the existing `savePurchaseHistoryWeek()` flow so the UI and persisted state stay in sync.
- The `Undo clear` handler restores the in-memory snapshot of `receiptTrackerWeeks`, refreshes templates and views, and re-saves the restored data.
- No other datasets (maintenance, cutting jobs, etc.) are modified by these actions.

### Testing
- No automated tests exist for this UI area, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27e97b2708325b34069a85bfa85cc)