### PR TITLE
Style maintenance data center table and center Data Center button

### DIFF
--- a/style.css
+++ b/style.css
@@ -545,6 +545,20 @@ body.cost-timeframe-modal-open{ overflow:hidden; }
   color:#000;
 }
 body.cost-data-center-open{ overflow:hidden; }
+
+[data-cost-window="dataCenter"] [data-open-data-center]{
+  display:block;
+  margin:0 auto;
+}
+
+.cost-data-center-panel [data-dc-panel="maintenance"] .cost-table{
+  border:3px solid #0f172a;
+  border-collapse:collapse;
+}
+.cost-data-center-panel [data-dc-panel="maintenance"] .cost-table th,
+.cost-data-center-panel [data-dc-panel="maintenance"] .cost-table td{
+  border:1px solid rgba(15,23,42,0.35);
+}
 .time-efficiency-tooltip{
   position:fixed;
   z-index:100100;


### PR DESCRIPTION
### Motivation
- Improve readability and layout of the Cost Analysis "Maintenance Data Center Table" by adding a stronger table outline and centering the launch button.

### Description
- Added scoped CSS to `style.css` to center the `Open Data Center` button inside the Cost Analysis data center card and to add a `3px` solid outline plus `1px` cell borders to the maintenance data center table; confirmed `vercel.json` contains the required exact `{"cleanUrls": true}` content.

### Testing
- No automated tests were executed since this is a CSS-only change, and the update was validated by inspecting the `style.css` diff to ensure the new selectors and rules were applied as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27efbb8dc8325af09032c0e379c2b)