### PR TITLE
Rename weekly report wording: ‘Cuts cost’ → ‘Cuts profit’ (chart & export)

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -11756,9 +11756,9 @@ function renderCosts(){
           <h2>Weekly Cost Report</h2>
           <div class="summary"><strong>Week:</strong> ${escHtml(weekTitle)}</div>
           <table>
-            <thead><tr><th colspan="4">Cuts completed</th></tr><tr><th>Cut</th><th>Category</th><th>Hours</th><th>Cost impact</th></tr></thead>
+            <thead><tr><th colspan="4">Cuts completed</th></tr><tr><th>Cut</th><th>Category</th><th>Hours</th><th>Profit impact</th></tr></thead>
             <tbody>${cutsRows}</tbody>
-            <tfoot class="totals"><tr><td colspan="3">Cuts total</td><td>${escHtml(report.totalCutCostLabel || "$0")}</td></tr><tr><td colspan="3">Cutting time</td><td>${escHtml(report.totalCutHoursLabel || "0 hr")}</td></tr></tfoot>
+            <tfoot class="totals"><tr><td colspan="3">Cuts total profit</td><td>${escHtml(report.totalCutCostLabel || "$0")}</td></tr><tr><td colspan="3">Cutting time</td><td>${escHtml(report.totalCutHoursLabel || "0 hr")}</td></tr></tfoot>
           </table>
           <table>
             <thead><tr><th colspan="4">Maintenance completed</th></tr><tr><th>Task</th><th>Type</th><th>Part #</th><th>Cost</th></tr></thead>
@@ -16936,7 +16936,7 @@ function drawWeeklyReportChart(canvas, report){
   const weeklyHoursActual = Math.max(0, Number(report.totalCutHours) || 0);
   const weeklyHoursGoal = 40;
   const costBars = [
-    { label: "Cuts cost", value: Math.max(0, Number(report.totalCutCost) || 0), color: "#2e7d32" },
+    { label: "Cuts profit", value: Math.max(0, Number(report.totalCutCost) || 0), color: "#2e7d32" },
     { label: "Maintenance cost", value: Math.abs(Number(report.totalMaintenanceCost) || 0), color: "#0a63c2" }
   ];
 


### PR DESCRIPTION
### Motivation
- Clarify the weekly report so the bar chart and exported workbook reflect "profit" rather than "cost" for cuts, matching the intended metric.
- No skills were used to make this change.

### Description
- Updated the chart label in `drawWeeklyReportChart` from `"Cuts cost"` to `"Cuts profit"` in `js/renderers.js`.
- Updated the exported workbook HTML in `renderCosts` to change the column header from `Cost impact` to `Profit impact` and the totals row from `Cuts total` to `Cuts total profit` in `js/renderers.js`.
- No other files were modified and `vercel.json` already matched the required content and was left unchanged.

### Testing
- Ran repository-wide searches to confirm original strings were removed and the new strings (`"Cuts profit"`, `"Profit impact"`, `"Cuts total profit"`) are present; the searches succeeded.
- Verified the only code change is in `js/renderers.js` and that `vercel.json` remains exactly `{ "cleanUrls": true }`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27f4a38548325aa53849e1f3b6f4d)