### PR TITLE
Sort completed cutting jobs by cumulative counter (C#) descending

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -16126,18 +16126,25 @@ function computeCostModel(){
     emptyMessage: orderRows.length ? "" : "Approve or deny order requests to build the spend log."
   };
 
-  const completedJobsForDataCenter = (Array.isArray(completedCuttingJobs) ? completedCuttingJobs.slice() : [])
+  const completedJobsInCounterOrder = Array.isArray(completedCuttingJobs) ? completedCuttingJobs.slice() : [];
+  const completedJobCounterById = new Map();
+  completedJobsInCounterOrder.forEach((job, index) => {
+    const key = job?.id != null ? String(job.id) : `completed_job_${index}`;
+    completedJobCounterById.set(key, index + 1);
+  });
+  const completedJobsForDataCenter = completedJobsInCounterOrder
     .sort((a, b) => {
-      const aDate = String(a?.completedAtISO || a?.dueISO || a?.startISO || "");
-      const bDate = String(b?.completedAtISO || b?.dueISO || b?.startISO || "");
-      return bDate.localeCompare(aDate);
+      const aKey = a?.id != null ? String(a.id) : "";
+      const bKey = b?.id != null ? String(b.id) : "";
+      const aCounter = completedJobCounterById.get(aKey) || 0;
+      const bCounter = completedJobCounterById.get(bKey) || 0;
+      return bCounter - aCounter;
     });
   const cuttingCategoryRemaining = new Map();
   completedJobsForDataCenter.forEach(job => {
     const key = job?.cat != null ? String(job.cat) : "__uncategorized__";
     cuttingCategoryRemaining.set(key, (cuttingCategoryRemaining.get(key) || 0) + 1);
   });
-  const totalCompletedJobs = completedJobsForDataCenter.length;
   const cuttingJobsDataTable = completedJobsForDataCenter.map((job, index) => {
     const categoryId = job?.cat != null ? String(job.cat) : "";
     const categoryLabel = categoryId ? resolveCategoryName(categoryId) : "Uncategorized";
@@ -16179,7 +16186,7 @@ function computeCostModel(){
       projectNumber: String(job?.projectNumber || "—"),
       notes: String(job?.notes || "").trim() || "—",
       priorityLabel: Number.isFinite(Number(job?.priority)) ? String(Math.max(1, Math.floor(Number(job.priority)))) : "—",
-      cumulativeCutNumberLabel: `#${Math.max(1, totalCompletedJobs - index)}`,
+      cumulativeCutNumberLabel: `C${Math.max(1, completedJobCounterById.get(job?.id != null ? String(job.id) : `completed_job_${index}`) || 0)}`,
       categoryCutNumberLabel: `#${categoryCutCount}`,
       hoursValue: hours,
       chargeRateValue: chargeRate,

--- a/js/views.js
+++ b/js/views.js
@@ -2882,11 +2882,7 @@ function viewJobs(){
   }
   const addFormOpen = addFormOpenState;
   const completedJobs = Array.isArray(window.completedCuttingJobs) ? window.completedCuttingJobs.slice() : [];
-  const completedSorted = completedJobs.sort((a,b)=>{
-    const aTime = new Date(a.completedAtISO || a.dueISO || a.startISO || 0).getTime();
-    const bTime = new Date(b.completedAtISO || b.dueISO || b.startISO || 0).getTime();
-    return bTime - aTime;
-  });
+  const completedSorted = completedJobs.slice();
   const allJobsForCutNumbers = (Array.isArray(cuttingJobs) ? cuttingJobs : []).concat(completedJobs).filter(Boolean);
   const addedOrderFromId = (job)=>{
     const id = String(job?.id || "");
@@ -2924,6 +2920,16 @@ function viewJobs(){
   });
   const jobCutLabel = (job)=> jobCutMap.get(String(job?.id || "")) || "C000";
   const jobCategoryCutLabel = (job)=> jobCategoryCutMap.get(String(job?.id || "")) || "0";
+  const cutNumberValue = (job)=> {
+    const label = jobCutLabel(job);
+    const numeric = Number.parseInt(String(label).replace(/[^\d]/g, ""), 10);
+    return Number.isFinite(numeric) ? numeric : 0;
+  };
+  completedSorted.sort((a, b) => {
+    const diff = cutNumberValue(b) - cutNumberValue(a);
+    if (diff !== 0) return diff;
+    return String(b?.completedAtISO || b?.dueISO || b?.startISO || "").localeCompare(String(a?.completedAtISO || a?.dueISO || a?.startISO || ""));
+  });
   const jobNameWithCut = (job, fallback = "Job")=> `${String(job?.name || fallback)} · ${jobCutLabel(job)} · ${jobCategoryCutLabel(job)}`;
   const historySearchRaw = typeof jobHistorySearchTerm === "string"
     ? jobHistorySearchTerm


### PR DESCRIPTION
### Motivation
- Completed cutting jobs should be displayed in order of the global cumulative job counter (C1, C2, ...) with the highest number at the top and lowest at the bottom instead of being ordered by completion date. 
- The UI should present the cumulative counter in the `C<number>` format to match the global assignment counter. 
- Ensure the repository keeps the exact required `vercel.json` content (`{ "cleanUrls": true }`) with no legacy `builds` section.

### Description
- Built a `completedJobCounterById` map from the original completed jobs array order and introduced `completedJobsInCounterOrder` to preserve the cumulative assignment order. 
- Sorted `completedJobsForDataCenter` by the mapped cumulative counter in descending order and removed the previous date-based sort. 
- Switched the displayed `cumulativeCutNumberLabel` to `C<number>` using the mapped counter and left category-specific numbering intact. 
- Replaced or ensured `vercel.json` contains exactly `{ "cleanUrls": true }` and did not add any `builds` section.

### Testing
- Inspected code references with repository searches (e.g. `rg`) to locate affected rendering paths and confirm the single-area change executed successfully. 
- Reviewed the working tree and patch with `git status --short` and `git diff -- js/renderers.js vercel.json | sed -n '1,220p'`, which displayed the expected modifications. 
- Verified `vercel.json` contents with `cat vercel.json` and committed the changes with `git commit`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b01df24c8325b0fddcf2da44942a)