### PR TITLE
Add sync/process logging and purchase→inventory linking UI + data-center views

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -565,8 +565,13 @@ function markCalendarTaskComplete(meta, dateISO){
   const task = meta.task;
   const mode = meta.mode === "asreq" || task.mode === "asreq" ? "asreq" : "interval";
   let changed = false;
+  const clearRemovedForKey = (member)=>{
+    if (!member || typeof member !== "object") return false;
+    return clearRemovedOccurrences(member, value => normalizeDateKey(value) === key);
+  };
 
   if (mode === "interval"){
+    if (clearRemovedForKey(task)) changed = true;
     const currentHoursRaw = typeof getCurrentMachineHours === "function" ? getCurrentMachineHours() : null;
     const currentHours = currentHoursRaw != null && Number.isFinite(Number(currentHoursRaw)) ? Number(currentHoursRaw) : null;
     if (currentHours != null){
@@ -630,6 +635,7 @@ function markCalendarTaskComplete(meta, dateISO){
     }
     changed = true;
   }else{
+    if (clearRemovedForKey(task)) changed = true;
     if (!Array.isArray(task.completedDates)) task.completedDates = [];
     if (!task.completedDates.includes(key)){
       task.completedDates.push(key);

--- a/js/core.js
+++ b/js/core.js
@@ -2099,6 +2099,9 @@ function snapshotState(){
     weeklyCostReports: Array.isArray(window.weeklyCostReports)
       ? window.weeklyCostReports.map(entry => ({ ...entry }))
       : [],
+    syncProcessLog: Array.isArray(window.syncProcessLog)
+      ? window.syncProcessLog.map(entry => ({ ...entry }))
+      : [],
     appConfig: normalizeAppConfig(window.appConfig),
     pumpEff: safePumpEff,
     deletedItems: trashSnapshot,
@@ -2790,6 +2793,7 @@ function adoptState(doc){
   opportunityRollups = Array.isArray(data.opportunityRollups) ? data.opportunityRollups : [];
   weeklyCostReports = Array.isArray(data.weeklyCostReports) ? data.weeklyCostReports.map(entry => ({ ...entry })) : [];
   receiptTrackerWeeks = Array.isArray(data.receiptTrackerWeeks) ? data.receiptTrackerWeeks.map(entry => ({ ...entry })) : [];
+  window.syncProcessLog = Array.isArray(data.syncProcessLog) ? data.syncProcessLog.map(entry => ({ ...entry })) : (Array.isArray(window.syncProcessLog) ? window.syncProcessLog : []);
 
   window.totalHistory = totalHistory;
   window.tasksInterval = tasksInterval;
@@ -3006,6 +3010,112 @@ const saveCloudInternal = debounce(async ()=>{
     console.error("Cloud save failed:", e);
   }
 }, 300);
+function recordDataFlowEvent(trigger = "save", nextSnapshot = null){
+  try {
+    if (!Array.isArray(window.syncProcessLog)) window.syncProcessLog = [];
+    const prev = window.__lastSnapshotForFlow && typeof window.__lastSnapshotForFlow === "object" ? window.__lastSnapshotForFlow : null;
+    const next = nextSnapshot && typeof nextSnapshot === "object" ? nextSnapshot : null;
+    const trackedKeys = ["totalHistory", "tasksInterval", "tasksAsReq", "inventory", "inventoryFolders", "receiptTrackerWeeks", "orderRequests", "cuttingJobs", "completedCuttingJobs", "dailyCutHours", "garnetCleanings", "settingsFolders"];
+    const skipTrigger = /history|syncprocesslog|data_flow_save/i.test(String(trigger || ""));
+    if (skipTrigger){
+      if (next) window.__lastSnapshotForFlow = next;
+      return;
+    }
+    const changedAreas = [];
+    const details = [];
+    if (prev && next){
+      trackedKeys.forEach(key => {
+        const beforeVal = prev[key] ?? null;
+        const afterVal = next[key] ?? null;
+        const a = getAreaSignature(key, beforeVal);
+        const b = getAreaSignature(key, afterVal);
+        if (a !== b){
+          changedAreas.push(key);
+          const beforeCount = Array.isArray(beforeVal) ? beforeVal.length : (beforeVal && typeof beforeVal === "object" ? Object.keys(beforeVal).length : (beforeVal == null ? 0 : 1));
+          const afterCount = Array.isArray(afterVal) ? afterVal.length : (afterVal && typeof afterVal === "object" ? Object.keys(afterVal).length : (afterVal == null ? 0 : 1));
+          details.push(`${key}: ${beforeCount} -> ${afterCount}`);
+        }
+      });
+    } else if (!prev && next){
+      trackedKeys.forEach(key => {
+        const afterVal = next[key] ?? null;
+        const afterCount = Array.isArray(afterVal) ? afterVal.length : (afterVal && typeof afterVal === "object" ? Object.keys(afterVal).length : (afterVal == null ? 0 : 1));
+        if (afterCount > 0){
+          changedAreas.push(key);
+          details.push(`${key}: initialized -> ${afterCount}`);
+        }
+      });
+    }
+    if (!changedAreas.length){
+      if (next) window.__lastSnapshotForFlow = next;
+      return;
+    }
+    const fingerprint = `${changedAreas.join(",")}::${details.join("|")}::${String(trigger || "")}`;
+    if (window.__lastDataFlowFingerprint === fingerprint){
+      if (next) window.__lastSnapshotForFlow = next;
+      return;
+    }
+    window.syncProcessLog.unshift({
+      atISO: new Date().toISOString(),
+      eventType: "data_flow_save",
+      status: "saved",
+      sourceArea: trigger,
+      targetArea: changedAreas.join(","),
+      message: `WHAT changed: ${details.join(" | ")}; FROM: ${trigger}; TO: ${changedAreas.join(", ")}; HOW: state diff on save.`
+    });
+    window.__lastDataFlowFingerprint = fingerprint;
+    if (window.syncProcessLog.length > 1000) window.syncProcessLog.length = 1000;
+    if (next) window.__lastSnapshotForFlow = next;
+  } catch (_err){}
+}
+function stableStringify(value){
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(item => stableStringify(item)).join(",")}]`;
+  const keys = Object.keys(value).sort();
+  return `{${keys.map(k => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(",")}}`;
+}
+function getAreaSignature(areaKey, areaValue){
+  if (!Array.isArray(areaValue) && (!areaValue || typeof areaValue !== "object")) return stableStringify(areaValue);
+  if (areaKey === "inventory"){
+    const rows = Array.isArray(areaValue) ? areaValue.slice() : [];
+    rows.sort((a,b)=> String(a?.id || a?.pn || a?.name || "").localeCompare(String(b?.id || b?.pn || b?.name || "")));
+    return stableStringify(rows.map(item => ({
+      id: item?.id ?? null, name: item?.name ?? null, pn: item?.pn ?? null, qtyNew: item?.qtyNew ?? null, qtyOld: item?.qtyOld ?? null, unit: item?.unit ?? null, price: item?.price ?? null, folderId: item?.folderId ?? null, link: item?.link ?? null
+    })));
+  }
+  if (areaKey === "receiptTrackerWeeks"){
+    const weeks = Array.isArray(areaValue) ? areaValue.slice() : [];
+    weeks.sort((a,b)=> String(a?.key || "").localeCompare(String(b?.key || "")));
+    return stableStringify(weeks.map(week => ({
+      key: week?.key ?? null,
+      startISO: week?.startISO ?? null,
+      endISO: week?.endISO ?? null,
+      rows: (Array.isArray(week?.rows) ? week.rows.slice() : []).map(row => ({
+        date: row?.date ?? null, purchased: row?.purchased ?? null, cost: row?.cost ?? null, qty: row?.qty ?? null, partNumber: row?.partNumber ?? null, inventoryItemId: row?.inventoryItemId ?? null, shipping: row?.shipping ?? null, tax: row?.tax ?? null
+      })).sort((a,b)=> `${a.date||""}|${a.purchased||""}|${a.partNumber||""}`.localeCompare(`${b.date||""}|${b.purchased||""}|${b.partNumber||""}`))
+    })));
+  }
+  return stableStringify(areaValue);
+}
+function getTrackedStateSignature(snapshot){
+  const snap = snapshot && typeof snapshot === "object" ? snapshot : {};
+  const tracked = {
+    totalHistory: snap.totalHistory ?? null,
+    tasksInterval: snap.tasksInterval ?? null,
+    tasksAsReq: snap.tasksAsReq ?? null,
+    inventory: snap.inventory ?? null,
+    inventoryFolders: snap.inventoryFolders ?? null,
+    receiptTrackerWeeks: snap.receiptTrackerWeeks ?? null,
+    orderRequests: snap.orderRequests ?? null,
+    cuttingJobs: snap.cuttingJobs ?? null,
+    completedCuttingJobs: snap.completedCuttingJobs ?? null,
+    dailyCutHours: snap.dailyCutHours ?? null,
+    garnetCleanings: snap.garnetCleanings ?? null,
+    settingsFolders: snap.settingsFolders ?? null
+  };
+  const normalized = Object.fromEntries(Object.entries(tracked).map(([k,v]) => [k, getAreaSignature(k, v)]));
+  return stableStringify(normalized);
+}
 function saveCloudDebounced(){
   if (isVercelPreviewRuntime()) return;
   try {

--- a/js/core.js
+++ b/js/core.js
@@ -1751,6 +1751,11 @@ function completeCuttingJob(jobId, { completedAtISO = null, normalizePriorities 
   completedCuttingJobs.push(completed);
   window.completedCuttingJobs = completedCuttingJobs;
 
+  if (typeof saveCloudDebounced === "function") saveCloudDebounced();
+  if (typeof saveCloudNow === "function"){
+    try { saveCloudNow(); } catch (err){ console.warn("Immediate save failed after completing cutting job", err); }
+  }
+
   return completed;
 }
 

--- a/js/core.js
+++ b/js/core.js
@@ -508,6 +508,7 @@ let firebaseSettingsApplied = false;
 let workspaceMetadataWritesBlocked = false;
 let workspaceStateUnsubscribe = null;
 let lastAppliedCloudRevision = 0;
+let hasPendingLocalChanges = false;
 const CLOUD_SYNC_CLIENT_KEY = "cloud_sync_client_id_v1";
 
 function getCloudSyncClientId(){
@@ -785,6 +786,7 @@ function startWorkspaceStateListener(){
     const incomingRev = Number(meta?.rev || 0);
     if (!incomingRev) return;
     const incomingBy = String(meta?.updatedBy || "");
+    if (hasPendingLocalChanges) return;
     if (incomingRev && incomingRev <= lastAppliedCloudRevision) return;
     if (incomingRev && incomingBy === localClientId && incomingRev === lastAppliedCloudRevision) return;
     adoptState(incoming || {});
@@ -3027,6 +3029,7 @@ const saveCloudInternal = debounce(async ()=>{
       const el = document.getElementById("dbgSnap");
       if (el) el.value = JSON.stringify(snap, null, 2);
     }
+    hasPendingLocalChanges = false;
     if (FB.workspaceDoc){
       await updateWorkspaceMetadata({
         workspaceId: WORKSPACE_ID,
@@ -3145,6 +3148,7 @@ function getTrackedStateSignature(snapshot){
 }
 function saveCloudDebounced(){
   if (isVercelPreviewRuntime()) return;
+  hasPendingLocalChanges = true;
   try {
     if (typeof setSettingsFolders === "function") setSettingsFolders(window.settingsFolders);
   } catch (err) {
@@ -3159,6 +3163,7 @@ function saveCloudDebounced(){
 }
 function saveCloudNow(){
   if (isVercelPreviewRuntime()) return;
+  hasPendingLocalChanges = true;
   try {
     if (typeof setSettingsFolders === "function") setSettingsFolders(window.settingsFolders);
   } catch (err) {
@@ -3250,7 +3255,8 @@ async function loadFromCloud(){
       if (seededRev > 0) lastAppliedCloudRevision = seededRev;
       if (typeof resetHistoryToCurrent === "function") resetHistoryToCurrent();
       await FB.docRef.set(seeded, { merge:true });
-      if (FB.workspaceDoc){
+      hasPendingLocalChanges = false;
+    if (FB.workspaceDoc){
         await updateWorkspaceMetadata({
           workspaceId: WORKSPACE_ID,
           lastTouchedAt: new Date().toISOString()

--- a/js/core.js
+++ b/js/core.js
@@ -1751,6 +1751,18 @@ function completeCuttingJob(jobId, { completedAtISO = null, normalizePriorities 
   completedCuttingJobs.push(completed);
   window.completedCuttingJobs = completedCuttingJobs;
 
+  if (!Array.isArray(window.syncProcessLog)) window.syncProcessLog = [];
+  window.syncProcessLog.unshift({
+    id: typeof genId === "function" ? genId("sync_log") : `sync_log_${Date.now()}`,
+    atISO: new Date().toISOString(),
+    eventType: "cutting_job_completed",
+    status: "saved",
+    sourceArea: "cuttingJobs",
+    targetArea: "completedCuttingJobs,dataCenter,charts",
+    message: `Cutting job "${String(job?.name || idStr)}" moved from active to completed and propagated to dependent views.`
+  });
+  if (window.syncProcessLog.length > 1000) window.syncProcessLog.length = 1000;
+
   if (typeof saveCloudDebounced === "function") saveCloudDebounced();
   if (typeof saveCloudNow === "function"){
     try { saveCloudNow(); } catch (err){ console.warn("Immediate save failed after completing cutting job", err); }
@@ -2997,6 +3009,16 @@ const saveCloudInternal = debounce(async ()=>{
   if (!FB.ready || !FB.docRef) return;
   try{
     const snap = snapshotState();
+    try {
+      const prevLogLen = Array.isArray(window.syncProcessLog) ? window.syncProcessLog.length : 0;
+      recordDataFlowEvent("cloud_save", snap);
+      const nextLogLen = Array.isArray(window.syncProcessLog) ? window.syncProcessLog.length : 0;
+      if (nextLogLen !== prevLogLen){
+        snap.syncProcessLog = window.syncProcessLog.slice();
+      }
+    } catch (err) {
+      console.warn("Failed to record save flow event", err);
+    }
     window.__lastSnapshot = snap;
     const writeRev = Number(snap?.syncMeta?.rev || 0);
     await FB.docRef.set(snap, { merge:true });

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10978,6 +10978,27 @@ function renderCosts(){
     const modal = content.querySelector("[data-data-center-modal]");
     const closeBtns = Array.from(content.querySelectorAll("[data-close-data-center]"));
     const tabButtons = modal instanceof HTMLElement ? Array.from(modal.querySelectorAll("[data-dc-tab]")) : [];
+    const invRowsHost = modal instanceof HTMLElement ? modal.querySelector('[data-dc-inventory-rows]') : null;
+    const renderDataCenterInventoryRows = ()=>{
+      if (!invRowsHost) return;
+      const folders = Array.isArray(window.inventoryFolders)?window.inventoryFolders:[];
+      const folderName=(id)=> (folders.find(f=>String(f?.id||'')===String(id||''))?.name)||'—';
+      let invRows = Array.isArray(window.inventory) ? window.inventory : (Array.isArray(inventory) ? inventory : []);
+      if ((!Array.isArray(invRows) || !invRows.length) && Array.isArray(window.inventoryFolders)){
+        invRows = window.inventoryFolders.flatMap(folder => Array.isArray(folder?.items) ? folder.items.map(item => ({ ...item, folderId: folder.id })) : []);
+      }
+      invRowsHost.innerHTML = invRows.length?invRows.map(item=>`<tr><td>${escapeHtml(item?.name||'')}</td><td>${escapeHtml(item?.pn||'—')}</td><td>${escapeHtml(String(Number(item?.qtyNew)||0))}</td><td>${escapeHtml(String(Number(item?.qtyOld)||0))}</td><td>${escapeHtml(item?.unit||'pcs')}</td><td>${escapeHtml(item?.price!=null?String(item.price):'—')}</td><td>${escapeHtml(folderName(item?.folderId))}</td><td style="white-space:normal;word-break:break-word">${escapeHtml(item?.link||'—')}</td></tr>`).join(''):`<tr><td colspan=8 class="cost-table-placeholder">No inventory rows available.</td></tr>`;
+    };
+    const logRowsHost = modal instanceof HTMLElement ? modal.querySelector('[data-dc-log-rows]') : null;
+    const renderDataCenterLogRows = ()=>{
+      if (!logRowsHost) return;
+      const logs = Array.isArray(window.syncProcessLog)?window.syncProcessLog:(Array.isArray(window.systemSaveLog)?window.systemSaveLog:[]);
+      const saveLogs = Array.isArray(window.maintenanceCostLog) ? window.maintenanceCostLog.slice(0, 100).map(entry => ({ atISO: entry?.createdAt, eventType: entry?.type || "save_event", status: "saved", sourceArea: "maintenanceCostLog", targetArea: "", partNumber: entry?.partNumber || "", qtyDelta: "", message: entry?.notes || entry?.message || "Saved cost/history entry." })) : [];
+      const merged = [...logs, ...saveLogs];
+      logRowsHost.innerHTML = merged.length?merged.slice(0,100).map(entry=>`<tr><td>${escapeHtml(String(entry?.atISO||entry?.createdAt||'—'))}</td><td>${escapeHtml(String(entry?.eventType||entry?.type||'—'))}</td><td>${escapeHtml(String(entry?.status||'—'))}</td><td>${escapeHtml(String(entry?.sourceArea||'—'))}</td><td>${escapeHtml(String(entry?.targetArea||'—'))}</td><td>${escapeHtml(String(entry?.partNumber||'—'))}</td><td>${escapeHtml(String(entry?.qtyDelta!=null?entry.qtyDelta:'—'))}</td><td>${escapeHtml(String(entry?.message||'—'))}</td></tr>`).join(''):`<tr><td colspan=8 class="cost-table-placeholder">No system wiring or save log entries yet.</td></tr>`;
+    };
+    renderDataCenterInventoryRows();
+    renderDataCenterLogRows();
     const panels = modal instanceof HTMLElement ? Array.from(modal.querySelectorAll("[data-dc-panel]")) : [];
     const setActiveTab = (tabKey)=>{
       if (typeof window !== "undefined"){
@@ -11005,7 +11026,7 @@ function renderCosts(){
     const rememberedTab = (typeof window !== "undefined" && typeof window.dataCenterActiveTab === "string")
       ? window.dataCenterActiveTab
       : "maintenance";
-    setActiveTab(["maintenance", "cutting", "spend", "efficiency"].includes(rememberedTab) ? rememberedTab : "maintenance");
+    setActiveTab(["maintenance", "cutting", "spend", "efficiency", "inventory", "logs"].includes(rememberedTab) ? rememberedTab : "maintenance");
     if (modal instanceof HTMLElement){
       document.body.appendChild(modal);
     }
@@ -11020,6 +11041,8 @@ function renderCosts(){
       modal.removeAttribute("hidden");
       modal.setAttribute("aria-hidden", "false");
       document.body.classList.add("cost-data-center-open");
+      renderDataCenterInventoryRows();
+      renderDataCenterLogRows();
       try { modal.focus({ preventScroll: true }); } catch (_err){ modal.focus(); }
       const panel = modal.querySelector(".cost-data-center-panel");
       if (panel instanceof HTMLElement){
@@ -11750,8 +11773,9 @@ function renderCosts(){
       qty: Number(item?.qty) || 0,
       partNumber: String(item?.partNumber || ""),
       shipping: Number(item?.shipping) || 0,
-      tax: Number(item?.tax) || 0
-    })).filter(row => row.date || row.purchased || row.cost || row.qty || row.partNumber || row.shipping || row.tax);
+      tax: Number(item?.tax) || 0,
+      inventoryItemId: String(item?.inventoryItemId || "")
+    })).filter(row => row.date || row.purchased || row.cost || row.qty || row.partNumber || row.shipping || row.tax || row.inventoryItemId);
     const renderCentralSpendRows = ()=>{
       const spendBody = document.querySelector("[data-spend-table-body]");
       if (!(spendBody instanceof HTMLElement)) return;
@@ -12059,7 +12083,20 @@ function renderCosts(){
         setField("shipping", Number(template.shipping || 0));
         setField("tax", Number(template.tax || 0));
       };
-      const appendEmptyRow = (focusFirst = false)=>{
+      
+      const inventorySelectOptionsMarkup = (selectedId)=>{
+        const selected = String(selectedId || "");
+        const rows = (Array.isArray(inventory) ? inventory : []).filter(Boolean).slice().sort((a,b)=>String(a.name||"").localeCompare(String(b.name||"")));
+        const opts = ['<option value="">Auto-detect from name</option>'];
+        rows.forEach(item => {
+          const id = String(item.id || "");
+          if (!id) return;
+          const label = `${item.name || "Unnamed"} ${item.pn ? `(${item.pn})` : ""}`.trim();
+          opts.push(`<option value="${escapeHtml(id)}" ${selected===id?"selected":""}>${escapeHtml(label)}</option>`);
+        });
+        return opts.join("");
+      };
+const appendEmptyRow = (focusFirst = false)=>{
         if (!(weekRowsBody instanceof HTMLElement)) return;
         const tr = document.createElement("tr");
         tr.setAttribute("data-receipt-row", "1");
@@ -12069,8 +12106,9 @@ function renderCosts(){
           <td><input type="number" min="0" step="0.01" data-col="cost" placeholder="0.00"></td>
           <td><input type="number" min="0" step="0.01" data-col="qty" placeholder="0"></td>
           <td><input type="text" data-col="partNumber" placeholder="Part #"></td>
-          <td><input type="number" min="0" step="0.01" data-col="shipping" placeholder="0.00"></td>
-          <td><input type="number" min="0" step="0.01" data-col="tax" placeholder="0.00"></td>
+          <td style="width:160px;max-width:160px"><select data-col="inventoryItemId" style="width:100%;max-width:160px;text-overflow:ellipsis">${inventorySelectOptionsMarkup("")}</select></td>
+          <td><input type="number" min="0" step="0.01" data-col="shipping" placeholder="0.00" style="min-width:86px"></td>
+          <td><input type="number" min="0" step="0.01" data-col="tax" placeholder="0.00" style="min-width:72px"></td>
           <td data-col="total">${formatUsd(0)}</td>`;
         weekRowsBody.appendChild(tr);
         if (focusFirst){
@@ -12109,19 +12147,107 @@ function renderCosts(){
             <td><input type="number" min="0" step="0.01" data-col="cost" value="${escapeHtml(String(row.cost || 0))}"></td>
             <td><input type="number" min="0" step="0.01" data-col="qty" value="${escapeHtml(String(row.qty || 0))}"></td>
             <td><input type="text" data-col="partNumber" value="${escapeHtml(row.partNumber || "")}"></td>
-            <td><input type="number" min="0" step="0.01" data-col="shipping" value="${escapeHtml(String(row.shipping || 0))}"></td>
-            <td><input type="number" min="0" step="0.01" data-col="tax" value="${escapeHtml(String(row.tax || 0))}"></td>
+            <td style="width:160px;max-width:160px"><select data-col="inventoryItemId" style="width:100%;max-width:160px;text-overflow:ellipsis">${inventorySelectOptionsMarkup(row.inventoryItemId || "")}</select></td>
+            <td><input type="number" min="0" step="0.01" data-col="shipping" value="${escapeHtml(String(row.shipping || 0))}" style="min-width:86px"></td>
+            <td><input type="number" min="0" step="0.01" data-col="tax" value="${escapeHtml(String(row.tax || 0))}" style="min-width:72px"></td>
             <td data-col="total">${formatUsd(computeRowTotal(row))}</td>
           </tr>`).join("");
         appendEmptyRow();
         recomputeWeekTotals();
+      };
+      const findInventoryByPartNumber = (partNumber)=>{
+        const key = String(partNumber || "").trim().toLowerCase();
+        if (!key || !Array.isArray(inventory)) return null;
+        return inventory.find(item => String(item?.pn || "").trim().toLowerCase() === key) || null;
+      };
+      const findInventoryByNameLike = (name)=>{
+        const key = String(name || "").trim().toLowerCase();
+        if (!key || !Array.isArray(inventory)) return null;
+        return inventory.find(item => String(item?.name || "").toLowerCase().includes(key)) || null;
+      };
+      const ensurePurchaseHistoryLinkForPartNumber = ({ partNumber, inventoryItemId, canonicalName })=>{
+        const partKey = String(partNumber || "").trim().toLowerCase();
+        if (!partKey || !inventoryItemId) return 0;
+        let updates = 0;
+        (window.receiptTrackerWeeks || []).forEach(week => {
+          if (!Array.isArray(week?.rows)) return;
+          week.rows = week.rows.map(row => {
+            const rowPart = String(row?.partNumber || "").trim().toLowerCase();
+            if (!rowPart || rowPart !== partKey) return row;
+            updates += 1;
+            return { ...row, inventoryItemId: String(inventoryItemId), purchased: canonicalName || row.purchased || "" };
+          });
+        });
+        return updates;
+      };
+      const openPurchaseLinkingWorkflow = (partNumber)=>{
+        const pn = String(partNumber || "").trim();
+        if (!pn){ toast("Part number is required before linking."); return; }
+        const matchingRows = [];
+        (window.receiptTrackerWeeks || []).forEach(week => {
+          normalizeRows(week?.rows).forEach(row => {
+            if (String(row?.partNumber || "").trim().toLowerCase() === pn.toLowerCase()) matchingRows.push(row);
+          });
+        });
+        const nameOptions = Array.from(new Set(matchingRows.map(row => String(row?.purchased || "").trim()).filter(Boolean)));
+        let selectedName = nameOptions[0] || "";
+        if (nameOptions.length > 1){
+          selectedName = prompt(`Multiple names use part number ${pn}. Choose the canonical name:\n${nameOptions.join("\n")}`, selectedName || nameOptions[0] || "") || "";
+          selectedName = selectedName.trim();
+          if (!selectedName) return;
+          const proceed = confirm(`This will rename all purchase history rows with part number ${pn} to "${selectedName}" and link them together. Continue?`);
+          if (!proceed) return;
+        }
+        const inventoryMatches = (Array.isArray(inventory) ? inventory : []).filter(item => String(item?.pn || "").trim().toLowerCase() === pn.toLowerCase());
+        let linkedItem = inventoryMatches[0] || null;
+        if (!linkedItem){
+          const createNew = confirm(`No inventory item is linked for part number ${pn}. Click OK to create a new inventory item, or Cancel to search by name.`);
+          if (createNew){
+            const newName = (prompt("New inventory item name", selectedName || matchingRows[0]?.purchased || "") || "").trim();
+            if (!newName) return;
+            const folderId = (prompt("Inventory folder ID/location (optional)", "") || "").trim();
+            const item = normalizeInventoryItem({ id: genId("inventory"), name: newName, pn, qtyNew: 0, qtyOld: 0, unit: "pcs", note: "Created from purchase history", folderId: folderId || null });
+            if (!item){ toast("Unable to create inventory item."); return; }
+            inventory.unshift(item);
+            window.inventory = inventory;
+            linkedItem = item;
+          } else {
+            const query = (prompt("Search inventory by name to link", selectedName || "") || "").trim().toLowerCase();
+            linkedItem = (Array.isArray(inventory) ? inventory : []).find(item => String(item?.name || "").toLowerCase().includes(query)) || null;
+          }
+        }
+        if (!linkedItem){ toast("No inventory item selected."); return; }
+        const canonicalName = linkedItem.name || selectedName || matchingRows[0]?.purchased || "";
+        const updated = ensurePurchaseHistoryLinkForPartNumber({ partNumber: pn, inventoryItemId: linkedItem.id, canonicalName });
+        if (updated > 0){
+          if (Array.isArray(window.maintenanceCostLog)){
+            window.maintenanceCostLog.unshift({
+              id: genId("purchase_link"),
+              type: "purchase_history_linked",
+              createdAt: new Date().toISOString(),
+              partNumber: pn,
+              linkedInventoryId: linkedItem.id,
+              linkedInventoryName: canonicalName,
+              affectedRows: updated
+            });
+          }
+          persistReceiptState();
+          saveWeekRowsFromDom();
+          renderWeekRows();
+          renderRangeTable();
+          renderCentralSpendRows();
+          toast(`Linked ${updated} purchase row${updated===1?"":"s"} to inventory item.`);
+        }
       };
       const renderRangeTable = ()=>{
         if (!(rangeRowsBody instanceof HTMLElement)) return;
         const { start, end } = getRangeWindow(activeRange);
         const rows = buildRangeRows(activeRange);
         const subtotal = rows.reduce((sum, row) => sum + row.total, 0);
-        rangeRowsBody.innerHTML = rows.length ? rows.map(row => `
+        rangeRowsBody.innerHTML = rows.length ? rows.map(row => {
+          const linked = !!findInventoryByPartNumber(row.partNumber);
+          const stateLabel = linked ? "Linked" : "Unlinked";
+          return `
           <tr>
             <td>${escapeHtml(row.date || "—")}</td>
             <td>${escapeHtml(row.purchased || "—")}</td>
@@ -12130,8 +12256,9 @@ function renderCosts(){
             <td>${formatUsd(row.shipping || 0)}</td>
             <td>${formatUsd(row.tax || 0)}</td>
             <td>${formatUsd(row.total || 0)}</td>
-            <td></td>
-          </tr>`).join("") : '<tr><td colspan="8" class="cost-table-placeholder">No receipt rows in this range.</td></tr>';
+            <td><span class="small muted">${stateLabel}</span></td>
+          </tr>`;
+        }).join("") : '<tr><td colspan="8" class="cost-table-placeholder">No receipt rows in this range.</td></tr>';
         if (rangeSubtotal) rangeSubtotal.textContent = formatUsd(subtotal);
         if (rangeLabel) rangeLabel.textContent = formatDateRangeLabel(start, end);
       };
@@ -12144,7 +12271,7 @@ function renderCosts(){
           event.preventDefault();
           const row = input.closest("tr[data-receipt-row]");
           if (!row) return;
-          const columns = ["date", "purchased", "cost", "qty", "partNumber", "shipping", "tax"];
+          const columns = ["date", "purchased", "cost", "qty", "partNumber", "inventoryItemId", "shipping", "tax"];
           const col = input.getAttribute("data-col") || "";
           const idx = columns.indexOf(col);
           if (idx < 0) return;
@@ -12161,7 +12288,21 @@ function renderCosts(){
           renderRangeTable();
           renderCentralSpendRows();
         });
-        weekRowsBody.addEventListener("input", ()=>{
+        weekRowsBody.addEventListener("input", (event)=>{
+          const inputEl = event.target;
+          if (inputEl instanceof HTMLInputElement && inputEl.getAttribute("data-col") === "purchased"){
+            const row = inputEl.closest("tr[data-receipt-row]");
+            const typed = String(inputEl.value || "").trim();
+            if (row && typed){
+              const inv = findInventoryByNameLike(typed);
+              if (inv){
+                const invSel = row.querySelector('[data-col="inventoryItemId"]');
+                const partEl = row.querySelector('[data-col="partNumber"]');
+                if (invSel instanceof HTMLSelectElement && String(invSel.value || "") !== String(inv.id || "")) invSel.value = String(inv.id || "");
+                if (partEl instanceof HTMLInputElement && !String(partEl.value || "").trim()) partEl.value = String(inv.pn || "");
+              }
+            }
+          }
           recomputeWeekTotals();
           hasUnsavedReceiptChanges = true;
           hasExplicitSaveSinceEdit = false;
@@ -12181,10 +12322,15 @@ function renderCosts(){
           if (input.getAttribute("data-col") !== "purchased") return;
           const key = String(input.value || "").trim().toLowerCase();
           if (!key) return;
-          const template = purchaseTemplates.get(key);
+          const template = purchaseTemplates.get(key) || Array.from(purchaseTemplates.entries()).find(([name]) => name.includes(key))?.[1];
           if (!template) return;
           const row = input.closest("tr[data-receipt-row]");
           applyTemplateToRow(row, template);
+          const inv = findInventoryByNameLike(input.value || "");
+          if (row && inv){
+            const invSel = row.querySelector('[data-col="inventoryItemId"]');
+            if (invSel instanceof HTMLSelectElement) invSel.value = String(inv.id || "");
+          }
           recomputeWeekTotals();
           hasUnsavedReceiptChanges = true;
           hasExplicitSaveSinceEdit = false;
@@ -12257,6 +12403,155 @@ function renderCosts(){
           downloadWorkbook(`receipt-week-${entry.key || "week"}.xls`, workbook);
         });
       }
+      const openFixerBtn = modal.querySelector("[data-receipt-open-fixer]");
+      if (openFixerBtn instanceof HTMLElement){
+        openFixerBtn.hidden = true;
+        openFixerBtn.setAttribute("aria-hidden", "true");
+      }
+      const buildUnlinkedGroups = ()=>{
+        const missing = [];
+        (window.receiptTrackerWeeks || []).forEach(week => {
+          normalizeRows(week?.rows).forEach((row,rowIndex) => {
+            const pn = String(row.partNumber || "").trim();
+            const linked = pn ? findInventoryByPartNumber(pn) : null;
+            const explicitId = String(row.inventoryItemId || "").trim();
+            if (!linked && !explicitId){ missing.push({ ...row, weekKey: String(week?.key||""), rowIndex }); }
+          });
+        });
+        const map = new Map();
+        missing.forEach(row => {
+          const pn = String(row.partNumber || "").trim();
+          const key = pn ? `pn:${pn.toLowerCase()}` : `row:${row.weekKey}:${row.rowIndex}`;
+          if (!map.has(key)) map.set(key, { key, partNumber: pn, rows: [] });
+          map.get(key).rows.push(row);
+        });
+        return Array.from(map.values()).map(group => {
+          const names = Array.from(new Set(group.rows.map(r => String(r.purchased || "").trim()).filter(Boolean)));
+          const qty = group.rows.reduce((sum,r)=>sum+(Number(r.qty)||0),0);
+          return { ...group, names, qty, count: group.rows.length };
+        });
+      };
+      const applyGroupLink = (group, inv)=>{
+        if (!group || !inv) return 0;
+        if (!Array.isArray(window.purchaseInventoryLinks)) window.purchaseInventoryLinks = [];
+        const canonicalName = String(inv.name || group.names[0] || "").trim();
+        if (!canonicalName) return 0;
+        let touched = 0;
+        (window.receiptTrackerWeeks || []).forEach(week => {
+          if (!Array.isArray(week?.rows)) return;
+          week.rows = week.rows.map((row, idx) => {
+            const samePn = group.partNumber && String(row?.partNumber||"").trim().toLowerCase() === String(group.partNumber).toLowerCase();
+            const sameRow = !group.partNumber && group.rows.some(x => x.weekKey===week.key && Number(x.rowIndex)===idx);
+            if (!samePn && !sameRow) return row;
+            touched += 1;
+            return { ...row, inventoryItemId: inv.id, isInventoryLinked: true, purchased: canonicalName || inv.name || row.purchased || "", partNumber: inv.pn || row.partNumber || "", pnSnapshot: inv.pn || row.partNumber || "", inventoryNameSnapshot: inv.name || "", linkedAtISO: new Date().toISOString(), linkSource: "manual_part_number_group" };
+          });
+        });
+        const linkRecord = {
+          id: genId("purchase_inventory_link"),
+          atISO: new Date().toISOString(),
+          inventoryId: String(inv.id || ""),
+          inventoryName: String(inv.name || ""),
+          inventoryPartNumber: String(inv.pn || ""),
+          purchaseGroupKey: String(group.key || ""),
+          purchasePartNumber: String(group.partNumber || ""),
+          purchaseNames: Array.isArray(group.names) ? group.names.slice() : [],
+          affectedRows: Number(group.count || 0),
+          canonicalName: String(canonicalName || inv.name || "")
+        };
+        window.purchaseInventoryLinks.unshift(linkRecord);
+        if (window.purchaseInventoryLinks.length > 500) window.purchaseInventoryLinks.length = 500;
+        if (typeof appendSystemLog === 'function'){
+          appendSystemLog({ eventType:'purchase_history_saved', sourceArea:'purchaseHistory', targetArea:'purchaseHistory', partNumber: group.partNumber || '', affectedCount: touched, inventoryId: inv.id, finalName: canonicalName || inv.name || '', qtyDelta:0, status:'saved', message:'Purchase history rows linked to inventory item.' });
+          appendSystemLog({ eventType:'inventory_link_updated', sourceArea:'inventory', targetArea:'inventory', partNumber: inv.pn || group.partNumber || '', affectedCount: touched, inventoryId: inv.id, finalName: canonicalName || inv.name || '', qtyDelta:0, status:'saved', message:'Inventory link reference updated from fixer.' });
+          appendSystemLog({ eventType:'central_data_inventory_refreshed', sourceArea:'dataCenter', targetArea:'dataCenter', partNumber: inv.pn || group.partNumber || '', affectedCount: touched, inventoryId: inv.id, finalName: canonicalName || inv.name || '', qtyDelta:0, status:'saved', message:'Central Data Table inventory/log views refreshed after link repair.' });
+        }
+        persistReceiptState();
+        renderWeekRows();
+        saveWeekRowsFromDom();
+        renderRangeTable();
+        renderCentralSpendRows();
+        return touched;
+      };
+      const openFixerWidget = ()=>{
+        return;
+        const inventoryRows = Array.isArray(window.inventory) ? window.inventory : (Array.isArray(inventory) ? inventory : []);
+        let selectedGroupKey = "";
+        let selectedInventoryId = "";
+        let searchTerm = "";
+        let activeTab = "unlinked";
+        const shell = document.createElement('div');
+        shell.className = 'cost-receipt-modal';
+        shell.style.color = '#000';
+        shell.style.zIndex = '10002';
+        const linkedRows = ()=>{
+          const output = [];
+          (window.receiptTrackerWeeks || []).forEach(week => {
+            normalizeRows(week?.rows).forEach((row, rowIndex) => {
+              if (!String(row?.inventoryItemId || "").trim()) return;
+              output.push({ ...row, weekKey: String(week?.key || ""), rowIndex });
+            });
+          });
+          return output;
+        };
+        const redraw = ()=>{
+          const groups = buildUnlinkedGroups();
+          const repaired = linkedRows();
+          const prevFocus = document.activeElement instanceof HTMLElement && document.activeElement.matches('[data-inv-search]') ? true : false;
+          const filteredInv = inventoryRows.filter(item => `${item?.name||""} ${item?.pn||""} ${item?.link||""}`.toLowerCase().includes(searchTerm.toLowerCase()));
+          shell.innerHTML = `<div class="cost-receipt-backdrop" data-close="1"></div><div class="cost-receipt-card" style="max-width:1200px;color:#000;background:#fff"><div class="cost-receipt-card-body"><h3>Repair Purchase-to-Inventory Links</h3><p class="small muted">How to use: select an unlinked purchase group, pick an inventory item, then click <strong>Link Selected</strong>. Linked rows appear under the <strong>Repaired</strong> tab where you can revisit prior fixes.</p><div style="display:flex;justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap"><div style="display:flex;gap:6px"><button class="btn ${activeTab==='unlinked'?'primary':'secondary'}" data-fixer-tab="unlinked">Unlinked (${groups.length})</button><button class="btn ${activeTab==='repaired'?'primary':'secondary'}" data-fixer-tab="repaired">Repaired (${repaired.length})</button></div><div style='display:flex;gap:8px;align-items:center'><input type='search' placeholder='Search inventory...' value='${escapeHtml(searchTerm)}' data-inv-search><button class='btn primary' data-link='1'>Link Selected</button></div></div><div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:10px" ${activeTab==='repaired'?'hidden':''}><div><h4>Unlinked purchase groups</h4><table class="cost-table"><thead><tr><th>Select</th><th>Part #</th><th>Names</th><th>Rows</th><th>Total Qty</th></tr></thead><tbody>${groups.map(g=>`<tr><td><input type='radio' name='g' value='${escapeHtml(g.key)}' ${selectedGroupKey===g.key?'checked':''}></td><td>${escapeHtml(g.partNumber||'—')}</td><td>${escapeHtml(g.names.join(', ')||'—')}</td><td>${g.count}</td><td>${g.qty}</td></tr>`).join('')||"<tr><td colspan='5'>No unlinked groups.</td></tr>"}</tbody></table></div><div><h4>Inventory items</h4><table class='cost-table'><thead><tr><th>Select</th><th>Name</th><th>Part #</th><th>Qty</th><th>Edit</th></tr></thead><tbody>${filteredInv.map(item=>`<tr><td><input type='radio' name='i' value='${escapeHtml(String(item.id||""))}' ${String(item.id)===selectedInventoryId?'checked':''}></td><td>${escapeHtml(item.name||'')}</td><td>${escapeHtml(item.pn||'—')}</td><td>${escapeHtml(String((Number(item.qtyNew)||0)+(Number(item.qtyOld)||0)))}</td><td><button class='btn secondary' data-go-inventory='1'>Inventory settings</button></td></tr>`).join('')||"<tr><td colspan='5'>No inventory matches.</td></tr>"}</tbody></table></div></div><div style="margin-top:10px" ${activeTab==='repaired'?'':'hidden'}><h4>Repaired links</h4><table class='cost-table'><thead><tr><th>Date</th><th>Name</th><th>Part #</th><th>Week</th><th>Edit</th></tr></thead><tbody>${repaired.map(row=>`<tr><td>${escapeHtml(String(row.linkedAtISO||row.date||'—'))}</td><td>${escapeHtml(String(row.purchased||'—'))}</td><td>${escapeHtml(String(row.partNumber||'—'))}</td><td>${escapeHtml(String(row.weekKey||'—'))}</td><td><button class='btn secondary' data-edit-fix='${escapeHtml(String(row.weekKey||''))}|${escapeHtml(String(row.rowIndex))}'>Open row</button></td></tr>`).join('')||"<tr><td colspan='5'>No repaired rows yet.</td></tr>"}</tbody></table></div><div style='display:flex;gap:8px;justify-content:flex-end;margin-top:10px'><button class='btn secondary' data-close='1'>Close</button></div></div></div>`;
+          shell.querySelectorAll("input[name='g']").forEach(el=>el.addEventListener('change',()=>{selectedGroupKey=el.value;}));
+          shell.querySelectorAll("input[name='i']").forEach(el=>el.addEventListener('change',()=>{selectedInventoryId=el.value;}));
+          shell.querySelectorAll("tbody tr").forEach(tr => tr.addEventListener("click", (event)=>{
+            const target = event.target;
+            if (target instanceof HTMLElement && (target.closest("button") || target.closest("input"))) return;
+            const radio = tr.querySelector("input[type='radio']");
+            if (radio instanceof HTMLInputElement){ radio.checked = true; radio.dispatchEvent(new Event("change", { bubbles: true })); }
+          }));
+          const sInput = shell.querySelector('[data-inv-search]');
+          sInput?.addEventListener('input',()=>{searchTerm=sInput.value||'';redraw();});
+          if (prevFocus && sInput instanceof HTMLInputElement){ sInput.focus(); sInput.setSelectionRange(sInput.value.length, sInput.value.length); }
+          shell.querySelectorAll('[data-fixer-tab]').forEach(btn => btn.addEventListener('click', ()=>{ activeTab = String(btn.getAttribute('data-fixer-tab') || 'unlinked'); redraw(); }));
+          shell.querySelectorAll('[data-go-inventory="1"]').forEach(btn => btn.addEventListener('click', ()=>{
+            shell.remove();
+            if (modal instanceof HTMLElement){
+              modal.hidden = true;
+              modal.setAttribute("aria-hidden", "true");
+            }
+            document.body.classList.remove("cost-receipt-modal-open");
+            if (typeof window !== "undefined"){
+              window.costPurchaseHistoryModalOpen = false;
+              window.location.hash = "#inventory";
+              requestAnimationFrame(()=>{ document.body.style.overflow = ""; });
+            }
+          }));
+          shell.querySelectorAll('[data-edit-fix]').forEach(btn => btn.addEventListener('click', ()=>{
+            const raw = String(btn.getAttribute('data-edit-fix') || '');
+            const [weekKey, rowIndexRaw] = raw.split('|');
+            openModal();
+            setTimeout(()=>focusReceiptWeekRow({ weekKey, rowIndex: Number(rowIndexRaw) }), 15);
+            shell.remove();
+          }));
+          shell.querySelectorAll('[data-close="1"]').forEach(btn=>btn.addEventListener('click',()=>shell.remove()));
+          shell.querySelector('[data-link="1"]')?.addEventListener('click',()=>{
+            const selectedGroupEl = shell.querySelector("input[name='g']:checked");
+            const selectedInvEl = shell.querySelector("input[name='i']:checked");
+            const selectedGroupValue = String(selectedGroupEl?.value || selectedGroupKey || "");
+            const selectedInvValue = String(selectedInvEl?.value || selectedInventoryId || "");
+            const g = groups.find(x=>x.key===selectedGroupValue); const inv = inventoryRows.find(x=>String(x?.id||'')===selectedInvValue);
+            if (!g || !inv){ toast('Select one purchase group and one inventory item.'); return; }
+            const updatedCount = applyGroupLink(g, inv);
+            if (!updatedCount){ toast('No rows were updated.'); return; }
+            selectedGroupKey = "";
+            activeTab = "repaired";
+            toast(`Linked ${updatedCount} purchase row${updatedCount===1?"":"s"}.`);
+            redraw();
+          });
+        };
+        redraw();
+        document.body.appendChild(shell);
+      };
+      // Fixer widget intentionally disabled; linking is now handled inline via direct data flows.
       if (exportRangeBtn instanceof HTMLElement){
         exportRangeBtn.addEventListener("click", ()=>{
           const { start, end } = getRangeWindow(activeRange);
@@ -21000,6 +21295,45 @@ function formatOrderDate(iso, { includeTime = false } = {}){
   return dt.toLocaleDateString();
 }
 
+
+function appendSystemLog(entry){
+  if (!Array.isArray(window.syncProcessLog)) window.syncProcessLog = [];
+  window.syncProcessLog.unshift({ id: genId("sync_log"), atISO: new Date().toISOString(), status: "ok", ...entry });
+  if (window.syncProcessLog.length > 500) window.syncProcessLog = window.syncProcessLog.slice(0, 500);
+}
+
+function scanPurchaseInventoryLinks(){
+  const invById = new Map((Array.isArray(inventory)?inventory:[]).filter(Boolean).map(item => [String(item.id), item]));
+  const requests = Array.isArray(orderRequests) ? orderRequests : [];
+  const lines = [];
+  requests.forEach(req => {
+    (Array.isArray(req?.items)?req.items:[]).forEach(item => {
+      if (!item) return;
+      const inventoryId = item.inventoryId != null ? String(item.inventoryId) : "";
+      const hasId = !!inventoryId;
+      const valid = hasId && invById.has(inventoryId);
+      const linkState = valid ? "linked" : (hasId ? "invalid" : "unlinked");
+      lines.push({ requestId: req.id, requestCode: req.code || req.id, requestStatus: req.status || "draft", item, inventoryId, linkState });
+    });
+  });
+  const unlinked = lines.filter(x=>x.linkState==="unlinked");
+  const invalid = lines.filter(x=>x.linkState==="invalid");
+  const groupsMap = new Map();
+  unlinked.forEach(row => {
+    const pn = String(row.item?.pn || "").trim();
+    const key = pn ? `pn:${pn.toLowerCase()}` : `item:${row.requestId}:${row.item?.id||genId('tmp')}`;
+    if (!groupsMap.has(key)) groupsMap.set(key,{ key, pn, rows: [] });
+    groupsMap.get(key).rows.push(row);
+  });
+  const groups = Array.from(groupsMap.values()).map(g=>{
+    const names = Array.from(new Set(g.rows.map(r=>String(r.item?.name||"").trim()).filter(Boolean)));
+    const qtyTotal = g.rows.reduce((sum,r)=>sum+(Number(r.item?.qty)||0),0);
+    const dates = g.rows.map(r=>String((r.item?.createdAt||"") || (r.item?.date||"") || r.requestCode || "")).filter(Boolean).sort();
+    return { ...g, names, qtyTotal, count: g.rows.length, dateStart: dates[0]||"—", dateEnd: dates[dates.length-1]||"—" };
+  });
+  return { lines, unlinked, invalid, linked: lines.filter(x=>x.linkState==='linked'), groups };
+}
+
 function computeOrderRequestModel(){
   const draft = ensureActiveOrderRequest();
   const existingIds = new Set(draft.items.map(item => item.id));
@@ -21434,7 +21768,7 @@ function applyInventoryForApprovedItems(items){
   if (!Array.isArray(items)) return;
   items.forEach(item => {
     if (!item) return;
-    if (!item.inventoryId) return;
+    if (!item.inventoryId){ appendSystemLog({ eventType:"purchase_inventory_update_skipped", sourceArea:"orderRequests", targetArea:"inventory", status:"skipped_unlinked_inventory", qtyDelta:0, message:"Purchase item was unlinked, so inventory was not updated." }); return; }
     const inv = inventory.find(x => x.id === item.inventoryId);
     if (!inv) return;
     const qty = Number(item.qty);
@@ -21516,6 +21850,13 @@ function renderOrderRequest(){
   const activeCard = content.querySelector(".order-card");
   const draft = ensureActiveOrderRequest();
 
+  const scan = scanPurchaseInventoryLinks();
+  const statsEl = content.querySelector("[data-order-link-stats]");
+  if (statsEl){
+    const noPn = scan.groups.filter(g => !String(g.pn||"").trim()).length;
+    statsEl.innerHTML = `<div>Total scanned: <strong>${scan.lines.length}</strong></div><div>Linked: <strong>${scan.linked.length}</strong></div><div>Unlinked: <strong>${scan.unlinked.length}</strong></div><div>Invalid: <strong>${scan.invalid.length}</strong></div><div>Unlinked PN groups: <strong>${scan.groups.length - noPn}</strong></div><div>No-PN records: <strong>${noPn}</strong></div><p class="small ${scan.unlinked.length||scan.invalid.length?"":"muted"}">${scan.unlinked.length||scan.invalid.length?"Action needed: unlinked/invalid purchase items found.":"Purchase links verified: no unlinked purchase items found."}</p>`;
+  }
+
   content.querySelectorAll("[data-order-tab]").forEach(btn => {
     btn.addEventListener("click", ()=>{
       const target = btn.getAttribute("data-order-tab") || "active";
@@ -21567,6 +21908,16 @@ function renderOrderRequest(){
   });
 
   activeCard?.addEventListener("click", (e)=>{
+    const linkBtn = e.target.closest("[data-order-item-link]");
+    if (linkBtn){ renderRepairModal("unlinked"); return; }
+    const fixBtn = e.target.closest("[data-order-fix-links]");
+    if (fixBtn){ renderRepairModal("unlinked"); return; }
+    const invalidBtn = e.target.closest("[data-order-review-invalid]");
+    if (invalidBtn){ renderRepairModal("invalid"); return; }
+    const refreshBtn = e.target.closest("[data-order-refresh-scan]");
+    if (refreshBtn){ renderOrderRequest(); return; }
+    const logBtn = e.target.closest("[data-order-view-system-log]");
+    if (logBtn){ location.hash = "#/costs"; renderCosts(); return; }
     const removeBtn = e.target.closest("[data-order-remove]");
     if (removeBtn){
       const id = removeBtn.getAttribute("data-order-remove");
@@ -21616,6 +21967,36 @@ function renderOrderRequest(){
     }
   });
 
+
+  content.addEventListener("click", (e)=>{
+    const viewBtn = e.target.closest("[data-order-group-view]");
+    const matchBtn = e.target.closest("[data-order-group-match]");
+    const createBtn = e.target.closest("[data-order-group-create]");
+    const clearBtn = e.target.closest("[data-order-group-clear]");
+    if (!(viewBtn||matchBtn||createBtn||clearBtn)) return;
+    const key = (viewBtn||matchBtn||createBtn||clearBtn).getAttribute("data-order-group-view") || (viewBtn||matchBtn||createBtn||clearBtn).getAttribute("data-order-group-match") || (viewBtn||matchBtn||createBtn||clearBtn).getAttribute("data-order-group-create") || (viewBtn||matchBtn||createBtn||clearBtn).getAttribute("data-order-group-clear");
+    const scan2 = scanPurchaseInventoryLinks();
+    let rows=[];
+    if (key && key.startsWith('invalid:')) rows = scan2.invalid.filter(r => `invalid:${r.item.id}`===key);
+    else rows = (scan2.groups.find(g=>g.key===key)?.rows)||[];
+    if (viewBtn){ toast(`Records: ${rows.map(r=>`${r.requestCode} / ${r.item.name}`).join(' | ') || 'none'}`); return; }
+    if (clearBtn){ rows.forEach(r=>{ r.item.inventoryId=null; r.item.isInventoryLinked=false; }); appendSystemLog({ eventType:'purchase_invalid_link_cleared', sourceArea:'orderRequests', targetArea:'orderRequests', status:'cleared_to_unlinked', qtyDelta:0, message:'Invalid inventory link cleared; no inventory quantity changed.'}); saveCloudDebounced(); renderOrderRequest(); return; }
+    const invName = prompt('Search inventory name/part number', rows[0]?.item?.name || '') || '';
+    const matches = (Array.isArray(inventory)?inventory:[]).filter(it => `${it.name||''} ${it.pn||''} ${it.link||''}`.toLowerCase().includes(invName.toLowerCase()));
+    let inv = matches[0]||null;
+    if (createBtn || !inv){
+      const finalName = (prompt('Final inventory name', rows[0]?.item?.name||'')||'').trim(); if(!finalName) return;
+      const pn = (rows[0]?.item?.pn || '').trim();
+      const folderId = (window.inventoryFolders && window.inventoryFolders[0] && window.inventoryFolders[0].id) ? window.inventoryFolders[0].id : null;
+      inv = normalizeInventoryItem({ id:genId('inventory'), name:finalName, pn, qtyNew:0, qtyOld:0, qty:0, unit: rows[0]?.item?.unit||'pcs', price: rows[0]?.item?.price||null, folderId, link: rows[0]?.item?.link||'' });
+      inventory.unshift(inv); window.inventory=inventory;
+    }
+    if (!inv) return;
+    rows.forEach(r=>{ r.item.inventoryId = inv.id; r.item.isInventoryLinked = true; r.item.inventoryNameSnapshot = inv.name||''; r.item.pnSnapshot = r.item.pn || inv.pn || ''; r.item.linkSnapshot = r.item.link || inv.link || ''; r.item.unitCostSnapshot = r.item.price != null ? Number(r.item.price)||0 : null; r.item.unitSnapshot = r.item.unit || inv.unit || 'pcs'; r.item.linkedAtISO = new Date().toISOString(); r.item.linkSource = 'manual_part_number_group'; r.item.name = inv.name || r.item.name; });
+    appendSystemLog({ eventType:'purchase_inventory_link_repaired', sourceArea:'orderRequests', targetArea:'inventory', partNumber: rows[0]?.item?.pn || '', affectedCount: rows.length, inventoryId: inv.id, finalName: inv.name, qtyDelta:0, status:'historical_link_repaired_no_qty_change', message:'Inventory quantity was not changed because this was a historical link repair.'});
+    saveCloudDebounced(); renderOrderRequest();
+  });
+
   content.querySelectorAll("[data-order-download-history]").forEach(btn => {
     btn.addEventListener("click", ()=>{
       const id = btn.getAttribute("data-order-download-history");
@@ -21624,6 +22005,19 @@ function renderOrderRequest(){
       if (req) downloadOrderRequestCSV(req);
     });
   });
+
+
+  function renderRepairModal(mode){
+    const modal = content.querySelector("#orderLinkRepairModal");
+    const host = content.querySelector("[data-order-repair-table]");
+    if (!modal || !host) return;
+    const rescan = scanPurchaseInventoryLinks();
+    const groups = mode === "invalid" ? rescan.invalid.map(row => ({ key:`invalid:${row.item.id}`, pn: row.item.pn||"", names:[row.item.name||""], count:1, qtyTotal:Number(row.item.qty)||0, rows:[row], badId: row.inventoryId, dateStart: row.requestCode, dateEnd: row.requestCode })) : rescan.groups;
+    host.innerHTML = `<table class="cost-table"><thead><tr><th>Status</th><th>Part number</th><th>Names found</th><th>Affected</th><th>Total qty</th><th>Date range</th><th>Current status</th><th>Actions</th></tr></thead><tbody>${groups.map(g=>`<tr><td>${mode==="invalid"?"Invalid":"Unlinked"}</td><td>${escapeHtml(g.pn||"—")}</td><td>${escapeHtml((g.names||[]).join(", ")||"—")}</td><td>${g.count}</td><td>${g.qtyTotal}</td><td>${escapeHtml(`${g.dateStart} → ${g.dateEnd}`)}</td><td>${mode==="invalid"?`Bad ID: ${escapeHtml(g.badId||"—")}`:"Needs link"}</td><td><button data-order-group-view="${escapeHtml(g.key)}">View Records</button> <button data-order-group-match="${escapeHtml(g.key)}">Match Existing Inventory</button> <button data-order-group-create="${escapeHtml(g.key)}">Create New Inventory Item</button>${mode==="invalid"?` <button data-order-group-clear="${escapeHtml(g.key)}">Clear Link</button>`:""}</td></tr>`).join("") || `<tr><td colspan='8'>No records to repair.</td></tr>`}</tbody></table>`;
+    modal.hidden = false; modal.setAttribute('aria-hidden','false');
+    modal.dataset.mode = mode;
+  }
+  content.querySelectorAll('[data-order-repair-close]').forEach(btn=>btn.addEventListener('click', ()=>{ const m=content.querySelector('#orderLinkRepairModal'); if(m){m.hidden=true;m.setAttribute('aria-hidden','true');} }));
 
   updateOrderTotalsUI(activeCard, draft);
 }
@@ -21771,3 +22165,5 @@ function renderDeletedItems(options){
     }
   }
 }
+
+window.debugPurchaseInventoryLinks = function(){ const scan = scanPurchaseInventoryLinks(); return { totalOrderRequests: Array.isArray(orderRequests)?orderRequests.length:0, totalPurchaseLines: scan.lines.length, linkedCount: scan.linked.length, unlinkedCount: scan.unlinked.length, invalidLinkCount: scan.invalid.length, unlinkedGroupsByPartNumber: scan.groups.filter(g=>g.pn).length, noPartNumberIndividualRecords: scan.groups.filter(g=>!g.pn).length, syncProcessLogCount: Array.isArray(window.syncProcessLog)?window.syncProcessLog.length:0, inventoryTransactionsCount: Array.isArray(window.inventoryTransactions)?window.inventoryTransactions.length:0, sampleUnlinkedRecords: scan.unlinked.slice(0,5), sampleInvalidRecords: scan.invalid.slice(0,5) }; };

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -10995,7 +10995,14 @@ function renderCosts(){
       const logs = Array.isArray(window.syncProcessLog)?window.syncProcessLog:(Array.isArray(window.systemSaveLog)?window.systemSaveLog:[]);
       const saveLogs = Array.isArray(window.maintenanceCostLog) ? window.maintenanceCostLog.slice(0, 100).map(entry => ({ atISO: entry?.createdAt, eventType: entry?.type || "save_event", status: "saved", sourceArea: "maintenanceCostLog", targetArea: "", partNumber: entry?.partNumber || "", qtyDelta: "", message: entry?.notes || entry?.message || "Saved cost/history entry." })) : [];
       const merged = [...logs, ...saveLogs];
-      logRowsHost.innerHTML = merged.length?merged.slice(0,100).map(entry=>`<tr><td>${escapeHtml(String(entry?.atISO||entry?.createdAt||'—'))}</td><td>${escapeHtml(String(entry?.eventType||entry?.type||'—'))}</td><td>${escapeHtml(String(entry?.status||'—'))}</td><td>${escapeHtml(String(entry?.sourceArea||'—'))}</td><td>${escapeHtml(String(entry?.targetArea||'—'))}</td><td>${escapeHtml(String(entry?.partNumber||'—'))}</td><td>${escapeHtml(String(entry?.qtyDelta!=null?entry.qtyDelta:'—'))}</td><td>${escapeHtml(String(entry?.message||'—'))}</td></tr>`).join(''):`<tr><td colspan=8 class="cost-table-placeholder">No system wiring or save log entries yet.</td></tr>`;
+      const toCst = (value)=>{
+        const iso = String(value || "").trim();
+        if (!iso) return "—";
+        const dt = new Date(iso);
+        if (Number.isNaN(dt.getTime())) return iso;
+        return new Intl.DateTimeFormat("en-US", { timeZone: "America/Chicago", year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: true, timeZoneName: "short" }).format(dt);
+      };
+      logRowsHost.innerHTML = merged.length?merged.slice(0,100).map(entry=>`<tr><td>${escapeHtml(toCst(entry?.atISO||entry?.createdAt||''))}</td><td>${escapeHtml(String(entry?.eventType||entry?.type||'—'))}</td><td>${escapeHtml(String(entry?.status||'—'))}</td><td>${escapeHtml(String(entry?.sourceArea||'—'))}</td><td>${escapeHtml(String(entry?.targetArea||'—'))}</td><td>${escapeHtml(String(entry?.partNumber||'—'))}</td><td>${escapeHtml(String(entry?.qtyDelta!=null?entry.qtyDelta:'—'))}</td><td>${escapeHtml(String(entry?.message||'—'))}</td></tr>`).join(''):`<tr><td colspan=8 class="cost-table-placeholder">No system wiring or save log entries yet.</td></tr>`;
     };
     renderDataCenterInventoryRows();
     renderDataCenterLogRows();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -6309,7 +6309,8 @@ function renderDashboard(){
       const curHours = getCurrentMachineHours();
       const baselineHours = parseBaselineHours(taskLastInput?.value);
       applyIntervalBaseline(template, { baselineHours, currentHours: curHours });
-      tasksInterval.unshift(template);
+      (Array.isArray(window.tasksInterval) ? window.tasksInterval : (window.tasksInterval = [])).unshift(template);
+      tasksInterval = window.tasksInterval;
       const instance = scheduleExistingIntervalTask(template, {
         dateISO: targetISO,
         refreshDashboard: false,
@@ -6343,7 +6344,8 @@ function renderDashboard(){
         endCount: repeatConfig.endCount || null
       };
       normalizeTaskRecurrence(task);
-      tasksAsReq.unshift(task);
+      (Array.isArray(window.tasksAsReq) ? window.tasksAsReq : (window.tasksAsReq = [])).unshift(task);
+      tasksAsReq = window.tasksAsReq;
       message = "As-required task added to Maintenance Settings";
     }
 
@@ -6386,7 +6388,8 @@ function renderDashboard(){
         const lastField = row.querySelector("[data-subtask-last]");
         const baselineHours = parseBaselineHours(lastField?.value);
         applyIntervalBaseline(subTask, { baselineHours, currentHours: curHours });
-        tasksInterval.unshift(subTask);
+        (Array.isArray(window.tasksInterval) ? window.tasksInterval : (window.tasksInterval = [])).unshift(subTask);
+        tasksInterval = window.tasksInterval;
       }else{
         const condInput = row.querySelector("[data-subtask-condition-input]");
         const subTask = Object.assign({}, subBase, {
@@ -6395,7 +6398,8 @@ function renderDashboard(){
           variant: "template",
           templateId: subBase.id
         });
-        tasksAsReq.unshift(subTask);
+        (Array.isArray(window.tasksAsReq) ? window.tasksAsReq : (window.tasksAsReq = [])).unshift(subTask);
+        tasksAsReq = window.tasksAsReq;
       }
     });
 
@@ -9537,7 +9541,8 @@ function renderSettings(){
     }else{
       const condition = (data.get("taskCondition")||"").toString().trim() || "As required";
       const task = Object.assign(base, { mode:"asreq", condition, variant: "template", templateId: id });
-      window.tasksAsReq.unshift(task);
+      (Array.isArray(window.tasksAsReq) ? window.tasksAsReq : (window.tasksAsReq = [])).unshift(task);
+      tasksAsReq = window.tasksAsReq;
       createdTask = task;
     }
 

--- a/js/views.js
+++ b/js/views.js
@@ -10,7 +10,19 @@ function renderAverageHoursBanner(contextLabel){
   const modeLabel = summary.mode === "fixed" ? "Fixed daily hours" : `${avgWindowLabel} average`;
   const eff = Number(summary.effectiveHours);
   const effLabel = Number.isFinite(eff) && eff > 0 ? `${eff.toFixed(2)} hrs/day` : "—";
-  return `<div class="block average-hours-banner" data-average-hours-banner="${esc(contextLabel || "")}"><div><strong>Average Hours Cut / Day:</strong> ${esc(avgLabel)}</div><div class="small muted">Prediction basis: ${esc(modeLabel)} • Effective: ${esc(effLabel)}</div></div>`;
+  return `<div class="block average-hours-banner" data-average-hours-banner="${esc(contextLabel || "")}"><div><strong>Average Hours Cut / Day:</strong> ${esc(avgLabel)}</div><div class="small muted">Prediction basis: ${esc(modeLabel)} • Effective: ${esc(effLabel)}</div></div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 }
 
 function viewDashboard(){
@@ -465,7 +477,19 @@ function viewDashboard(){
         </form>
       </div>
     </div>
-  </div>`;
+  </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 }
 
 function taskDetailsInterval(task){
@@ -612,7 +636,19 @@ function viewSettings(){
              data-part-k="note" data-part-id="${p.pid}" data-parent="${parentId}" data-list="${listType}">
       <button class="danger" type="button"
               data-part-remove="${p.pid}" data-parent="${parentId}" data-list="${listType}">Remove</button>
-    </div>`;
+    </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 
   // One maintenance card (task). Kept attrs used by renderSettings().
   const card = (t, listType) => {
@@ -702,7 +738,19 @@ function viewSettings(){
       </div>` : "";
     const list       = (listType==="interval"?tasksInterval:tasksAsReq);
     const tasksHtml  = tasksIn(list, folder.id).map(t => card(t, listType)).join("")
-                      || `<div class="small muted">No items in this category.</div>`;
+                      || `<div class="small muted">No items in this category.</div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
     return `
       <details class="folder block" data-folder-id="${folder.id}" open>
         <summary class="folder-title" style="display:flex;align-items:center;gap:10px;font-weight:700;">
@@ -734,7 +782,19 @@ function viewSettings(){
     <div class="folder-dropzone folder-dropzone-line small muted" data-drop-folder-tail=""
          style="border:1px dashed #bbb; padding:6px; margin:4px 0 6px; border-radius:8px;">
       Drag folders here to place at the end of root categories
-    </div>`;
+    </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 
   // Root-level (no folder) tasks should appear at the top of each menu (no "Uncategorized" label).
   const rootTasksBlock = (listType)=>{
@@ -751,7 +811,19 @@ function viewSettings(){
       <div class="folder-dropzone small muted" data-drop-menu="${listType}"
            style="border:1px dashed #bbb; padding:6px; margin:6px 8px 10px 8px; border-radius:8px;">
         Drag here to move an item into <b>${title}</b> (${listType === "interval" ? "will require an Interval" : "as-needed"})
-      </div>`;
+      </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
     const listId = listType==="interval" ? "intervalList" : "asreqList";
     return `
       <details class="block" open data-menu="${listType}">
@@ -809,7 +881,19 @@ function viewSettings(){
         <button id="saveTasksBtn">Save All</button>
       </div>
     </div>
-  </div>`;
+  </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 }
 
 function renderSettingsCategoriesPane(){
@@ -1877,9 +1961,9 @@ function viewCosts(model){
           <p class="small muted" data-receipt-week-range>—</p>
           <div class="cost-weekly-table-wrap">
             <table class="cost-table cost-receipt-week-table">
-              <thead><tr><th>Date</th><th>Purchased</th><th>Cost</th><th>Qty</th><th>Part number</th><th>Shipping</th><th>Tax</th><th>Total</th></tr></thead>
+              <thead><tr><th>Date</th><th>Purchased</th><th>Cost</th><th>Qty</th><th>Part number</th><th style="width:160px;max-width:160px">Inventory link</th><th>Shipping</th><th>Tax</th><th>Total</th></tr></thead>
               <tbody data-receipt-week-rows></tbody>
-              <tfoot><tr><th colspan="7">Subtotal</th><th data-receipt-week-subtotal>$0.00</th></tr></tfoot>
+              <tfoot><tr><th colspan="8">Subtotal</th><th data-receipt-week-subtotal>$0.00</th></tr></tfoot>
             </table>
           </div>
           <div class="cost-receipt-summary-controls">
@@ -1903,6 +1987,7 @@ function viewCosts(model){
               <tfoot><tr><th colspan="7">Subtotal</th><th data-receipt-range-subtotal>$0.00</th></tr></tfoot>
             </table>
           </div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
         </div>
       </div>
     </div>
@@ -1922,7 +2007,8 @@ function viewCosts(model){
               </button>
               <div class="chart-info-bubble" id="costOverviewInsight" role="tooltip">
                 <p>${esc(overviewInsight)}</p>
-              </div>
+              
+</div>
             </div>
           </div>
         </div>
@@ -2113,6 +2199,8 @@ function viewCosts(model){
                 <button type="button" class="cost-data-center-tab" data-dc-tab="spend" role="tab" aria-selected="false">Total Spend</button>
                 <button type="button" class="cost-data-center-tab" data-dc-tab="cutting" role="tab" aria-selected="false">Completed Cutting Jobs</button>
                 <button type="button" class="cost-data-center-tab" data-dc-tab="efficiency" role="tab" aria-selected="false">Efficiency Metrics</button>
+                <button type="button" class="cost-data-center-tab" data-dc-tab="inventory" role="tab" aria-selected="false">Inventory</button>
+                <button type="button" class="cost-data-center-tab" data-dc-tab="logs" role="tab" aria-selected="false">History Logs</button>
               </div>
               <div class="cost-data-center-panel-content" data-dc-panel="maintenance">
               <div class="cost-data-center-search">
@@ -2310,6 +2398,20 @@ function viewCosts(model){
                   </tbody>
                 </table>
                 ` : `<p class="small muted">No efficiency rows found in the central data table.</p>`}
+              </div>
+              <div class="cost-data-center-panel-content" data-dc-panel="inventory" hidden>
+                <p class="small muted">Inventory source-of-truth table.</p>
+                <table class="cost-table" style="margin-top:10px">
+                  <thead><tr><th>Name</th><th>Part #</th><th>Qty New</th><th>Qty Old</th><th>Unit</th><th>Price</th><th>Folder</th><th>Link</th></tr></thead>
+                  <tbody data-dc-inventory-rows></tbody>
+                </table>
+              </div>
+              <div class="cost-data-center-panel-content" data-dc-panel="logs" hidden>
+                <p class="small muted">System Wiring & Save Log</p>
+                <table class="cost-table" style="margin-top:10px">
+                  <thead><tr><th>Date/time</th><th>Event type</th><th>Status</th><th>Source</th><th>Target</th><th>Part #</th><th>Qty Δ</th><th>Message</th></tr></thead>
+                  <tbody data-dc-log-rows></tbody>
+                </table>
               </div>
             </div>
           </div>
@@ -2510,9 +2612,22 @@ function viewCosts(model){
               <p>${esc(efficiencyInsight)}</p>
             </div>
           </div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
         </div>
       </div>
-    </div></div>`;
+    </div></div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 }
 
 function viewJobs(){
@@ -3344,7 +3459,19 @@ function viewJobs(){
           <input type="color" class="category-color-picker" value="${categoryAccentHex(id)}" data-job-folder-color-input="${esc(id)}" aria-label="Choose color for ${esc(folder.name || (isRoot ? "All Jobs" : "Category"))}">
         </span>
         <button type="button" class="category-color-reset${categoryHasCustomColor(id) ? "" : " is-hidden"}" data-job-folder-color-reset="${esc(id)}" title="Use automatic color">Auto</button>
-      </div>`;
+      </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
     return `
       <div class="job-folder" data-job-folder="${esc(id)}">
         <div class="job-folder-row${selectedClass}" data-category-color="1"${colorStyleAttr}>
@@ -3927,7 +4054,19 @@ function viewJobs(){
           return `<li class="job-file-menu-item"><a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a></li>`;
         }).join("")
       : "";
-    const fileMenuActions = `<div class="job-file-menu-actions"><button type="button" class="job-file-menu-action" data-job-file-add="${j.id}">+ Add files</button></div>`;
+    const fileMenuActions = `<div class="job-file-menu-actions"><button type="button" class="job-file-menu-action" data-job-file-add="${j.id}">+ Add files</button></div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
     const fileMenu = (fileCount
       ? `<ul class="job-file-menu-list">${fileMenuItems}</ul>`
       : `<p class="job-file-menu-empty small muted">No files attached</p>`)
@@ -4479,6 +4618,7 @@ function viewJobs(){
             <button type="button" class="job-note-modal-secondary" data-note-save-new>Save &amp; add another</button>
             <button type="button" class="job-note-modal-primary" data-note-save>Save notes</button>
           </div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
         </div>
       </div>
     </div>
@@ -4510,7 +4650,19 @@ function viewJobs(){
       ${historyFilterStatus}
       ${completedTable}
     </div>
-  </div>`;
+  </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 }
 
 function filterInventoryItems(term){
@@ -4694,7 +4846,19 @@ function materialSheetTableHTML(model, typeId){
         <button type="button" class="small" data-material-row-add="${esc(typeId)}">+ Row</button>
       </div>
       <div class="small muted">Double-click any table cell/header to edit.</div>
-    </div>`;
+    </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 }
 
 function viewInventoryMaterial(model){
@@ -4717,7 +4881,19 @@ function viewInventoryMaterial(model){
         </label>
       </div>
       <div class="material-table-wrap">${body}</div>
-    </div>`;
+    </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 }
 
 function viewInventory(){
@@ -4857,7 +5033,19 @@ function viewInventory(){
         </form>
       </section>
     </div>
-  </div>`;
+  </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 }
 
 function viewOrderRequest(model){
@@ -4883,6 +5071,17 @@ function viewOrderRequest(model){
           <span class="value">${esc(active.created || "—")}</span>
         </div>
       </div>
+      <div class="order-link-repair" data-order-link-repair>
+        <h4>Purchase ↔ Inventory Link Repair</h4>
+        <div class="order-link-repair-stats" data-order-link-stats></div>
+        <div class="order-link-repair-actions">
+          <button type="button" class="btn" data-order-fix-links>Fix Purchase Links</button>
+          <button type="button" class="btn" data-order-review-invalid>Review Invalid Links</button>
+          <button type="button" class="btn" data-order-refresh-scan>Refresh Scan</button>
+          <button type="button" class="btn" data-order-view-system-log>View System Log</button>
+        </div>
+      </div>
+
       ${active.items && active.items.length ? `
         <div class="order-table-wrap">
           <table class="order-table">
@@ -4895,6 +5094,7 @@ function viewOrderRequest(model){
                 <th>Qty</th>
                 <th>Line total</th>
                 <th>Store link</th>
+                <th>Link status</th>
                 <th></th>
               </tr>
             </thead>
@@ -4908,7 +5108,8 @@ function viewOrderRequest(model){
                   <td><input type="number" min="1" step="1" data-order-qty="${esc(item.id)}" value="${esc(item.qtyInput || "1")}"></td>
                   <td class="order-money">${esc(item.lineTotal || "$0.00")}</td>
                   <td>${item.link ? `<a href="${esc(item.link)}" target="_blank" rel="noopener">View</a>` : "—"}</td>
-                  <td><button type="button" class="link danger" data-order-remove="${esc(item.id)}">Remove</button></td>
+                  <td><span class="status-chip ${esc(item.linkStatusClass || "")}">${esc(item.linkStatusLabel || "Unlinked")}</span></td>
+                  <td><button type="button" class="link" data-order-item-link="${esc(item.id)}">Link</button> <button type="button" class="link danger" data-order-remove="${esc(item.id)}">Remove</button></td>
                 </tr>
               `).join("")}
             </tbody>
@@ -4927,7 +5128,19 @@ function viewOrderRequest(model){
           <button type="button" class="secondary" data-order-deny ${!active.canApprove ? "disabled" : ""}>Mark denied</button>
         </div>
       </div>
-    </div>`;
+    </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 
   const historyContent = `
     <div class="order-history">
@@ -4971,7 +5184,19 @@ function viewOrderRequest(model){
           </div>
         </details>
       `).join("") : `<p class="small muted">No previous order requests yet. Approved or denied requests will appear here.</p>`}
-    </div>`;
+    </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 
   const summaryContent = `
     <div class="order-summary">
@@ -4987,7 +5212,19 @@ function viewOrderRequest(model){
         <span class="label">Last update</span>
         <span class="value">${esc(summary.lastUpdated || "—")}</span>
       </div>
-    </div>`;
+    </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 
   return `
     <div class="container order-request-layout">
@@ -5003,7 +5240,19 @@ function viewOrderRequest(model){
           ${tab === "history" ? historyContent : activeContent}
         </div>
       </div>
-    </div>`;
+    </div>
+    <div class="cost-receipt-modal" id="orderLinkRepairModal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+      <div class="cost-receipt-backdrop" data-order-repair-close></div>
+      <div class="cost-receipt-card" role="document">
+        <div class="cost-receipt-card-body">
+          <h3>Repair Purchase-to-Inventory Links</h3>
+          <button type="button" class="cost-receipt-close" data-order-repair-close>×</button>
+          <div data-order-repair-table></div>
+          <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button type="button" class="btn danger" data-receipt-open-fixer>Fix Unlinked Purchase Links</button></div>
+        </div>
+      </div>
+    </div>
+`;
 }
 
 function viewDeletedItems(model){

--- a/style.css
+++ b/style.css
@@ -6190,3 +6190,15 @@ body.job-flow-lock-scroll {
 .cost-weekly-section-totals{ display:flex; flex-wrap:wrap; gap:10px 16px; padding:10px 12px; border-top:1px solid #e4e9f3; color:#1e2b45; background:#fbfcff; font-variant-numeric:tabular-nums; }
 
 .average-hours-banner{grid-column:1/-1;display:flex;justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap;}
+[data-receipt-open-fixer]{
+  display:none !important;
+}
+
+[data-dc-log-rows] td{
+  white-space:normal !important;
+  line-height:1.25 !important;
+  padding-top:6px !important;
+  padding-bottom:6px !important;
+  vertical-align:top;
+  word-break:break-word;
+}


### PR DESCRIPTION
### Motivation
- Improve observability of state changes during saves and provide an audit trail (`syncProcessLog`) for debugging sync/data-flow events.
- Provide tools to detect and repair mismatches between purchase history (receipt tracker / order requests) and inventory items, enabling manual and semi-automated linking.
- Surface inventory and system-log information in the Maintenance Data Center and ensure removed-occurrence cleanup when marking calendar tasks complete.

### Description
- Persist `syncProcessLog` in `snapshotState()` and restore it in `adoptState()` and add `appendSystemLog()` and `scanPurchaseInventoryLinks()` utilities to record and inspect save/log events and purchase→inventory link state. 
- Add `recordDataFlowEvent()`, `stableStringify()`, `getAreaSignature()`, and `getTrackedStateSignature()` helpers to detect changed areas across snapshots and push `data_flow_save` events into `window.syncProcessLog`.
- Enhance the receipt/purchase history UI to support inventory linking: add an `inventoryItemId` select column, auto-detection by part number/name, inline linking workflows, templates, repair modal (`renderRepairModal`), and a disabled fixer widget for batch repairs. 
- Add Inventory and Logs tabs to the Maintenance Data Center and render data center inventory rows and sync/log rows (`renderDataCenterInventoryRows`, `renderDataCenterLogRows`).
- Add UI/UX changes across `renderers.js` and `views.js` to surface repair actions in Order Requests and other views and inject a reusable repair modal markup; include a debug helper `window.debugPurchaseInventoryLinks`.
- Make minor behavior fixes: clear removed occurrences when marking a calendar task complete in `markCalendarTaskComplete()` and log skipped inventory updates in `applyInventoryForApprovedItems()` when purchase line lacks `inventoryId`.
- Add CSS to hide the disabled fixer button and improve log-cell layout in the data center (`style.css`).

### Testing
- Ran project lint and static checks via `npm run lint` which completed successfully.
- Executed the test suite via `npm test` and existing unit tests passed without failures.
- Performed a production build via `npm run build` to ensure no bundling/runtime syntax errors and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2528b22348325a97478d70f4002e3)