### PR TITLE
Add material weight/cost calculator to job form with settings panel and layout updates

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -19073,7 +19073,9 @@ function renderJobs(){
     if (!form) return;
     const getVal = (id)=>{
       const el = document.getElementById(id);
-      return el && typeof el.value === "string" ? el.value : "";
+      if (!el) return "";
+      if (typeof el.value === "string") return el.value;
+      return typeof el.textContent === "string" ? el.textContent : "";
     };
     window.jobAddDraft = {
       name: getVal("jobName"),
@@ -19082,6 +19084,9 @@ function renderJobs(){
       charge: getVal("jobCharge"),
       costRate: getVal("jobCostRate"),
       material: getVal("jobMaterial"),
+      materialThickness: getVal("jobMaterialThickness"),
+      materialLengthFt: getVal("jobMaterialLengthFt"),
+      materialWidthFt: getVal("jobMaterialWidthFt"),
       materialCost: getVal("jobMaterialCost"),
       materialQty: getVal("jobMaterialQty"),
       start: getVal("jobStart"),
@@ -19090,9 +19095,154 @@ function renderJobs(){
       category: getVal("jobCategory")
     };
   };
+  const MATERIAL_SETTINGS_KEY = "job_material_pricing_v1";
+  const defaultMaterialSettings = ()=>({
+    wasteFactor: 10,
+    materials: [
+      { name: "A36 steel", density: 0.283, pricePerLb: 0.8 },
+      { name: "Grade 572-50 steel", density: 0.283, pricePerLb: 0.95 },
+      { name: "Stainless Steel", density: 0.289, pricePerLb: 1.9 },
+      { name: "Aluminum", density: 0.098, pricePerLb: 1.75 }
+    ]
+  });
+  const loadMaterialSettings = ()=>{
+    try {
+      const parsed = JSON.parse(localStorage.getItem(MATERIAL_SETTINGS_KEY) || "null");
+      if (!parsed || typeof parsed !== "object") return defaultMaterialSettings();
+      const fallback = defaultMaterialSettings();
+      const materials = Array.isArray(parsed.materials) ? parsed.materials.filter(m => m && m.name) : fallback.materials;
+      return { wasteFactor: Number(parsed.wasteFactor) >= 0 ? Number(parsed.wasteFactor) : fallback.wasteFactor, materials };
+    } catch(_){ return defaultMaterialSettings(); }
+  };
+  const saveMaterialSettings = (settings)=> localStorage.setItem(MATERIAL_SETTINGS_KEY, JSON.stringify(settings));
+  let materialSettings = loadMaterialSettings();
+  const gcd = (a, b)=> b ? gcd(b, a % b) : a;
+  const fractionToNumber = (value)=>{
+    const txt = String(value || "").trim();
+    if (!txt) return NaN;
+    if (txt.includes("/")){
+      const [n, d] = txt.split("/").map(Number);
+      if (!Number.isFinite(n) || !Number.isFinite(d) || d === 0) return NaN;
+      return n / d;
+    }
+    const num = Number(txt);
+    return Number.isFinite(num) ? num : NaN;
+  };
+  const toNearestSixteenthText = (value)=>{
+    const num = fractionToNumber(value);
+    if (!Number.isFinite(num) || num <= 0) return "";
+    const rounded = Math.max(1, Math.round(num * 16));
+    if (rounded % 16 === 0) return String(rounded / 16);
+    const divisor = gcd(rounded, 16);
+    return `${rounded / divisor}/${16 / divisor}`;
+  };
+  const recalcMaterialTotals = ()=>{
+    const matEl = document.getElementById("jobMaterial");
+    const tEl = document.getElementById("jobMaterialThickness");
+    const lengthEl = document.getElementById("jobMaterialLengthFt");
+    const widthEl = document.getElementById("jobMaterialWidthFt");
+    const costEl = document.getElementById("jobMaterialCost");
+    const qtyEl = document.getElementById("jobMaterialQty");
+    if (!(matEl && tEl && lengthEl && widthEl && costEl && qtyEl)) return;
+    const selected = materialSettings.materials.find(m => m.name === matEl.value);
+    const thickness = fractionToNumber(tEl.value);
+    const lengthFt = Number(lengthEl.value);
+    const widthFt = Number(widthEl.value);
+    const areaSqIn = lengthFt * widthFt * 144;
+    if (!selected || !Number.isFinite(thickness) || !Number.isFinite(areaSqIn) || thickness <= 0 || areaSqIn <= 0){
+      costEl.value = "";
+      qtyEl.textContent = "0.00";
+      return;
+    }
+    const baseWeight = thickness * areaSqIn * Number(selected.density || 0);
+    const wasteMultiplier = 1 + (Math.max(0, Number(materialSettings.wasteFactor) || 0) / 100);
+    const weight = baseWeight * wasteMultiplier;
+    const totalCost = weight * Number(selected.pricePerLb || 0);
+    qtyEl.textContent = weight.toFixed(2);
+    costEl.value = totalCost.toFixed(2);
+  };
+  const renderMaterialSettingsPanel = ()=>{
+    const list = document.getElementById("jobMaterialSettingsList");
+    const matSelect = document.getElementById("jobMaterial");
+    const wasteInput = document.getElementById("jobWasteFactor");
+    if (!list || !matSelect || !wasteInput) return;
+    wasteInput.value = String(materialSettings.wasteFactor);
+    matSelect.innerHTML = `<option value="">Select material</option>${materialSettings.materials.map(m=>`<option value="${escapeHtml(m.name)}">${escapeHtml(m.name)}</option>`).join("")}`;
+    list.innerHTML = materialSettings.materials.map((m, idx)=>`
+      <div class="job-material-row">
+        <label>Name<input data-mat-name="${idx}" value="${escapeHtml(m.name)}"></label>
+        <label>Density (lb/in³)<input data-mat-density="${idx}" type="number" step="0.001" min="0" value="${Number(m.density) || 0}"></label>
+        <label>Price ($/lb)<input data-mat-price="${idx}" type="number" step="0.01" min="0" value="${Number(m.pricePerLb) || 0}"></label>
+        <button type="button" data-mat-remove="${idx}">Remove</button>
+      </div>
+    `).join("");
+  };
   const addJobForm = document.getElementById("addJobForm");
   addJobForm?.addEventListener("input", syncAddJobDraftFromForm);
   addJobForm?.addEventListener("change", syncAddJobDraftFromForm);
+  addJobForm?.addEventListener("input", (e)=>{
+    if (["jobMaterial", "jobMaterialThickness", "jobMaterialLengthFt", "jobMaterialWidthFt"].includes(e.target?.id)) recalcMaterialTotals();
+  });
+  addJobForm?.addEventListener("keydown", (e)=>{
+    if (e.key !== "Enter" || e.shiftKey) return;
+    const target = e.target;
+    if (!(target instanceof HTMLInputElement || target instanceof HTMLSelectElement)) return;
+    e.preventDefault();
+    const fields = Array.from(addJobForm.querySelectorAll("input, select, button[type='submit']"))
+      .filter(el => !el.disabled && el.type !== "hidden" && el.id !== "jobFiles");
+    const idx = fields.indexOf(target);
+    const next = idx >= 0 ? fields[idx + 1] : null;
+    if (next && typeof next.focus === "function") next.focus();
+  });
+  document.getElementById("jobMaterialThickness")?.addEventListener("blur", (e)=>{
+    const normalized = toNearestSixteenthText(e.target.value);
+    if (normalized) e.target.value = normalized;
+    recalcMaterialTotals();
+    syncAddJobDraftFromForm();
+  });
+  renderMaterialSettingsPanel();
+  document.getElementById("jobMaterialSettingsBtn")?.addEventListener("click", ()=>{
+    const panel = document.getElementById("jobMaterialSettingsPanel");
+    if (!panel) return;
+    panel.hidden = false; panel.setAttribute("aria-hidden", "false");
+    renderMaterialSettingsPanel();
+  });
+  document.getElementById("jobMaterialSettingsClose")?.addEventListener("click", ()=>{
+    const panel = document.getElementById("jobMaterialSettingsPanel");
+    if (!panel) return;
+    panel.hidden = true; panel.setAttribute("aria-hidden", "true");
+  });
+  document.getElementById("jobMaterialAddTypeBtn")?.addEventListener("click", ()=>{
+    materialSettings.materials.push({ name: "New Material", density: 0.1, pricePerLb: 1 });
+    saveMaterialSettings(materialSettings);
+    renderMaterialSettingsPanel();
+  });
+  document.getElementById("jobWasteFactor")?.addEventListener("change", (e)=>{
+    materialSettings.wasteFactor = Math.max(0, Number(e.target.value) || 0);
+    saveMaterialSettings(materialSettings);
+    recalcMaterialTotals();
+  });
+  document.getElementById("jobMaterialSettingsList")?.addEventListener("input", (e)=>{
+    const t = e.target;
+    const idx = Number(t.dataset.matName ?? t.dataset.matDensity ?? t.dataset.matPrice);
+    if (!Number.isInteger(idx) || !materialSettings.materials[idx]) return;
+    if (t.dataset.matName != null) materialSettings.materials[idx].name = t.value.trim() || "Material";
+    if (t.dataset.matDensity != null) materialSettings.materials[idx].density = Math.max(0, Number(t.value) || 0);
+    if (t.dataset.matPrice != null) materialSettings.materials[idx].pricePerLb = Math.max(0, Number(t.value) || 0);
+    saveMaterialSettings(materialSettings);
+    renderMaterialSettingsPanel();
+    recalcMaterialTotals();
+  });
+  document.getElementById("jobMaterialSettingsList")?.addEventListener("click", (e)=>{
+    const btn = e.target.closest("[data-mat-remove]");
+    if (!btn) return;
+    const idx = Number(btn.getAttribute("data-mat-remove"));
+    if (!Number.isInteger(idx)) return;
+    materialSettings.materials.splice(idx, 1);
+    saveMaterialSettings(materialSettings);
+    renderMaterialSettingsPanel();
+    recalcMaterialTotals();
+  });
   const addJobEstHoursInput = document.getElementById("jobEst");
   const addJobEstMinutesInput = document.getElementById("jobEstMinutes");
   const addJobEstBreakdown = document.getElementById("jobEstBreakdown");
@@ -19109,6 +19259,7 @@ function renderJobs(){
 
   document.getElementById("addJobForm")?.addEventListener("submit",(e)=>{
     e.preventDefault();
+    recalcMaterialTotals();
     const name  = document.getElementById("jobName").value.trim();
     const estMinutesInput = document.getElementById("jobEstMinutes");
     applyMinutesToHours(addJobEstHoursInput, estMinutesInput, addJobEstBreakdown);
@@ -19117,7 +19268,7 @@ function renderJobs(){
     const chargeRaw = document.getElementById("jobCharge")?.value ?? "";
     const costRateRaw = document.getElementById("jobCostRate")?.value ?? "";
     const materialCostRaw = document.getElementById("jobMaterialCost")?.value ?? "";
-    const materialQtyRaw = document.getElementById("jobMaterialQty")?.value ?? "";
+    const materialQtyRaw = document.getElementById("jobMaterialQty")?.textContent ?? "";
     const start = document.getElementById("jobStart").value;
     const due   = document.getElementById("jobDue").value;
     const projectNumberRaw = document.getElementById("jobProjectNumber")?.value ?? "";
@@ -19130,15 +19281,25 @@ function renderJobs(){
     const previousCategoryFilter = typeof window.jobCategoryFilter === "string" && window.jobCategoryFilter
       ? window.jobCategoryFilter
       : jobRootCategoryId;
-    const materialCost = materialCostRaw === "" ? 0 : Number(materialCostRaw);
-    const materialQty = materialQtyRaw === "" ? 0 : Number(materialQtyRaw);
+    let materialCost = materialCostRaw === "" ? 0 : Number(materialCostRaw);
+    const materialWeight = materialQtyRaw === "" ? 0 : Number(materialQtyRaw);
+    const materialQty = 1;
     const chargeRate = chargeRaw === "" ? 200 : Number(chargeRaw);
     const costRate = costRateRaw === "" ? 45 : Number(costRateRaw);
     if (!name || !isFinite(est) || est<=0 || !start || !due || !projectNumber){ toast("Fill job fields, including project #."); return; }
-    if (!Number.isFinite(materialCost) || materialCost < 0){ toast("Enter a valid material cost."); return; }
-    if (!Number.isFinite(materialQty) || materialQty < 0){ toast("Enter a valid material quantity."); return; }
+    if (!Number.isFinite(materialCost) || materialCost < 0){
+      materialCost = 0;
+    }
+    if (!Number.isFinite(materialWeight) || materialWeight < 0){ toast("Enter a valid material quantity."); return; }
     if (!Number.isFinite(chargeRate) || chargeRate < 0){ toast("Enter a valid charge rate."); return; }
     if (!Number.isFinite(costRate) || costRate < 0){ toast("Enter a valid cost rate."); return; }
+    if (materialCost <= 0 && materialWeight > 0){
+      const selectedMaterial = materialSettings.materials.find(m => m.name === material);
+      const pricePerLb = Number(selectedMaterial?.pricePerLb || 0);
+      if (Number.isFinite(pricePerLb) && pricePerLb > 0){
+        materialCost = Number((materialWeight * pricePerLb).toFixed(2));
+      }
+    }
     if (!categoryId){ toast("Choose a category."); return; }
     if (categoryId === "__new__"){
       const parent = window.jobCategoryFilter || (typeof window.JOB_ROOT_FOLDER_ID === "string" ? window.JOB_ROOT_FOLDER_ID : "jobs_root");
@@ -19148,7 +19309,7 @@ function renderJobs(){
       ensureJobCategoryFolderOpen(categoryId);
     }
     const attachments = pendingNewJobFiles.map(f=>({ ...f }));
-    const newJob = { id: genId(name), name, estimateHours:est, startISO:start, dueISO:due, projectNumber, material, materialCost, materialQty, chargeRate, costRate, priority, notes:"", manualLogs:[], files:attachments, cat: categoryId };
+    const newJob = { id: genId(name), name, estimateHours:est, startISO:start, dueISO:due, projectNumber, material, materialCost, materialQty, materialWeight, chargeRate, costRate, priority, notes:"", manualLogs:[], files:attachments, cat: categoryId };
     cuttingJobs.push(newJob);
     reorderPriorities(newJob.id, priority);
     ensureJobCategories?.();
@@ -21889,5 +22050,5 @@ function renderDeletedItems(options){
     } catch (_){
       /* ignore selection failures (e.g. unsupported input types) */
     }
-  }
+    }
 }

--- a/js/views.js
+++ b/js/views.js
@@ -2862,13 +2862,11 @@ function viewJobs(){
     if (efficiency && efficiency.costRate != null && Number.isFinite(Number(efficiency.costRate))){
       costRate = Number(efficiency.costRate);
     } else {
-      const hoursBase = hoursForTotal > 0 ? hoursForTotal : hoursFromEstimate;
-      const variableRate = hoursBase > 0 ? (materialTotal / hoursBase) : 0;
-      costRate = JOB_BASE_COST_PER_HOUR + variableRate;
+      costRate = JOB_BASE_COST_PER_HOUR;
     }
     const netRate = chargeRate - costRate;
     const totalHours = hoursForTotal > 0 ? hoursForTotal : 0;
-    return netRate * totalHours;
+    return (netRate * totalHours) - materialTotal;
   };
 
   const pendingFiles = Array.isArray(window.pendingNewJobFiles) ? window.pendingNewJobFiles : [];
@@ -3419,9 +3417,7 @@ function viewJobs(){
     const efficiencyCost = Number(job?.efficiency?.costRate);
     if (Number.isFinite(efficiencyCost) && efficiencyCost >= 0) return efficiencyCost;
     const hoursVal = Number(estHours);
-    return (Number.isFinite(hoursVal) && hoursVal > 0)
-      ? JOB_BASE_COST_PER_HOUR + (matTotal / hoursVal)
-      : JOB_BASE_COST_PER_HOUR;
+    return JOB_BASE_COST_PER_HOUR;
   };
   const completedStats = completedFiltered.reduce((acc, job)=>{
     const eff = computeJobEfficiency(job);
@@ -4301,6 +4297,7 @@ function viewJobs(){
         aria-hidden="${addFormOpen ? "false" : "true"}"
       >
         <form id="addJobForm" class="mini-form job-add-form">
+          <div class="job-add-column">
           <label>Job name
             <input type="text" id="jobName" placeholder="Job name" required value="${esc(addJobDraftField("name"))}">
           </label>
@@ -4323,15 +4320,8 @@ function viewJobs(){
           <label>Cost rate ($/hr)
             <input type="number" id="jobCostRate" placeholder="45.00" min="0" step="0.01" value="${esc(addJobDraftField("costRate", "45"))}">
           </label>
-          <label>Material
-            <input type="text" id="jobMaterial" placeholder="Material" list="jobMaterialOptions" value="${esc(addJobDraftField("material"))}">
-          </label>
-          <label>Material cost ($)
-            <input type="number" id="jobMaterialCost" placeholder="0.00" min="0" step="0.01" value="${esc(addJobDraftField("materialCost"))}">
-          </label>
-          <label>Material quantity
-            <input type="number" id="jobMaterialQty" placeholder="0.00" min="0" step="0.01" value="${esc(addJobDraftField("materialQty"))}">
-          </label>
+          </div>
+          <div class="job-add-column">
           <label>Start date
             <input type="date" id="jobStart" required value="${esc(addJobDraftField("start", defaultJobDateISO))}">
           </label>
@@ -4350,6 +4340,34 @@ function viewJobs(){
               Choose a category to keep jobs organized. We'll save it under All Jobs if you skip this step.
             </p>
           </div>
+          </div>
+          <div class="job-add-column job-add-column-material">
+          <label>Material
+            <select id="jobMaterial" aria-label="Material">
+              <option value="">Select material</option>
+              <option value="A36 steel">A36 steel</option>
+              <option value="Grade 572-50 steel">Grade 572-50 steel</option>
+              <option value="Stainless Steel">Stainless Steel</option>
+              <option value="Aluminum">Aluminum</option>
+            </select>
+          </label>
+          <label>Thickness (in, fraction or decimal)
+            <input type="text" id="jobMaterialThickness" placeholder="1/4" inputmode="decimal" value="${esc(addJobDraftField("materialThickness"))}">
+          </label>
+          <label>Path length (ft)
+            <input type="number" id="jobMaterialLengthFt" placeholder="10" min="0.01" step="0.01" value="${esc(addJobDraftField("materialLengthFt"))}">
+          </label>
+          <label>Path width (ft)
+            <input type="number" id="jobMaterialWidthFt" placeholder="4" min="0.01" step="0.01" value="${esc(addJobDraftField("materialWidthFt"))}">
+          </label>
+          <label>Material cost ($)
+            <input type="number" id="jobMaterialCost" placeholder="0.00" min="0" step="0.01" value="${esc(addJobDraftField("materialCost"))}" readonly aria-readonly="true">
+          </label>
+          <label>Material weight (lb)
+            <output id="jobMaterialQty" class="job-material-output">${esc(addJobDraftField("materialQty") || "0.00")}</output>
+          </label>
+          <button type="button" id="jobMaterialSettingsBtn">Material settings</button>
+          </div>
           <div class="job-add-actions">
             <button type="button" id="jobFilesBtn">Attach Files</button>
             <button type="button" id="jobOneDriveLibraryAddBtn">Add from this computer OneDrive folder</button>
@@ -4359,6 +4377,19 @@ function viewJobs(){
           <datalist id="jobMaterialOptions">${materialInventoryOptionsMarkup}</datalist>
         </form>
         <div class="small muted job-files-summary" id="jobFilesSummary">${pendingSummary}</div>
+        <div class="job-material-settings-modal" id="jobMaterialSettingsPanel" hidden aria-hidden="true">
+          <div class="job-material-settings">
+            <div class="job-material-settings-header">
+              <strong>Material settings</strong>
+              <button type="button" id="jobMaterialSettingsClose">Close</button>
+            </div>
+            <label>Waste factor (%)
+              <input type="number" id="jobWasteFactor" min="0" step="1" value="10">
+            </label>
+            <div id="jobMaterialSettingsList"></div>
+            <button type="button" id="jobMaterialAddTypeBtn">+ Add material type</button>
+          </div>
+        </div>
       </section>
 
       <div class="job-category-indicator-wrapper">

--- a/style.css
+++ b/style.css
@@ -2250,6 +2250,9 @@ body.modal-open .auth-bar {
   grid-template-columns: repeat(6, minmax(120px, 1fr));
   min-height: 118px;
 }
+.job-add-form > .job-add-column:nth-child(1) > label{
+  padding-top: 16px;
+}
 .job-add-form > .job-add-column:nth-child(2){
   flex: 1 1 calc(50% - 5px);
   grid-template-columns: repeat(4, minmax(150px, 1fr));

--- a/style.css
+++ b/style.css
@@ -2247,26 +2247,23 @@ body.modal-open .auth-bar {
 }
 .job-add-form > .job-add-column:nth-child(1){
   flex: 1 1 calc(50% - 5px);
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(120px, 1fr));
   min-height: 118px;
 }
 .job-add-form > .job-add-column:nth-child(2){
   flex: 1 1 calc(50% - 5px);
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(150px, 1fr));
   min-height: 118px;
 }
 .job-add-column-material{
   flex: 1 1 100%;
-  grid-template-columns: 1.4fr 0.7fr 0.7fr 0.7fr 0.7fr 0.7fr;
+  grid-template-columns: repeat(6, minmax(140px, 1fr));
   align-items:end;
   width:100%;
   justify-self:stretch;
 }
-.job-add-column-material > label:first-child{
-  grid-column: span 2;
-}
 .job-add-column-material > #jobMaterialSettingsBtn{
-  grid-column: 1 / -1;
+  grid-column: 6;
   justify-self:end;
   min-width:180px;
 }
@@ -2310,7 +2307,7 @@ body.modal-open .auth-bar {
 }
 .job-estimate-label-group .small {
   position: absolute;
-  top: -14px;
+  top: 0;
   left: 0;
   display:block;
   margin-bottom:0;
@@ -2320,7 +2317,10 @@ body.modal-open .auth-bar {
 }
 .job-estimate-label-group {
   position: relative;
-  padding-top: 12px;
+  padding-top: 16px;
+}
+.job-category-field{
+  align-self:end;
 }
 .job-priority-hint {
   margin: 4px 0 0;

--- a/style.css
+++ b/style.css
@@ -2238,7 +2238,7 @@ body.modal-open .auth-bar {
   grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
   gap:8px 10px;
   align-content:start;
-  align-items:end;
+  align-items:start;
   min-width:0;
   padding:8px;
   border:1px solid #cfdcf4;
@@ -2319,8 +2319,9 @@ body.modal-open .auth-bar {
   position: relative;
   padding-top: 16px;
 }
-.job-category-field{
-  align-self:end;
+.job-add-form > .job-add-column:nth-child(2) > label,
+.job-add-form > .job-add-column:nth-child(2) .job-category-field{
+  align-self:start;
 }
 .job-priority-hint {
   margin: 4px 0 0;

--- a/style.css
+++ b/style.css
@@ -2229,17 +2229,17 @@ body.modal-open .auth-bar {
 .job-add-form {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
   align-items: start;
   width: 100%;
 }
 .job-add-column{
   display:grid;
   grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
-  gap:10px 12px;
+  gap:8px 10px;
   align-content:start;
   min-width:0;
-  padding:10px;
+  padding:8px;
   border:1px solid #cfdcf4;
   border-radius:12px;
   background:#f4f8ff;
@@ -2247,10 +2247,12 @@ body.modal-open .auth-bar {
 .job-add-form > .job-add-column:nth-child(1){
   flex: 1 1 calc(50% - 5px);
   grid-template-columns: repeat(6, minmax(0, 1fr));
+  min-height: 118px;
 }
 .job-add-form > .job-add-column:nth-child(2){
   flex: 1 1 calc(50% - 5px);
   grid-template-columns: repeat(4, minmax(0, 1fr));
+  min-height: 118px;
 }
 .job-add-column-material{
   flex: 1 1 100%;
@@ -2287,11 +2289,11 @@ body.modal-open .auth-bar {
 .job-add-form input,
 .job-add-form select {
   width: 100%;
-  min-height: 36px;
+  min-height: 34px;
   border-radius: 12px;
   border: 1px solid #cdd8ea;
   background: #ffffff;
-  padding: 10px 12px;
+  padding: 8px 10px;
   font-size: 14px;
   color: #18304f;
   box-shadow: inset 0 1px 2px rgba(10, 30, 56, 0.05);
@@ -2342,11 +2344,11 @@ body.modal-open .auth-bar {
   font-weight:600;
 }
 .job-material-output{
-  min-height:36px;
+  min-height:34px;
   border-radius:12px;
   border:1px solid #cdd8ea;
   background:#f8fbff;
-  padding:10px 12px;
+  padding:8px 10px;
   display:flex;
   align-items:center;
 }

--- a/style.css
+++ b/style.css
@@ -2227,10 +2227,51 @@ body.modal-open .auth-bar {
   display: none;
 }
 .job-add-form {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 12px 14px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
   align-items: start;
+  width: 100%;
+}
+.job-add-column{
+  display:grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap:10px 12px;
+  align-content:start;
+  min-width:0;
+  padding:10px;
+  border:1px solid #cfdcf4;
+  border-radius:12px;
+  background:#f4f8ff;
+}
+.job-add-form > .job-add-column:nth-child(1){
+  flex: 1 1 calc(50% - 5px);
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+.job-add-form > .job-add-column:nth-child(2){
+  flex: 1 1 calc(50% - 5px);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+.job-add-column-material{
+  flex: 1 1 100%;
+  width:100%;
+  justify-self:stretch;
+}
+.job-add-column-material > label:first-child{
+  grid-column: span 2;
+}
+.job-add-column-material > #jobMaterialSettingsBtn{
+  grid-column: 1 / -1;
+  justify-self:end;
+  min-width:180px;
+}
+.job-add-column-material > #jobMaterialSettingsBtn{
+  min-height:40px;
+  border-radius:10px;
+  border:1px solid #c5d7f4;
+  background:#fff;
+  font-weight:600;
+  color:#1d3d66;
 }
 .job-add-form > label,
 .job-category-field {
@@ -2246,7 +2287,7 @@ body.modal-open .auth-bar {
 .job-add-form input,
 .job-add-form select {
   width: 100%;
-  min-height: 42px;
+  min-height: 36px;
   border-radius: 12px;
   border: 1px solid #cdd8ea;
   background: #ffffff;
@@ -2263,16 +2304,14 @@ body.modal-open .auth-bar {
   box-shadow: 0 0 0 3px rgba(94, 163, 255, 0.18);
 }
 .job-estimate-label-group .small {
-  position: absolute;
-  top: -18px;
-  left: 0;
+  position: static;
+  display:block;
+  margin-bottom:2px;
   font-weight: 500;
   letter-spacing: 0;
   white-space: nowrap;
 }
-.job-estimate-label-group {
-  position: relative;
-}
+.job-estimate-label-group { position: static; }
 .job-priority-hint {
   margin: 4px 0 0;
   min-height: 18px;
@@ -2286,6 +2325,48 @@ body.modal-open .auth-bar {
   align-items: center;
   justify-content: center;
   padding-top: 2px;
+  justify-content: flex-start;
+}
+.job-material-row{
+  display:grid;
+  grid-template-columns: 1.2fr 1fr 1fr auto;
+  gap:8px;
+  align-items:end;
+  margin:8px 0;
+}
+.job-material-row label{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  font-size:12px;
+  font-weight:600;
+}
+.job-material-output{
+  min-height:36px;
+  border-radius:12px;
+  border:1px solid #cdd8ea;
+  background:#f8fbff;
+  padding:10px 12px;
+  display:flex;
+  align-items:center;
+}
+.job-material-settings-modal{
+  position:fixed;
+  inset:0;
+  background:rgba(8,19,35,.45);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  z-index:2000;
+}
+.job-material-settings-modal[hidden]{ display:none; }
+.job-material-settings{
+  width:min(880px, 92vw);
+  max-height:86vh;
+  overflow:auto;
+  background:#fff;
+  padding:16px;
+  border-radius:14px;
 }
 .job-add-actions button {
   min-height: 40px;

--- a/style.css
+++ b/style.css
@@ -2248,7 +2248,8 @@ body.modal-open .auth-bar {
 .job-add-form > .job-add-column:nth-child(1){
   flex: 1 1 calc(50% - 5px);
   grid-template-columns: repeat(6, minmax(120px, 1fr));
-  min-height: 118px;
+  min-height: 136px;
+  padding-bottom: 22px;
 }
 .job-add-form > .job-add-column:nth-child(1) > label{
   padding-top: 16px;
@@ -2256,7 +2257,7 @@ body.modal-open .auth-bar {
 .job-add-form > .job-add-column:nth-child(2){
   flex: 1 1 calc(50% - 5px);
   grid-template-columns: repeat(4, minmax(150px, 1fr));
-  min-height: 118px;
+  min-height: 136px;
 }
 .job-add-column-material{
   flex: 1 1 100%;

--- a/style.css
+++ b/style.css
@@ -2238,6 +2238,7 @@ body.modal-open .auth-bar {
   grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
   gap:8px 10px;
   align-content:start;
+  align-items:end;
   min-width:0;
   padding:8px;
   border:1px solid #cfdcf4;
@@ -2256,6 +2257,8 @@ body.modal-open .auth-bar {
 }
 .job-add-column-material{
   flex: 1 1 100%;
+  grid-template-columns: 1.4fr 0.7fr 0.7fr 0.7fr 0.7fr 0.7fr;
+  align-items:end;
   width:100%;
   justify-self:stretch;
 }
@@ -2306,14 +2309,19 @@ body.modal-open .auth-bar {
   box-shadow: 0 0 0 3px rgba(94, 163, 255, 0.18);
 }
 .job-estimate-label-group .small {
-  position: static;
+  position: absolute;
+  top: -14px;
+  left: 0;
   display:block;
-  margin-bottom:2px;
+  margin-bottom:0;
   font-weight: 500;
   letter-spacing: 0;
   white-space: nowrap;
 }
-.job-estimate-label-group { position: static; }
+.job-estimate-label-group {
+  position: relative;
+  padding-top: 12px;
+}
 .job-priority-hint {
   margin: 4px 0 0;
   min-height: 18px;


### PR DESCRIPTION
### Motivation
- Provide first-class material pricing and weight estimation in the Add Job form so material cost can be computed from thickness and path dimensions and stored with jobs.
- Persist editable material types and a waste factor to localStorage for reuse across sessions.
- Improve form ergonomics and layout for the new material inputs.

### Description
- Add a material pricing feature backed by a `job_material_pricing_v1` localStorage entry with loader/saver functions `loadMaterialSettings` and `saveMaterialSettings` and default material types.
- Implement parsing and normalization utilities `fractionToNumber` and `toNearestSixteenthText`, and a `recalcMaterialTotals` function that computes material weight and cost from thickness, length, width, density and price; wire these into the add-job form and readonly material cost/weight display.
- Add a material settings modal with `renderMaterialSettingsPanel`, controls to add/remove/edit materials and waste factor, and event handlers to persist changes and recalc totals; add keyboard Enter navigation inside the form.
- Update `syncAddJobDraftFromForm` to read `textContent` when an element lacks a `value`, and adapt submit handling to use `materialWeight` (from the output) while keeping `materialQty` as `1`, auto-calc `materialCost` from selected material price when not provided, and include `materialWeight` on the job object.
- Adjust job economics logic in `viewJobs` to simplify cost rate selection (`resolveCostRate` now returns `JOB_BASE_COST_PER_HOUR` by default) and to subtract material total from computed net in `computeJobNetTotal`.
- Layout and style changes in `style.css` to introduce `.job-add-column`, `.job-add-column-material`, material settings modal styles, and various spacing/visual tweaks for the Add Job panel.
- Miscellaneous minor fixes: ensure `recalcMaterialTotals` runs on form submit and fix selection-range brace alignment.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa3644de408325b296e64562103b2a)