### PR TITLE
Add Monday-start lookback option for average hours/day calculations

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,6 +182,11 @@
           <input type="checkbox" id="configExcludeWeekends" name="configExcludeWeekends" />
           <span>Ignore weekends in scheduling</span>
         </label>
+        <label class="config-toggle" for="configMondayStartLookback">
+          <input type="checkbox" id="configMondayStartLookback" name="configMondayStartLookback" />
+          <span>Use Monday-start lookback windows</span>
+        </label>
+        <p class="config-note">When enabled, 1 week = Monday to today and 1 month = 4 Mondays ago to today.</p>
         <p class="config-note">Weekend work counts as bonus time when ignored.</p>
         <div class="config-actions">
           <button type="submit" class="config-button config-button-primary" id="configSave">Save changes</button>

--- a/js/core.js
+++ b/js/core.js
@@ -59,7 +59,8 @@ const DEFAULT_APP_CONFIG = {
   dailyHours: DEFAULT_DAILY_HOURS,
   predictionMode: "fixed",
   averageWindowDays: DEFAULT_PREDICTION_AVERAGE_WINDOW,
-  timeEfficiencyGoalMode: "maximum"
+  timeEfficiencyGoalMode: "maximum",
+  mondayStartLookback: false
 };
 let appConfig = { ...DEFAULT_APP_CONFIG };
 
@@ -241,6 +242,7 @@ function normalizeAppConfig(config){
     }
     normalized.averageWindowDays = normalizePredictionAverageWindow(config.averageWindowDays);
     normalized.timeEfficiencyGoalMode = config.timeEfficiencyGoalMode === "average" ? "average" : "maximum";
+    if (typeof config.mondayStartLookback === "boolean") normalized.mondayStartLookback = config.mondayStartLookback;
   }
   return normalized;
 }
@@ -294,8 +296,20 @@ function getAverageDailyCutHours(windowDaysOverride = null){
   today.setHours(0,0,0,0);
   const cfg = appConfig && typeof appConfig === "object" ? appConfig : DEFAULT_APP_CONFIG;
   const windowDays = normalizePredictionAverageWindow(windowDaysOverride != null ? windowDaysOverride : cfg.averageWindowDays);
+  const useMondayStartLookback = !!cfg.mondayStartLookback;
   const start = new Date(today);
-  start.setDate(start.getDate() - windowDays);
+  if (useMondayStartLookback){
+    const day = today.getDay();
+    const mondayOffset = (day + 6) % 7;
+    const currentMonday = new Date(today);
+    currentMonday.setDate(today.getDate() - mondayOffset);
+    const weekSpanByWindow = { 7: 1, 14: 2, 30: 4, 60: 8, 90: 13 };
+    const weeks = weekSpanByWindow[windowDays] || Math.max(1, Math.ceil(windowDays / 7));
+    start.setTime(currentMonday.getTime());
+    start.setDate(currentMonday.getDate() - ((weeks - 1) * 7));
+  } else {
+    start.setDate(start.getDate() - windowDays);
+  }
   const startKey = ymd(start);
   const endKey = ymd(today);
   const excludeWeekends = shouldExcludeWeekends();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -2930,14 +2930,15 @@ function getConfigurationElements(){
   const excludeWeekends = document.getElementById("configExcludeWeekends");
   const predictionMode = document.getElementById("configPredictionMode");
   const averageWindow = document.getElementById("configAverageWindow");
+  const mondayStartLookback = document.getElementById("configMondayStartLookback");
   const cancel = document.getElementById("configCancel");
-  return { modal, form, hoursInput, excludeWeekends, predictionMode, averageWindow, cancel };
+  return { modal, form, hoursInput, excludeWeekends, predictionMode, averageWindow, mondayStartLookback, cancel };
 }
 
 function currentAppConfiguration(){
   if (typeof normalizeAppConfig === "function") return normalizeAppConfig(window.appConfig);
   const fallbackDaily = typeof getConfiguredDailyHours === "function" ? getConfiguredDailyHours() : 8;
-  return { excludeWeekends: false, dailyHours: fallbackDaily, predictionMode: "fixed", averageWindowDays: 60 };
+  return { excludeWeekends: false, dailyHours: fallbackDaily, predictionMode: "fixed", averageWindowDays: 60, mondayStartLookback: false };
 }
 
 function closeConfigurationModal(){
@@ -2958,7 +2959,7 @@ function closeConfigurationModal(){
 }
 
 function openConfigurationModal(trigger){
-  const { modal, hoursInput, excludeWeekends, predictionMode, averageWindow } = getConfigurationElements();
+  const { modal, hoursInput, excludeWeekends, predictionMode, averageWindow, mondayStartLookback } = getConfigurationElements();
   if (!modal) return;
   const cfg = currentAppConfiguration();
   if (hoursInput){
@@ -2975,6 +2976,9 @@ function openConfigurationModal(trigger){
     averageWindow.value = String(cfg.averageWindowDays != null ? cfg.averageWindowDays : 60);
     averageWindow.disabled = !!(predictionMode && predictionMode.value === "fixed");
   }
+  if (mondayStartLookback){
+    mondayStartLookback.checked = !!cfg.mondayStartLookback;
+  }
   modal.removeAttribute("hidden");
   modal.setAttribute("aria-hidden", "false");
   modal.classList.add("is-open");
@@ -2987,7 +2991,7 @@ function openConfigurationModal(trigger){
 }
 
 function applyConfigurationForm(){
-  const { hoursInput, excludeWeekends, predictionMode, averageWindow } = getConfigurationElements();
+  const { hoursInput, excludeWeekends, predictionMode, averageWindow, mondayStartLookback } = getConfigurationElements();
   const nextDaily = hoursInput ? Number(hoursInput.value) : null;
   const nextMode = predictionMode && predictionMode.value === "fixed" ? "fixed" : "average";
   const nextWindow = averageWindow ? Number(averageWindow.value) : 60;
@@ -2995,7 +2999,8 @@ function applyConfigurationForm(){
     dailyHours: nextDaily,
     excludeWeekends: !!(excludeWeekends && excludeWeekends.checked),
     predictionMode: nextMode,
-    averageWindowDays: nextWindow
+    averageWindowDays: nextWindow,
+    mondayStartLookback: !!(mondayStartLookback && mondayStartLookback.checked)
   };
   if (typeof setAppConfig === "function") setAppConfig(nextConfig);
   else {


### PR DESCRIPTION
### Motivation
- Introduce a Monday-anchored lookback for the dashboard average-hours/day calculation so weekly and monthly averages can be computed from a Monday boundary instead of a simple trailing N-days window. 
- Preserve existing `Ignore weekends` behavior so weekend exclusion still affects eligible-day counting and averages.

### Description
- Added a workspace configuration toggle `Use Monday-start lookback windows` in the configuration modal (`index.html`) to control the new behavior. 
- Extended app configuration with a new boolean `mondayStartLookback` and persisted it via `normalizeAppConfig` and the configuration modal read/save flow (`js/core.js`, `js/renderers.js`).
- Updated the average-hours calculation in `getAverageDailyCutHours` (`js/core.js`) to optionally anchor windows on Mondays when `mondayStartLookback` is enabled, mapping common UI windows to whole-week spans (e.g. `1 week` → current Monday..today; `1 month` → four Mondays ago..today) while still honoring `shouldExcludeWeekends`. 
- Wired the new setting into the modal getters/initialization and save/application paths (`getConfigurationElements`, `openConfigurationModal`, `applyConfigurationForm` in `js/renderers.js`).

### Testing
- Ran JavaScript syntax checks with `node --check js/core.js js/renderers.js js/computations.js`, which completed without errors. 
- Verified UI changes present in `index.html` and configuration flow updates in `js/renderers.js` by loading the modified files (no runtime unit tests available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca6095c0c83258ead52595a4868c4)