### PR TITLE
Introduce Maintenance Calendar V2 collections, compatibility stream, and UI hooks

### DIFF
--- a/docs/maintenance-compat-audit.md
+++ b/docs/maintenance-compat-audit.md
@@ -1,0 +1,180 @@
+# Maintenance Calendar Evolution Design (No Migration, Legacy Safe)
+
+## Fixed Constraints (must remain true)
+1. Existing Firebase records in `tasksInterval` and `tasksAsReq` are **legacy source-of-truth** for existing tasks.
+2. Legacy records must keep current mutation/write paths for completion, uncompletion, remove/skip, notes, hours, reporting, and Data Center rows.
+3. No bulk migration, no silent conversion, no rename/replace of legacy structures.
+4. New model applies only to newly created maintenance calendar records unless a user explicitly upgrades a specific legacy item.
+
+## Plain-English Domain Model
+- **Maintenance Settings Task** = reusable definition (“what this task is”).
+- **Calendar Instance** = user’s scheduling intent (“how this task behaves on calendar this time”).
+- **Occurrence/Event Record** = actual action or outcome on a date (“what happened”).
+
+## Option Comparison
+
+### Option 1: Versioned payload on each new maintenance task/calendar item
+**Shape:** Add `modelVersion: 2` and nested `calendarInstances` / `occurrences` directly under task records.
+
+**Pros**
+- Fewer top-level collections.
+- Easy task-centric reads.
+
+**Cons/Risks**
+- High collision risk with current task mutation functions that assume legacy fields on task object.
+- Harder to guarantee old/new write-path isolation.
+- Increased chance of accidental writes from legacy handlers.
+
+### Option 2: Sibling collections in state (recommended base)
+**Shape:** Keep legacy lists untouched; add separate top-level arrays/maps for new system.
+
+**Pros**
+- Strong blast-radius isolation from legacy code.
+- Clean separation of write paths.
+- Easier phased rollout and feature flagging.
+
+**Cons**
+- Requires adapter to join data at read time.
+- More moving parts initially.
+
+### Option 3: Hybrid (recommended overall)
+**Shape:**
+- New task definitions in their own collection.
+- New calendar instances + occurrence log in sibling collections.
+- Optional lightweight marker on related UI objects only (not mutating legacy records).
+
+**Pros**
+- Best balance of isolation and future extensibility.
+- Supports event-sourcing style history without touching legacy fields.
+- Clean path to unified reporting adapter.
+
+**Cons**
+- Slightly more conceptual complexity than Option 2 alone.
+
+## Recommended Conceptual Data Model (New Records Only)
+
+### A) `maintenanceTasksV2` (home base definitions)
+Each entry represents a reusable maintenance task definition.
+- `id`
+- `system`: `"v2"`
+- `name`
+- `taskType`: `"per_interval" | "as_required" | "downtime" | ...`
+- `intervalHours` (optional metadata, not forced behavior)
+- `defaultDurationHours` (optional)
+- `price`, `pn`, links, category, etc.
+- `createdAtISO`, `updatedAtISO`, `archivedAtISO?`
+
+### B) `maintenanceCalendarInstancesV2` (scheduling intent)
+Each entry represents one calendar usage of a task.
+- `id`
+- `system`: `"v2"`
+- `taskId` (FK to `maintenanceTasksV2.id`)
+- `instanceMode`: `"one_time" | "repeat" | "past_log"`
+- `startDateISO`
+- `timezone` (optional but recommended)
+- `repeatRule` (nullable)
+  - e.g. basis: `"calendar" | "machine_hours"`
+  - cadence details (daily/weekly/monthly or interval-hours tracker semantics)
+- `status`: `"active" | "stopped" | "archived"`
+- `stoppedAtISO?`, `stopReason?`
+- `createdAtISO`, `updatedAtISO`
+
+### C) `maintenanceOccurrencesV2` (what happened)
+Append-oriented history records tied to one calendar instance.
+- `id`
+- `system`: `"v2"`
+- `instanceId` (FK to `maintenanceCalendarInstancesV2.id`)
+- `taskId` (denormalized for reporting speed)
+- `eventType`: `"scheduled" | "completed" | "uncompleted" | "skipped" | "moved" | "removed" | "note_set" | "hours_set" | "past_logged"`
+- `effectiveDateISO` (date occurrence applies to)
+- `recordedAtISO` (when event was recorded)
+- `payload` (event-specific details)
+  - moved: from/to date
+  - note_set: note text (or cleared flag)
+  - hours_set: value (or cleared flag)
+  - completed/uncompleted: hours snapshot metadata, source
+- `supersedesEventId?` (optional linkage for corrections)
+- `actor?` / source metadata
+
+## Relationship Rules
+1. One task definition (`maintenanceTasksV2`) can have many calendar instances.
+2. One calendar instance can have many occurrence/event records.
+3. Calendar display state is derived from instance + ordered event log.
+4. Reporting rolls up from occurrence facts (plus task metadata), not from mutating task definitions.
+
+## Behavior Mapping
+
+### One-time reminder
+- Create instance with `instanceMode = one_time`, no repeat rule.
+- Occurrences can include scheduled/completed/skipped/moved/note/hours.
+- Once completed/removed/stopped, no future projections.
+
+### Repeat-tracking reminder
+- Create instance with `instanceMode = repeat` and `repeatRule`.
+- Interval metadata on task is advisory; instance decides repeat behavior.
+- Future reminders are projections from instance + event history.
+
+### Past completion record
+- Create instance with `instanceMode = past_log` (or one_time with past date).
+- Write `past_logged` and/or `completed` event with backdated `effectiveDateISO`.
+- Must appear in reporting/Data Center as historical completion.
+
+## Linking Lifecycle Actions
+- **Completed**: add `completed` event.
+- **Uncompleted**: add `uncompleted` event referencing prior completion date/event.
+- **Skipped**: add `skipped` event for date.
+- **Moved**: add `moved` event with `fromDateISO` + `toDateISO`.
+- **Stopped**: set instance status `stopped` (+ optional stop event).
+- **Removed**: append `removed` event; do not hard-delete history.
+
+This preserves auditability and avoids destructive rewrites.
+
+## Legacy + New Coexistence Strategy
+- Keep reading legacy `tasksInterval/tasksAsReq` exactly as now.
+- New items are created only in V2 collections.
+- No shared mutation functions at first.
+- Read adapter merges outputs from:
+  1) legacy task-derived occurrences
+  2) v2 instance/event-derived occurrences
+
+## Legacy vs New Marker
+- Use explicit discriminator field `system`:
+  - legacy items: implicit (no `system` or treated as `legacy`)
+  - new items: `system: "v2"`
+- Optional additional marker: `schemaVersion: 2` on V2 records.
+
+## Read Adapter (future integration contract)
+Output unified records in one stream with stable fields used by calendar/reporting:
+- `streamId` (unique)
+- `sourceSystem`: `"legacy" | "v2"`
+- `taskId`, `taskName`
+- `instanceId?`
+- `dateISO`
+- `status`: due/manual/completed/skipped/removed/etc.
+- `note`, `hours`, `price`, `categoryId`, links
+- `provenance` (pointer to original record ids)
+
+Calendar renderer and reporting/Data Center consume only this normalized stream.
+
+## Edge Cases to Resolve Before Coding
+1. Duplicate same-day events (complete then uncomplete then complete).
+2. Timezone/day-boundary drift for date-only records.
+3. Move + complete on same date ordering.
+4. Repeating instance stopped, then reactivated.
+5. Note/hours clears vs overwrites (audit trail).
+6. Deleting a task definition with active instances.
+7. Reporting dedupe when both projected and completed facts exist.
+8. Idempotency for retrying writes offline.
+9. Conflict resolution when multiple clients update same instance.
+10. Explicit user-triggered upgrade path for a single legacy task (future scope, opt-in only).
+
+## Recommendation
+Adopt **Hybrid (Option 3)**:
+- Sibling V2 collections for strict safety.
+- Event-style occurrence log for robust history/audit.
+- Adapter-driven unified read model for calendar/reporting.
+
+Why this is safest now:
+- Minimizes risk to legacy behavior.
+- Preserves existing Firebase contracts.
+- Enables gradual rollout by surface area (create → display → mutate → report) without migration.

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -184,6 +184,37 @@ function hideBubbleSoon(){
     hideBubble();
   }, 180);
 }
+
+function showV2OneTimeBubble(instanceId, anchorEl){
+  const lookup = (typeof window !== "undefined" && window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object")
+    ? window.__calendarV2OneTimeLookup
+    : {};
+  const ev = lookup && instanceId != null ? lookup[String(instanceId)] : null;
+  if (!ev){
+    toast("V2 reminder details unavailable");
+    return;
+  }
+  ensureBubble();
+  clearTimeout(bubbleTimer);
+  const b = document.getElementById("bubble");
+  if (!b) return;
+  const dateText = parseDateLocal(ev.dateISO)?.toDateString() || ev.dateISO || "—";
+  b.innerHTML = `
+    <div class="bubble-title">${escapeHtml(ev.name || "Maintenance reminder")}</div>
+    <div class="bubble-kv"><span>Date:</span><span>${escapeHtml(dateText)}</span></div>
+    <div class="bubble-kv"><span>Mode:</span><span>One-time (V2)</span></div>
+    <div class="bubble-kv"><span>Status:</span><span>Scheduled</span></div>
+    <div class="bubble-kv"><span>Note:</span><span>${escapeHtml(ev.note || "—")}</span></div>
+    <div class="bubble-kv"><span>Info:</span><span>Completion/actions for V2 reminders are coming in the next step.</span></div>
+    <div class="bubble-actions"><button type="button" data-bubble-close>Close</button></div>
+  `;
+  const closeBtn = b.querySelector("[data-bubble-close]");
+  closeBtn?.addEventListener("click", ()=> hideBubbleSoon());
+  const rect = anchorEl.getBoundingClientRect();
+  b.style.top  = `${window.scrollY + rect.bottom + 8}px`;
+  b.style.left = `${window.scrollX + rect.left}px`;
+  b.classList.add("show");
+}
 function triggerDashboardAddPicker(opts){
   const detail = (opts && typeof opts === "object") ? { ...opts } : {};
   const enqueueRequest = ()=>{
@@ -1645,6 +1676,7 @@ function wireCalendarBubbles(){
     hoverTarget = el;
     if (el.dataset.calJob)  showJobBubble(el.dataset.calJob, el);
     if (el.dataset.calTask) showTaskBubble(el.dataset.calTask, el, extractTaskOptions(el));
+    if (el.dataset.calV2OneTime) showV2OneTimeBubble(el.dataset.calV2OneTime, el);
     if (el.dataset.calGarnet) showGarnetBubble(el.dataset.calGarnet, el);
   });
   months.addEventListener("mouseout", (e)=>{
@@ -1659,6 +1691,7 @@ function wireCalendarBubbles(){
     if (!el) return;
     if (el.dataset.calJob)  showJobBubble(el.dataset.calJob, el);
     if (el.dataset.calTask) showTaskBubble(el.dataset.calTask, el, extractTaskOptions(el));
+    if (el.dataset.calV2OneTime) showV2OneTimeBubble(el.dataset.calV2OneTime, el);
     if (el.dataset.calGarnet) showGarnetBubble(el.dataset.calGarnet, el);
   });
 }
@@ -2367,6 +2400,50 @@ function renderCalendar(){
     }
   });
 
+  const v2TaskLookup = new Map();
+  (Array.isArray(window.maintenanceTasksV2) ? window.maintenanceTasksV2 : []).forEach(entry => {
+    if (!entry || entry.id == null) return;
+    v2TaskLookup.set(String(entry.id), entry);
+  });
+  const v2InstanceLookup = new Map();
+  (Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2 : []).forEach(entry => {
+    if (!entry || entry.id == null) return;
+    if (String(entry.system || "") !== "v2" && Number(entry.schemaVersion || 0) < 2) return;
+    if (String(entry.instanceMode || "") !== "one_time") return;
+    v2InstanceLookup.set(String(entry.id), entry);
+  });
+  const oneTimeLookup = {};
+  (Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : []).forEach(event => {
+    if (!event || event.id == null) return;
+    if (String(event.system || "") !== "v2" && Number(event.schemaVersion || 0) < 2) return;
+    const instanceId = event.instanceId != null ? String(event.instanceId) : "";
+    const instance = v2InstanceLookup.get(instanceId);
+    if (!instance) return;
+    const eventType = String(event.eventType || "");
+    if (eventType !== "scheduled") return;
+    const dateISO = normalizeDateKey(event.effectiveDateISO || event.dateISO || instance.startDateISO || null);
+    if (!dateISO) return;
+    const task = v2TaskLookup.get(String(instance.taskId || event.taskId || "")) || null;
+    const name = String(event.taskName || (task && task.name) || "Maintenance reminder");
+    const note = event.payload && typeof event.payload === "object" && event.payload.note != null ? String(event.payload.note) : "";
+    const mapKey = `${instanceId}:${dateISO}`;
+    if (oneTimeLookup[mapKey]) return;
+    oneTimeLookup[mapKey] = { instanceId, dateISO, name, note };
+    (dueMap[dateISO] ||= []).push({
+      type: "v2task",
+      id: `v2-one-time:${instanceId}:${dateISO}`,
+      instanceId,
+      name,
+      status: "manual",
+      mode: "one_time_v2",
+      dateISO
+    });
+  });
+  window.__calendarV2OneTimeLookup = Object.values(oneTimeLookup).reduce((acc, entry)=>{
+    acc[String(entry.instanceId)] = entry;
+    return acc;
+  }, {});
+
   const jobsMap = {};
   cuttingJobs.forEach(j => {
     const start = parseDateLocal(j.startISO);
@@ -2579,10 +2656,15 @@ function renderCalendar(){
       (dueMap[key]||[]).forEach(ev=>{
         const chip = document.createElement("div");
         let cls = "event generic cal-task";
+        if (ev.type === "v2task") cls += " v2-event";
         if (ev.status === "completed") cls += " is-complete";
         chip.className = cls;
         const baseTaskId = ev.taskId || ev.id;
-        chip.dataset.calTask = baseTaskId;
+        if (ev.type === "v2task" && ev.instanceId){
+          chip.dataset.calV2OneTime = String(ev.instanceId);
+        }else{
+          chip.dataset.calTask = baseTaskId;
+        }
         chip.dataset.calStatus = ev.status || "due";
         if (ev.mode) chip.dataset.calMode = ev.mode;
         chip.dataset.calDate = ev.dateISO || key;

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -185,11 +185,11 @@ function hideBubbleSoon(){
   }, 180);
 }
 
-function showV2OneTimeBubble(instanceId, anchorEl){
+function showV2OneTimeBubble(occurrenceId, anchorEl){
   const lookup = (typeof window !== "undefined" && window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object")
     ? window.__calendarV2OneTimeLookup
     : {};
-  const ev = lookup && instanceId != null ? lookup[String(instanceId)] : null;
+  const ev = lookup && occurrenceId != null ? lookup[String(occurrenceId)] : null;
   if (!ev){
     toast("V2 reminder details unavailable");
     return;
@@ -2413,6 +2413,7 @@ function renderCalendar(){
     v2InstanceLookup.set(String(entry.id), entry);
   });
   const oneTimeLookup = {};
+  const seenV2ChipKeys = new Set();
   (Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : []).forEach(event => {
     if (!event || event.id == null) return;
     if (String(event.system || "") !== "v2" && Number(event.schemaVersion || 0) < 2) return;
@@ -2426,12 +2427,23 @@ function renderCalendar(){
     const task = v2TaskLookup.get(String(instance.taskId || event.taskId || "")) || null;
     const name = String(event.taskName || (task && task.name) || "Maintenance reminder");
     const note = event.payload && typeof event.payload === "object" && event.payload.note != null ? String(event.payload.note) : "";
-    const mapKey = `${instanceId}:${dateISO}`;
-    if (oneTimeLookup[mapKey]) return;
-    oneTimeLookup[mapKey] = { instanceId, dateISO, name, note };
+    const occurrenceId = String(event.id);
+    const mapKey = `${occurrenceId}:${dateISO}`;
+    if (seenV2ChipKeys.has(mapKey)) return;
+    seenV2ChipKeys.add(mapKey);
+    oneTimeLookup[occurrenceId] = {
+      occurrenceId,
+      eventType,
+      instanceId,
+      taskId: String(instance.taskId || event.taskId || ""),
+      dateISO,
+      name,
+      note
+    };
     (dueMap[dateISO] ||= []).push({
       type: "v2task",
-      id: `v2-one-time:${instanceId}:${dateISO}`,
+      id: `v2-one-time:${occurrenceId}`,
+      occurrenceId,
       instanceId,
       name,
       status: "manual",
@@ -2439,10 +2451,7 @@ function renderCalendar(){
       dateISO
     });
   });
-  window.__calendarV2OneTimeLookup = Object.values(oneTimeLookup).reduce((acc, entry)=>{
-    acc[String(entry.instanceId)] = entry;
-    return acc;
-  }, {});
+  window.__calendarV2OneTimeLookup = oneTimeLookup;
 
   const jobsMap = {};
   cuttingJobs.forEach(j => {
@@ -2660,8 +2669,8 @@ function renderCalendar(){
         if (ev.status === "completed") cls += " is-complete";
         chip.className = cls;
         const baseTaskId = ev.taskId || ev.id;
-        if (ev.type === "v2task" && ev.instanceId){
-          chip.dataset.calV2OneTime = String(ev.instanceId);
+        if (ev.type === "v2task" && ev.occurrenceId){
+          chip.dataset.calV2OneTime = String(ev.occurrenceId);
         }else{
           chip.dataset.calTask = baseTaskId;
         }

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -199,22 +199,101 @@ function showV2OneTimeBubble(occurrenceId, anchorEl){
   const b = document.getElementById("bubble");
   if (!b) return;
   const dateText = parseDateLocal(ev.dateISO)?.toDateString() || ev.dateISO || "—";
+  const statusText = ev.status === "completed" ? "Completed" : "Scheduled";
   b.innerHTML = `
     <div class="bubble-title">${escapeHtml(ev.name || "Maintenance reminder")}</div>
     <div class="bubble-kv"><span>Date:</span><span>${escapeHtml(dateText)}</span></div>
     <div class="bubble-kv"><span>Mode:</span><span>One-time (V2)</span></div>
-    <div class="bubble-kv"><span>Status:</span><span>Scheduled</span></div>
+    <div class="bubble-kv"><span>Status:</span><span>${escapeHtml(statusText)}</span></div>
     <div class="bubble-kv"><span>Note:</span><span>${escapeHtml(ev.note || "—")}</span></div>
+    <div class="bubble-kv"><span>Hours:</span><span>${ev.hours != null ? escapeHtml(String(ev.hours)) : "—"}</span></div>
     <div class="bubble-kv"><span>Info:</span><span>Completion/actions for V2 reminders are coming in the next step.</span></div>
-    <div class="bubble-actions"><button type="button" data-bubble-close>Close</button></div>
+    <div class="bubble-actions">
+      <button type="button" data-v2-complete>${ev.status === "completed" ? "Completed" : "Mark complete"}</button>
+      <button type="button" data-v2-uncomplete>Mark incomplete</button>
+      <button type="button" data-v2-note>Set note</button>
+      <button type="button" data-v2-hours>Set hours</button>
+      <button type="button" data-bubble-close>Close</button>
+    </div>
   `;
   const closeBtn = b.querySelector("[data-bubble-close]");
   closeBtn?.addEventListener("click", ()=> hideBubbleSoon());
+  b.querySelector("[data-v2-complete]")?.addEventListener("click", ()=>{
+    if (typeof window.completeV2OneTimeOccurrence === "function") window.completeV2OneTimeOccurrence(String(occurrenceId));
+  });
+  b.querySelector("[data-v2-uncomplete]")?.addEventListener("click", ()=>{
+    if (typeof window.uncompleteV2OneTimeOccurrence === "function") window.uncompleteV2OneTimeOccurrence(String(occurrenceId));
+  });
+  b.querySelector("[data-v2-note]")?.addEventListener("click", ()=>{
+    if (typeof window.setV2OneTimeOccurrenceNote === "function") window.setV2OneTimeOccurrenceNote(String(occurrenceId));
+  });
+  b.querySelector("[data-v2-hours]")?.addEventListener("click", ()=>{
+    if (typeof window.setV2OneTimeOccurrenceHours === "function") window.setV2OneTimeOccurrenceHours(String(occurrenceId));
+  });
   const rect = anchorEl.getBoundingClientRect();
   b.style.top  = `${window.scrollY + rect.bottom + 8}px`;
   b.style.left = `${window.scrollX + rect.left}px`;
   b.classList.add("show");
 }
+
+function appendV2OccurrenceEvent(baseOccurrenceId, eventType, payload = {}, supersedesEventId = null){
+  const list = Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : (window.maintenanceOccurrencesV2 = []);
+  const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};
+  const base = lookup[String(baseOccurrenceId)];
+  if (!base) return false;
+  const next = {
+    id: genId(`v2_${eventType}`),
+    system: "v2",
+    schemaVersion: 2,
+    instanceId: base.instanceId,
+    taskId: base.taskId,
+    eventType,
+    effectiveDateISO: base.dateISO,
+    recordedAtISO: new Date().toISOString(),
+    supersedesEventId: supersedesEventId || null,
+    rootOccurrenceId: String(baseOccurrenceId),
+    payload: { ...(payload || {}) }
+  };
+  list.unshift(next);
+  if (typeof saveCloudNow === "function") saveCloudNow();
+  else saveCloudDebounced();
+  renderCalendar();
+  return true;
+}
+
+window.completeV2OneTimeOccurrence = (occurrenceId)=>{
+  const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};
+  const base = lookup[String(occurrenceId)];
+  if (!base) return;
+  if (base.status === "completed"){ toast("Already completed"); return; }
+  if (appendV2OccurrenceEvent(occurrenceId, "completed", {}, String(occurrenceId))) toast("Marked complete");
+};
+window.uncompleteV2OneTimeOccurrence = (occurrenceId)=>{
+  const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};
+  const base = lookup[String(occurrenceId)];
+  if (!base) return;
+  if (base.status !== "completed"){ toast("Already incomplete"); return; }
+  if (appendV2OccurrenceEvent(occurrenceId, "uncompleted", {}, String(occurrenceId))) toast("Marked incomplete");
+};
+window.setV2OneTimeOccurrenceNote = (occurrenceId)=>{
+  const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};
+  const base = lookup[String(occurrenceId)];
+  if (!base) return;
+  const input = window.prompt("Set note for this V2 reminder:", base.note || "");
+  if (input === null) return;
+  if (appendV2OccurrenceEvent(occurrenceId, "note_set", { note: String(input) }, String(occurrenceId))) toast("Note saved");
+};
+window.setV2OneTimeOccurrenceHours = (occurrenceId)=>{
+  const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};
+  const base = lookup[String(occurrenceId)];
+  if (!base) return;
+  const input = window.prompt("Set hours for this V2 reminder:", base.hours != null ? String(base.hours) : "");
+  if (input === null) return;
+  const trimmed = String(input).trim();
+  const hours = trimmed === "" ? null : Number(trimmed);
+  if (trimmed !== "" && (!Number.isFinite(hours) || hours < 0)){ toast("Enter a valid non-negative number."); return; }
+  if (appendV2OccurrenceEvent(occurrenceId, "hours_set", { hours }, String(occurrenceId))) toast("Hours saved");
+};
 function triggerDashboardAddPicker(opts){
   const detail = (opts && typeof opts === "object") ? { ...opts } : {};
   const enqueueRequest = ()=>{
@@ -2426,8 +2505,23 @@ function renderCalendar(){
     if (!dateISO) return;
     const task = v2TaskLookup.get(String(instance.taskId || event.taskId || "")) || null;
     const name = String(event.taskName || (task && task.name) || "Maintenance reminder");
-    const note = event.payload && typeof event.payload === "object" && event.payload.note != null ? String(event.payload.note) : "";
     const occurrenceId = String(event.id);
+    const rootOccurrenceId = occurrenceId;
+    const timeline = (Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : []).filter(e => {
+      if (!e || typeof e !== "object") return false;
+      const rid = e.rootOccurrenceId != null ? String(e.rootOccurrenceId) : (String(e.id || "") === rootOccurrenceId ? rootOccurrenceId : "");
+      return rid === rootOccurrenceId || String(e.id || "") === rootOccurrenceId;
+    });
+    let status = "scheduled";
+    let note = event.payload && typeof event.payload === "object" && event.payload.note != null ? String(event.payload.note) : "";
+    let hours = event.payload && typeof event.payload === "object" && Number.isFinite(Number(event.payload.hours)) ? Number(event.payload.hours) : null;
+    timeline.forEach(e => {
+      const type = String(e.eventType || "");
+      if (type === "completed") status = "completed";
+      if (type === "uncompleted") status = "scheduled";
+      if (type === "note_set" && e.payload && typeof e.payload.note === "string") note = e.payload.note;
+      if (type === "hours_set" && e.payload && (e.payload.hours == null || Number.isFinite(Number(e.payload.hours)))) hours = e.payload.hours == null ? null : Number(e.payload.hours);
+    });
     const mapKey = `${occurrenceId}:${dateISO}`;
     if (seenV2ChipKeys.has(mapKey)) return;
     seenV2ChipKeys.add(mapKey);
@@ -2438,7 +2532,9 @@ function renderCalendar(){
       taskId: String(instance.taskId || event.taskId || ""),
       dateISO,
       name,
-      note
+      note,
+      hours,
+      status
     };
     (dueMap[dateISO] ||= []).push({
       type: "v2task",
@@ -2446,7 +2542,7 @@ function renderCalendar(){
       occurrenceId,
       instanceId,
       name,
-      status: "manual",
+      status: status === "completed" ? "completed" : "manual",
       mode: "one_time_v2",
       dateISO
     });

--- a/js/core.js
+++ b/js/core.js
@@ -1652,6 +1652,9 @@ if (!Array.isArray(window.dailyCutHours)) window.dailyCutHours = [];
 if (!Array.isArray(window.opportunityRollups)) window.opportunityRollups = [];
 if (!Array.isArray(window.weeklyCostReports)) window.weeklyCostReports = [];
 if (!Array.isArray(window.receiptTrackerWeeks)) window.receiptTrackerWeeks = [];
+if (!Array.isArray(window.maintenanceTasksV2)) window.maintenanceTasksV2 = [];
+if (!Array.isArray(window.maintenanceCalendarInstancesV2)) window.maintenanceCalendarInstancesV2 = [];
+if (!Array.isArray(window.maintenanceOccurrencesV2)) window.maintenanceOccurrencesV2 = [];
 if (!Array.isArray(window.jobFolders)) window.jobFolders = defaultJobFolders();
 if (typeof window.orderRequestTab !== "string") window.orderRequestTab = "active";
 
@@ -1672,6 +1675,9 @@ let orderRequests = window.orderRequests;
 let orderRequestTab = window.orderRequestTab;
 let garnetCleanings = window.garnetCleanings;
 let dailyCutHours = window.dailyCutHours;
+let maintenanceTasksV2 = window.maintenanceTasksV2;
+let maintenanceCalendarInstancesV2 = window.maintenanceCalendarInstancesV2;
+let maintenanceOccurrencesV2 = window.maintenanceOccurrencesV2;
 let jobFolders = window.jobFolders;
 let weeklyCostReports = window.weeklyCostReports;
 let receiptTrackerWeeks = window.receiptTrackerWeeks;
@@ -1848,6 +1854,15 @@ function refreshGlobalCollections(){
   if (!Array.isArray(window.dailyCutHours)) window.dailyCutHours = [];
   dailyCutHours = window.dailyCutHours;
 
+  if (!Array.isArray(window.maintenanceTasksV2)) window.maintenanceTasksV2 = [];
+  maintenanceTasksV2 = window.maintenanceTasksV2;
+
+  if (!Array.isArray(window.maintenanceCalendarInstancesV2)) window.maintenanceCalendarInstancesV2 = [];
+  maintenanceCalendarInstancesV2 = window.maintenanceCalendarInstancesV2;
+
+  if (!Array.isArray(window.maintenanceOccurrencesV2)) window.maintenanceOccurrencesV2 = [];
+  maintenanceOccurrencesV2 = window.maintenanceOccurrencesV2;
+
   if (!Array.isArray(window.jobFolders)) window.jobFolders = defaultJobFolders();
   jobFolders = window.jobFolders;
 }
@@ -1944,6 +1959,9 @@ window.defaultAsReqTasks = defaultAsReqTasks;
     copyArr("orderRequests");
     copyArr("receiptTrackerWeeks");
     copyArr("garnetCleanings");
+    copyArr("maintenanceTasksV2");
+    copyArr("maintenanceCalendarInstancesV2");
+    copyArr("maintenanceOccurrencesV2");
     copyArr("totalHistory");
     copyObj("appConfig");
     copyObj("settingsFolders");
@@ -1970,6 +1988,9 @@ window.defaultAsReqTasks = defaultAsReqTasks;
     if (!Array.isArray(sanitized.orderRequests) && Array.isArray(window.orderRequests)) sanitized.orderRequests = window.orderRequests.slice();
     if (!Array.isArray(sanitized.receiptTrackerWeeks) && Array.isArray(window.receiptTrackerWeeks)) sanitized.receiptTrackerWeeks = window.receiptTrackerWeeks.slice();
     if (!Array.isArray(sanitized.garnetCleanings) && Array.isArray(window.garnetCleanings)) sanitized.garnetCleanings = window.garnetCleanings.slice();
+    if (!Array.isArray(sanitized.maintenanceTasksV2) && Array.isArray(window.maintenanceTasksV2)) sanitized.maintenanceTasksV2 = window.maintenanceTasksV2.slice();
+    if (!Array.isArray(sanitized.maintenanceCalendarInstancesV2) && Array.isArray(window.maintenanceCalendarInstancesV2)) sanitized.maintenanceCalendarInstancesV2 = window.maintenanceCalendarInstancesV2.slice();
+    if (!Array.isArray(sanitized.maintenanceOccurrencesV2) && Array.isArray(window.maintenanceOccurrencesV2)) sanitized.maintenanceOccurrencesV2 = window.maintenanceOccurrencesV2.slice();
     if (!Array.isArray(sanitized.totalHistory) && Array.isArray(window.totalHistory)) sanitized.totalHistory = window.totalHistory.slice();
     if (!Array.isArray(sanitized.deletedItems) && Array.isArray(window.deletedItems)) sanitized.deletedItems = window.deletedItems.slice();
     if (!Array.isArray(sanitized.jobFolders) && Array.isArray(window.jobFolders)) sanitized.jobFolders = window.jobFolders.slice();
@@ -1991,6 +2012,9 @@ window.defaultAsReqTasks = defaultAsReqTasks;
     if (!Array.isArray(window.orderRequests)) window.orderRequests = [];
     if (!Array.isArray(window.receiptTrackerWeeks)) window.receiptTrackerWeeks = [];
     if (!Array.isArray(window.garnetCleanings)) window.garnetCleanings = [];
+    if (!Array.isArray(window.maintenanceTasksV2)) window.maintenanceTasksV2 = [];
+    if (!Array.isArray(window.maintenanceCalendarInstancesV2)) window.maintenanceCalendarInstancesV2 = [];
+    if (!Array.isArray(window.maintenanceOccurrencesV2)) window.maintenanceOccurrencesV2 = [];
     if (!Array.isArray(window.totalHistory)) window.totalHistory = [];
     if (!window.settingsFolders || !Array.isArray(window.settingsFolders)) window.settingsFolders = typeof defaultSettingsFolders === "function" ? defaultSettingsFolders() : [];
     if (!window.folders || typeof window.folders !== "object") window.folders = Array.isArray(window.settingsFolders) ? JSON.parse(JSON.stringify(window.settingsFolders)) : [];
@@ -2037,6 +2061,9 @@ function stateHasMeaningfulData(data){
     "pumpEff",
     "jobFolders",
     "orderRequestTab",
+    "maintenanceTasksV2",
+    "maintenanceCalendarInstancesV2",
+    "maintenanceOccurrencesV2",
     "schema"
   ]);
   return keys.some(key => meaningfulKeys.has(key));
@@ -2158,6 +2185,9 @@ function snapshotState(){
     weeklyCostReports: Array.isArray(window.weeklyCostReports)
       ? window.weeklyCostReports.map(entry => ({ ...entry }))
       : [],
+    maintenanceTasksV2: Array.isArray(maintenanceTasksV2) ? maintenanceTasksV2.map(entry => ({ ...entry })) : [],
+    maintenanceCalendarInstancesV2: Array.isArray(maintenanceCalendarInstancesV2) ? maintenanceCalendarInstancesV2.map(entry => ({ ...entry })) : [],
+    maintenanceOccurrencesV2: Array.isArray(maintenanceOccurrencesV2) ? maintenanceOccurrencesV2.map(entry => ({ ...entry })) : [],
     syncProcessLog: Array.isArray(window.syncProcessLog)
       ? window.syncProcessLog.map(entry => ({ ...entry }))
       : [],
@@ -2339,6 +2369,226 @@ function ensureTaskCategories(){
     }
   });
 }
+
+function detectMaintenanceRecordSystem(record){
+  if (!record || typeof record !== "object") return "legacy";
+  if (record.system === "v2") return "v2";
+  if ("eventType" in record || "effectiveDateISO" in record || "recordedAtISO" in record || "payload" in record) return "v2";
+  if (Number(record.schemaVersion) >= 2) return "v2";
+  return "legacy";
+}
+
+function createMaintenanceCompatibilityRow(base){
+  return {
+    streamId: base.streamId || "",
+    sourceSystem: base.sourceSystem || "legacy",
+    taskId: base.taskId || null,
+    taskName: base.taskName || "",
+    instanceId: base.instanceId || null,
+    occurrenceId: base.occurrenceId || null,
+    eventId: base.eventId || base.occurrenceId || null,
+    dateISO: normalizeDateISO(base.dateISO || ""),
+    status: base.status || "unknown",
+    eventType: base.eventType || null,
+    instanceMode: base.instanceMode || null,
+    note: base.note != null ? String(base.note) : null,
+    hours: base.hours != null && Number.isFinite(Number(base.hours)) ? Number(base.hours) : null,
+    categoryRef: base.categoryRef || null,
+    inventoryRef: base.inventoryRef || null,
+    costRef: base.costRef ?? null,
+    linkRef: base.linkRef || null,
+    provenance: base.provenance && typeof base.provenance === "object" ? { ...base.provenance } : {}
+  };
+}
+
+function normalizeLegacyMaintenanceTask(task, mode){
+  if (!task || typeof task !== "object") return null;
+  const taskId = task.id != null ? String(task.id) : "";
+  if (!taskId) return null;
+  return createMaintenanceCompatibilityRow({
+    streamId: `legacy-task:${mode}:${taskId}`,
+    sourceSystem: "legacy",
+    taskId,
+    taskName: String(task.name || "").trim(),
+    instanceId: null,
+    occurrenceId: null,
+    dateISO: normalizeDateISO(task.calendarDateISO || task.nextDueISO || task.lastDoneISO || ""),
+    status: "task_definition",
+    instanceMode: mode === "asreq" ? "one_time" : "repeat",
+    note: null,
+    hours: null,
+    categoryRef: task.cat != null ? String(task.cat) : null,
+    inventoryRef: task.inventoryId != null ? String(task.inventoryId) : null,
+    costRef: task.price != null ? Number(task.price) : null,
+    linkRef: task.storeLink != null ? String(task.storeLink) : null,
+    provenance: {
+      taskMode: mode,
+      taskId,
+      sourceField: "tasksInterval/tasksAsReq"
+    }
+  });
+}
+
+function buildMaintenanceCompatibilityStream(){
+  const out = [];
+  const normalizeLegacyEvents = (task, mode)=>{
+    if (!task || typeof task !== "object") return;
+    const taskId = task.id != null ? String(task.id) : "";
+    if (!taskId) return;
+    const taskName = String(task.name || "").trim();
+    const instanceMode = mode === "asreq" ? "one_time" : "repeat";
+    const categoryRef = task.cat != null ? String(task.cat) : null;
+    const inventoryRef = task.inventoryId != null ? String(task.inventoryId) : null;
+    const costRef = task.price != null ? Number(task.price) : null;
+    const linkRef = task.storeLink != null ? String(task.storeLink) : null;
+    const instanceId = task.templateId != null ? String(task.templateId) : null;
+    const variant = task.variant != null ? String(task.variant) : null;
+    const common = { sourceSystem: "legacy", taskId, taskName, instanceMode, categoryRef, inventoryRef, costRef, linkRef, instanceId };
+    const pushEvent = (input)=> out.push(createMaintenanceCompatibilityRow({ ...common, ...input }));
+
+    if (task.calendarDateISO){
+      pushEvent({
+        streamId: `legacy-calendar:${mode}:${taskId}:${task.calendarDateISO}`,
+        status: "scheduled",
+        eventType: "scheduled",
+        dateISO: task.calendarDateISO,
+        provenance: { sourceField: "calendarDateISO", taskMode: mode, taskId, templateId: instanceId, variant }
+      });
+    }
+    (Array.isArray(task.completedDates) ? task.completedDates : []).forEach((date, idx)=>{
+      pushEvent({
+        streamId: `legacy-completed:${mode}:${taskId}:${idx}:${String(date)}`,
+        occurrenceId: `legacy-completed:${taskId}:${String(date)}:${idx}`,
+        status: "completed",
+        eventType: "completed",
+        dateISO: date,
+        provenance: { sourceField: "completedDates", index: idx, taskMode: mode, taskId, templateId: instanceId, variant }
+      });
+    });
+    (Array.isArray(task.manualHistory) ? task.manualHistory : []).forEach((entry, idx)=>{
+      const dateISO = entry && typeof entry === "object" ? (entry.dateISO || entry.date || entry.doneDateISO) : entry;
+      const note = entry && typeof entry === "object" ? (entry.note || entry.notes || null) : null;
+      const hours = entry && typeof entry === "object" ? (entry.hours ?? entry.timeHours ?? null) : null;
+      pushEvent({
+        streamId: `legacy-manual:${mode}:${taskId}:${idx}`,
+        occurrenceId: `legacy-manual:${taskId}:${idx}`,
+        status: "completed",
+        eventType: "manual_history",
+        dateISO,
+        note,
+        hours,
+        provenance: { sourceField: "manualHistory", index: idx, rawId: entry && entry.id != null ? String(entry.id) : null, taskMode: mode, taskId, templateId: instanceId, variant }
+      });
+    });
+    (Array.isArray(task.removedOccurrences) ? task.removedOccurrences : []).forEach((entry, idx)=>{
+      const dateISO = entry && typeof entry === "object" ? (entry.dateISO || entry.date || entry.when) : entry;
+      pushEvent({
+        streamId: `legacy-removed:${mode}:${taskId}:${idx}`,
+        occurrenceId: `legacy-removed:${taskId}:${idx}`,
+        status: "removed",
+        eventType: "removed",
+        dateISO,
+        provenance: { sourceField: "removedOccurrences", index: idx, taskMode: mode, taskId, templateId: instanceId, variant }
+      });
+    });
+    const notesMap = task.occurrenceNotes && typeof task.occurrenceNotes === "object" ? task.occurrenceNotes : {};
+    Object.entries(notesMap).forEach(([dateKey, note])=>{
+      pushEvent({
+        streamId: `legacy-note:${mode}:${taskId}:${dateKey}`,
+        occurrenceId: `legacy-note:${taskId}:${dateKey}`,
+        status: "annotated",
+        eventType: "note",
+        dateISO: dateKey,
+        note,
+        provenance: { sourceField: "occurrenceNotes", key: dateKey, taskMode: mode, taskId, templateId: instanceId, variant }
+      });
+    });
+    const hoursMap = task.occurrenceHours && typeof task.occurrenceHours === "object" ? task.occurrenceHours : {};
+    Object.entries(hoursMap).forEach(([dateKey, hours])=>{
+      pushEvent({
+        streamId: `legacy-hours:${mode}:${taskId}:${dateKey}`,
+        occurrenceId: `legacy-hours:${taskId}:${dateKey}`,
+        status: "annotated",
+        eventType: "hours",
+        dateISO: dateKey,
+        hours,
+        provenance: { sourceField: "occurrenceHours", key: dateKey, taskMode: mode, taskId, templateId: instanceId, variant }
+      });
+    });
+  };
+  const intervalList = Array.isArray(window.tasksInterval) ? window.tasksInterval : [];
+  const asReqList = Array.isArray(window.tasksAsReq) ? window.tasksAsReq : [];
+  intervalList.forEach(task => {
+    const row = normalizeLegacyMaintenanceTask(task, "interval");
+    if (row) out.push(row);
+    normalizeLegacyEvents(task, "interval");
+  });
+  asReqList.forEach(task => {
+    const row = normalizeLegacyMaintenanceTask(task, "asreq");
+    if (row) out.push(row);
+    normalizeLegacyEvents(task, "asreq");
+  });
+
+  const v2Tasks = Array.isArray(window.maintenanceTasksV2) ? window.maintenanceTasksV2 : [];
+  const v2Instances = Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2 : [];
+  const v2Occurrences = Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : [];
+  const taskMap = new Map();
+  v2Tasks.forEach(task => {
+    if (!task || typeof task !== "object") return;
+    const id = task.id != null ? String(task.id) : "";
+    if (!id) return;
+    taskMap.set(id, task);
+  });
+  const instanceMap = new Map();
+  v2Instances.forEach(instance => {
+    if (!instance || typeof instance !== "object") return;
+    const id = instance.id != null ? String(instance.id) : "";
+    if (!id) return;
+    instanceMap.set(id, instance);
+  });
+  v2Occurrences.forEach(event => {
+    if (!event || typeof event !== "object") return;
+    if (detectMaintenanceRecordSystem(event) !== "v2") return;
+    const occurrenceId = event.id != null ? String(event.id) : "";
+    const instanceId = event.instanceId != null ? String(event.instanceId) : "";
+    const inst = instanceMap.get(instanceId) || null;
+    const taskId = event.taskId != null ? String(event.taskId) : (inst && inst.taskId != null ? String(inst.taskId) : "");
+    const task = taskMap.get(taskId) || null;
+    out.push({
+      streamId: `v2-occurrence:${occurrenceId || `${instanceId}:unknown`}`,
+      sourceSystem: "v2",
+      taskId: taskId || null,
+      taskName: String(event.taskName || (task && task.name) || "").trim(),
+      instanceId: instanceId || null,
+      occurrenceId: occurrenceId || null,
+      dateISO: normalizeDateISO(event.effectiveDateISO || event.dateISO || event.completedAtISO || event.occurredAtISO || ""),
+      status: String(event.status || event.eventType || event.type || "unknown"),
+      eventType: event.eventType != null ? String(event.eventType) : (event.type != null ? String(event.type) : null),
+      instanceMode: inst && inst.instanceMode ? String(inst.instanceMode) : null,
+      note: event.note != null ? String(event.note) : (event.payload && event.payload.note != null ? String(event.payload.note) : null),
+      hours: event.hours != null && Number.isFinite(Number(event.hours)) ? Number(event.hours) : (event.payload && Number.isFinite(Number(event.payload.hours)) ? Number(event.payload.hours) : null),
+      categoryRef: task && task.folderId != null ? String(task.folderId) : null,
+      inventoryRef: task && task.inventoryId != null ? String(task.inventoryId) : null,
+      costRef: task && task.costProfileId != null ? String(task.costProfileId) : null,
+      linkRef: task && task.linkRef != null ? String(task.linkRef) : null,
+      provenance: {
+        taskId: taskId || null,
+        instanceId: instanceId || null,
+        occurrenceId: occurrenceId || null,
+        supersedesEventId: event.supersedesEventId != null ? String(event.supersedesEventId) : null,
+        recordedAtISO: event.recordedAtISO != null ? String(event.recordedAtISO) : null,
+        sourceField: "maintenanceOccurrencesV2",
+        taskRecordSystem: task ? detectMaintenanceRecordSystem(task) : null,
+        instanceRecordSystem: inst ? detectMaintenanceRecordSystem(inst) : null,
+        occurrenceRecordSystem: detectMaintenanceRecordSystem(event)
+      }
+    });
+  });
+  return out;
+}
+
+window.detectMaintenanceRecordSystem = detectMaintenanceRecordSystem;
+window.buildMaintenanceCompatibilityStream = buildMaintenanceCompatibilityStream;
 
 function ensureJobCategories(){
   const folders = Array.isArray(window.jobFolders) ? window.jobFolders : defaultJobFolders();
@@ -2852,6 +3102,9 @@ function adoptState(doc){
   opportunityRollups = Array.isArray(data.opportunityRollups) ? data.opportunityRollups : [];
   weeklyCostReports = Array.isArray(data.weeklyCostReports) ? data.weeklyCostReports.map(entry => ({ ...entry })) : [];
   receiptTrackerWeeks = Array.isArray(data.receiptTrackerWeeks) ? data.receiptTrackerWeeks.map(entry => ({ ...entry })) : [];
+  maintenanceTasksV2 = Array.isArray(data.maintenanceTasksV2) ? data.maintenanceTasksV2.map(entry => ({ ...entry })) : [];
+  maintenanceCalendarInstancesV2 = Array.isArray(data.maintenanceCalendarInstancesV2) ? data.maintenanceCalendarInstancesV2.map(entry => ({ ...entry })) : [];
+  maintenanceOccurrencesV2 = Array.isArray(data.maintenanceOccurrencesV2) ? data.maintenanceOccurrencesV2.map(entry => ({ ...entry })) : [];
   window.syncProcessLog = Array.isArray(data.syncProcessLog) ? data.syncProcessLog.map(entry => ({ ...entry })) : (Array.isArray(window.syncProcessLog) ? window.syncProcessLog : []);
 
   window.totalHistory = totalHistory;
@@ -2866,6 +3119,9 @@ function adoptState(doc){
   window.opportunityRollups = opportunityRollups;
   window.weeklyCostReports = weeklyCostReports;
   window.receiptTrackerWeeks = receiptTrackerWeeks;
+  window.maintenanceTasksV2 = maintenanceTasksV2;
+  window.maintenanceCalendarInstancesV2 = maintenanceCalendarInstancesV2;
+  window.maintenanceOccurrencesV2 = maintenanceOccurrencesV2;
   deletedItems = normalizeDeletedItems(Array.isArray(data.deletedItems) ? data.deletedItems : deletedItems);
   window.deletedItems = deletedItems;
   purgeExpiredDeletedItems();
@@ -2879,6 +3135,14 @@ function adoptState(doc){
     window.orderRequestTab = orderRequestTab || "active";
   }
   orderRequestTab = window.orderRequestTab;
+
+  if (window.DEBUG_MODE){
+    console.info("V2 maintenance storage ready", {
+      tasks: Array.isArray(window.maintenanceTasksV2) ? window.maintenanceTasksV2.length : 0,
+      instances: Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2.length : 0,
+      occurrences: Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2.length : 0
+    });
+  }
 
   const rawFolders = Array.isArray(data.settingsFolders)
     ? data.settingsFolders
@@ -3093,7 +3357,7 @@ function recordDataFlowEvent(trigger = "save", nextSnapshot = null){
     if (!Array.isArray(window.syncProcessLog)) window.syncProcessLog = [];
     const prev = window.__lastSnapshotForFlow && typeof window.__lastSnapshotForFlow === "object" ? window.__lastSnapshotForFlow : null;
     const next = nextSnapshot && typeof nextSnapshot === "object" ? nextSnapshot : null;
-    const trackedKeys = ["totalHistory", "tasksInterval", "tasksAsReq", "inventory", "inventoryFolders", "receiptTrackerWeeks", "orderRequests", "cuttingJobs", "completedCuttingJobs", "dailyCutHours", "garnetCleanings", "settingsFolders"];
+    const trackedKeys = ["totalHistory", "tasksInterval", "tasksAsReq", "inventory", "inventoryFolders", "receiptTrackerWeeks", "orderRequests", "cuttingJobs", "completedCuttingJobs", "dailyCutHours", "garnetCleanings", "maintenanceTasksV2", "maintenanceCalendarInstancesV2", "maintenanceOccurrencesV2", "settingsFolders"];
     const skipTrigger = /history|syncprocesslog|data_flow_save/i.test(String(trigger || ""));
     if (skipTrigger){
       if (next) window.__lastSnapshotForFlow = next;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -5301,6 +5301,7 @@ function renderDashboard(){
   const existingTaskEmpty  = taskExistingForm?.querySelector('[data-task-existing-empty]');
   const existingTaskSearchEmpty = taskExistingForm?.querySelector('[data-task-existing-search-empty]');
   const taskExistingNoteInput = document.getElementById("dashTaskExistingNote");
+  const taskExistingAddModeInput = document.getElementById("dashTaskExistingAddMode");
   const taskExistingRepeatInput = document.getElementById("dashTaskExistingRepeat");
   const taskExistingBasisInput = document.getElementById("dashTaskExistingRepeatBasis");
   const taskExistingEveryInput = document.getElementById("dashTaskExistingRepeatEvery");
@@ -5565,6 +5566,7 @@ function renderDashboard(){
   function resetExistingTaskForm(){
     if (taskExistingSearchInput) taskExistingSearchInput.value = "";
     if (taskExistingNoteInput) taskExistingNoteInput.value = "";
+    if (taskExistingAddModeInput) taskExistingAddModeInput.value = "one_time";
     if (taskExistingRepeatInput) taskExistingRepeatInput.value = "no";
     if (taskExistingRepeatInput) taskExistingRepeatInput.disabled = true;
     if (taskExistingBasisInput) taskExistingBasisInput.value = "calendar_day";
@@ -6064,6 +6066,89 @@ function renderDashboard(){
     modal.setAttribute("aria-hidden", "false");
     document.body?.classList.add("modal-open");
     showStep(step);
+  }
+
+  function ensureMaintenanceV2Collections(){
+    if (!Array.isArray(window.maintenanceTasksV2)) window.maintenanceTasksV2 = [];
+    if (!Array.isArray(window.maintenanceCalendarInstancesV2)) window.maintenanceCalendarInstancesV2 = [];
+    if (!Array.isArray(window.maintenanceOccurrencesV2)) window.maintenanceOccurrencesV2 = [];
+    return {
+      tasks: window.maintenanceTasksV2,
+      instances: window.maintenanceCalendarInstancesV2,
+      occurrences: window.maintenanceOccurrencesV2
+    };
+  }
+
+  function createMaintenanceV2FromTemplate(task, opts = {}){
+    if (!task || task.id == null) return null;
+    const collections = ensureMaintenanceV2Collections();
+    const mode = String(opts.mode || "one_time");
+    const eventType = String(opts.eventType || "scheduled");
+    const effectiveDateISO = normalizeDateKey(opts.effectiveDateISO || addContextDateISO || ymd(new Date()));
+    const nowISO = new Date().toISOString();
+    const legacyTaskId = String(task.id);
+    const existingTask = collections.tasks.find(entry => entry && String(entry.legacyTaskId || "") === legacyTaskId) || null;
+    const taskRecord = existingTask || {
+      id: genId("maintenance_task_v2"),
+      system: "v2",
+      schemaVersion: 2,
+      legacyTaskId,
+      name: task.name || "Maintenance task",
+      categoryRef: task.cat != null ? String(task.cat) : null,
+      inventoryId: task.inventoryId != null ? String(task.inventoryId) : null,
+      storeLink: task.storeLink || "",
+      manualLink: task.manualLink || "",
+      pn: task.pn || "",
+      price: task.price != null ? Number(task.price) : null,
+      createdAtISO: nowISO,
+      updatedAtISO: nowISO
+    };
+    if (!existingTask){
+      collections.tasks.unshift(taskRecord);
+    }else{
+      taskRecord.updatedAtISO = nowISO;
+    }
+    const instance = {
+      id: genId("maintenance_instance_v2"),
+      system: "v2",
+      schemaVersion: 2,
+      taskId: taskRecord.id,
+      legacyTaskId,
+      instanceMode: mode,
+      startDateISO: effectiveDateISO,
+      status: "active",
+      repeatRule: mode === "repeat" ? (opts.repeatRule || null) : null,
+      createdAtISO: nowISO,
+      updatedAtISO: nowISO
+    };
+    collections.instances.unshift(instance);
+    const occurrence = {
+      id: genId("maintenance_occurrence_v2"),
+      system: "v2",
+      schemaVersion: 2,
+      instanceId: instance.id,
+      taskId: taskRecord.id,
+      legacyTaskId,
+      eventType,
+      effectiveDateISO,
+      recordedAtISO: nowISO,
+      payload: {
+        note: opts.note || "",
+        hours: Number.isFinite(Number(opts.hours)) ? Number(opts.hours) : null
+      }
+    };
+    collections.occurrences.unshift(occurrence);
+    if (window.DEBUG_MODE){
+      console.info("[maintenance-v2] created records", {
+        legacyTaskId,
+        taskId: taskRecord.id,
+        instanceId: instance.id,
+        occurrenceId: occurrence.id,
+        instanceMode: mode,
+        eventType
+      });
+    }
+    return { taskRecord, instance, occurrence };
   }
 
   function hideBackdrop(){
@@ -6604,36 +6689,45 @@ function renderDashboard(){
       endCountInput: taskExistingEndCountInput,
       defaultBasis: task.mode === "interval" ? "machine_hours" : "calendar_day"
     });
+    let choice = String(taskExistingAddModeInput?.value || "").trim();
+    if (!choice){
+      const choiceRaw = window.prompt(
+        "Temporary chooser fallback:\n1) One-time reminder\n2) Start repeat tracking\n3) Log past completion",
+        "1"
+      );
+      const mapped = { "1": "one_time", "2": "repeat", "3": "past_log" };
+      choice = mapped[String(choiceRaw || "").trim()] || "";
+    }
+    if (!choice || !["one_time", "repeat", "past_log"].includes(choice)){
+      toast("Add to calendar cancelled");
+      return;
+    }
     let message = "Maintenance task added";
-    if (task.mode === "interval"){
-      const instance = scheduleExistingIntervalTask(task, {
-        dateISO: targetISO,
+    if (choice === "one_time"){
+      createMaintenanceV2FromTemplate(task, {
+        mode: "one_time",
+        eventType: "scheduled",
+        effectiveDateISO: targetISO,
+        note: occurrenceNote
+      });
+      message = `One-time reminder created for "${task.name || "Task"}"`;
+    }else if (choice === "repeat"){
+      createMaintenanceV2FromTemplate(task, {
+        mode: "repeat",
+        eventType: "repeat_started",
+        effectiveDateISO: targetISO,
         note: occurrenceNote,
-        refreshDashboard: true,
-        recurrence: repeatConfig
-      }) || task;
-      const parsed = parseDateLocal(targetISO);
-      const todayMidnight = new Date(); todayMidnight.setHours(0,0,0,0);
-      let dateLabel = targetISO;
-      let completed = false;
-      if (parsed instanceof Date && !Number.isNaN(parsed.getTime())){
-        const display = new Date(parsed.getTime());
-        dateLabel = display.toLocaleDateString();
-        const compare = new Date(parsed.getTime());
-        compare.setHours(0,0,0,0);
-        completed = compare.getTime() <= todayMidnight.getTime();
-      }
-      message = completed
-        ? `Logged "${instance.name || "Task"}" as completed on ${dateLabel}`
-        : `Scheduled "${instance.name || "Task"}" for ${dateLabel}`;
+        repeatRule: repeatConfig.enabled ? repeatConfig : null
+      });
+      message = `Repeat tracking started for "${task.name || "Task"}"`;
     }else{
-      const instance = scheduleExistingAsReqTask(task, {
-        dateISO: targetISO,
-        note: occurrenceNote,
-        refreshDashboard: true,
-        recurrence: repeatConfig
-      }) || task;
-      message = "As-required task linked from Maintenance Settings";
+      createMaintenanceV2FromTemplate(task, {
+        mode: "past_log",
+        eventType: "completed",
+        effectiveDateISO: targetISO,
+        note: occurrenceNote
+      });
+      message = `Past completion logged for "${task.name || "Task"}"`;
     }
     setContextDate(targetISO);
     if (typeof saveCloudNow === "function") saveCloudNow();

--- a/js/views.js
+++ b/js/views.js
@@ -364,6 +364,12 @@ function viewDashboard(){
           <p class="small muted" data-task-existing-empty hidden>No maintenance tasks yet. Create one below to get started.</p>
           <p class="small muted" data-task-existing-search-empty hidden>No tasks match your search. Try a different name.</p>
           <label>Occurrence note<textarea id="dashTaskExistingNote" rows="3" placeholder="Optional note for this calendar date"></textarea></label>
+          <label>Add mode<select id="dashTaskExistingAddMode">
+            <option value="one_time">One-time reminder</option>
+            <option value="repeat">Start repeat tracking</option>
+            <option value="past_log">Log past completion</option>
+          </select></label>
+          <p class="small muted">This creates V2 planning records only for now. Legacy calendar behavior remains unchanged until V2 rendering/actions are enabled.</p>
           <label>Repeat<select id="dashTaskExistingRepeat">
             <option value="no">Does not repeat</option>
             <option value="yes">Repeats</option>


### PR DESCRIPTION
### Motivation
- Introduce a non-destructive V2 maintenance model that can coexist with legacy `tasksInterval`/`tasksAsReq` storage and avoid any bulk migration or silent conversions. 
- Provide an append-oriented event/occurrence model and a read-side compatibility adapter so calendar/reporting can consume a unified stream from both legacy and V2 records. 
- Add UI affordances to create V2 records from existing maintenance templates so the new model can be exercised incrementally. 

### Description
- Added a design document `docs/maintenance-compat-audit.md` describing the Hybrid V2 model, relationship rules, adapter contract, and rollout guidance. 
- Initialized new in-memory collections and module-level bindings for `maintenanceTasksV2`, `maintenanceCalendarInstancesV2`, and `maintenanceOccurrencesV2` and wired them into `snapshotState`, `adoptState`, `refreshGlobalCollections`, `snapshotState` output and the cloud/state change tracking via `stateHasMeaningfulData` and `recordDataFlowEvent`. 
- Implemented compatibility/read-adapter helpers in `js/core.js`: `detectMaintenanceRecordSystem`, `createMaintenanceCompatibilityRow`, `normalizeLegacyMaintenanceTask`, and `buildMaintenanceCompatibilityStream`, and exposed them on `window` for diagnostics/consumption. 
- Added V2 creation helpers in `js/renderers.js`: `ensureMaintenanceV2Collections` and `createMaintenanceV2FromTemplate`, and wired form handling to create one-time, repeat-start, or past-log V2 records when adding an existing maintenance task to the calendar, including a fallback prompt when UI input is unavailable. 
- Updated UI in `js/views.js` to add an `Add mode` select (`dashTaskExistingAddMode`) and explanatory text to the existing-task modal so users can choose `one_time`, `repeat`, or `past_log` actions that generate V2 records. 
- Included debug logging when adopting state and when creating V2 records to assist rollout diagnostics. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcba07af2083259f7b70eec4b91854)