### PR TITLE
Hotfix: scope previewReadonly guard to Vercel previews to restore cloud saves

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -2368,7 +2368,7 @@ function renderCalendar(){
   });
 
   const jobsMap = {};
-  const activeJobs = Array.isArray(window.cuttingJobs) ? window.cuttingJobs : (Array.isArray(cuttingJobs) ? cuttingJobs : []);
+  const activeJobs = Array.isArray(window.cuttingJobs) ? window.cuttingJobs : ((typeof cuttingJobs !== "undefined" && Array.isArray(cuttingJobs)) ? cuttingJobs : []);
   activeJobs.forEach(j => {
     const start = parseDateLocal(j.startISO);
     const end   = parseDateLocal(j.dueISO);

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -2368,7 +2368,8 @@ function renderCalendar(){
   });
 
   const jobsMap = {};
-  cuttingJobs.forEach(j => {
+  const activeJobs = Array.isArray(window.cuttingJobs) ? window.cuttingJobs : (Array.isArray(cuttingJobs) ? cuttingJobs : []);
+  activeJobs.forEach(j => {
     const start = parseDateLocal(j.startISO);
     const end   = parseDateLocal(j.dueISO);
     if (!start || !end) return;

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1360,7 +1360,7 @@ function showJobBubble(jobId, anchor){
   };
   try{
     const active = cuttingJobs.find(x => String(x.id) === String(jobId));
-    const completedJobs = Array.isArray(window.completedCuttingJobs) ? window.completedCuttingJobs : [];
+    const completedJobs = normalizeJobList(window.completedCuttingJobs);
     const completed = completedJobs.find(x => String(x?.id) === String(jobId));
     const prioritySchedule = typeof computePrioritySchedule === "function"
       ? computePrioritySchedule(cuttingJobs)
@@ -2378,7 +2378,16 @@ function renderCalendar(){
   });
 
   const jobsMap = {};
-  const activeJobs = Array.isArray(window.cuttingJobs) ? window.cuttingJobs : ((typeof cuttingJobs !== "undefined" && Array.isArray(cuttingJobs)) ? cuttingJobs : []);
+  const normalizeJobList = (source)=>{
+    if (Array.isArray(source)) return source.filter(Boolean);
+    if (source && typeof source === "object") return Object.values(source).filter(Boolean);
+    return [];
+  };
+  const activeJobs = normalizeJobList(
+    Array.isArray(window.cuttingJobs) || (window.cuttingJobs && typeof window.cuttingJobs === "object")
+      ? window.cuttingJobs
+      : ((typeof cuttingJobs !== "undefined") ? cuttingJobs : [])
+  );
   activeJobs.forEach(j => {
     const start = parseDateLocal(j.startISO || j.startDate || j.start);
     const end = parseDateLocal(j.dueISO || j.dueDate || j.endISO || j.completedAtISO);
@@ -2395,7 +2404,7 @@ function renderCalendar(){
     }
   });
 
-  const completedJobs = Array.isArray(window.completedCuttingJobs) ? window.completedCuttingJobs : [];
+  const completedJobs = normalizeJobList(window.completedCuttingJobs);
   completedJobs.forEach(job => {
     if (!job) return;
     const start = parseDateLocal(job.startISO || job.startDate || job.start);

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -2385,6 +2385,21 @@ function renderCalendar(){
   const completedJobs = Array.isArray(window.completedCuttingJobs) ? window.completedCuttingJobs : [];
   completedJobs.forEach(job => {
     if (!job) return;
+    const start = parseDateLocal(job.startISO);
+    const end = parseDateLocal(job.dueISO || job.completedAtISO);
+    if (start && end){
+      start.setHours(0,0,0,0);
+      end.setHours(0,0,0,0);
+      const from = start.getTime() <= end.getTime() ? start : end;
+      const to = start.getTime() <= end.getTime() ? end : start;
+      const cur = new Date(from.getTime());
+      while (cur <= to){
+        const key = ymd(cur);
+        (jobsMap[key] ||= []).push({ type:"job", id:String(job.id), name:job.name, status:"completed", cat:job.cat });
+        cur.setDate(cur.getDate()+1);
+      }
+      return;
+    }
     const completionKey = job.completedAtISO ? ymd(job.completedAtISO) : (job.dueISO ? ymd(job.dueISO) : null);
     if (!completionKey) return;
     (jobsMap[completionKey] ||= []).push({ type:"job", id:String(job.id), name:job.name, status:"completed", cat:job.cat });

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -13,6 +13,12 @@ function rerenderCalendarKeepScroll(){
   }
 }
 
+function normalizeJobList(source){
+  if (Array.isArray(source)) return source.filter(Boolean);
+  if (source && typeof source === "object") return Object.values(source).filter(Boolean);
+  return [];
+}
+
 if (typeof window !== "undefined"){
   if (typeof window.__calendarShowAllMonths !== "boolean"){
     window.__calendarShowAllMonths = true;
@@ -2378,11 +2384,6 @@ function renderCalendar(){
   });
 
   const jobsMap = {};
-  const normalizeJobList = (source)=>{
-    if (Array.isArray(source)) return source.filter(Boolean);
-    if (source && typeof source === "object") return Object.values(source).filter(Boolean);
-    return [];
-  };
   const activeJobs = normalizeJobList(
     Array.isArray(window.cuttingJobs) || (window.cuttingJobs && typeof window.cuttingJobs === "object")
       ? window.cuttingJobs

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -2388,9 +2388,19 @@ function renderCalendar(){
       ? window.cuttingJobs
       : ((typeof cuttingJobs !== "undefined") ? cuttingJobs : [])
   );
+  const resolveJobRange = (job)=>{
+    if (!job || typeof job !== "object") return { start:null, end:null };
+    const startCandidate = job.startISO ?? job.startDate ?? job.start ?? job.startAtISO ?? job.start_at ?? job.createdAt ?? null;
+    const endCandidate = job.dueISO ?? job.dueDate ?? job.endISO ?? job.endDate ?? job.end ?? job.completedAtISO ?? job.completedAt ?? null;
+    const start = parseDateLocal(startCandidate);
+    const end = parseDateLocal(endCandidate);
+    if (start && end) return { start, end };
+    if (start && !end) return { start, end: new Date(start.getTime()) };
+    if (!start && end) return { start: new Date(end.getTime()), end };
+    return { start:null, end:null };
+  };
   activeJobs.forEach(j => {
-    const start = parseDateLocal(j.startISO || j.startDate || j.start);
-    const end = parseDateLocal(j.dueISO || j.dueDate || j.endISO || j.completedAtISO);
+    const { start, end } = resolveJobRange(j);
     if (!start || !end) return;
     start.setHours(0,0,0,0);
     end.setHours(0,0,0,0);
@@ -2407,8 +2417,7 @@ function renderCalendar(){
   const completedJobs = normalizeJobList(window.completedCuttingJobs);
   completedJobs.forEach(job => {
     if (!job) return;
-    const start = parseDateLocal(job.startISO || job.startDate || job.start);
-    const end = parseDateLocal(job.dueISO || job.dueDate || job.endISO || job.completedAtISO);
+    const { start, end } = resolveJobRange(job);
     if (start && end){
       start.setHours(0,0,0,0);
       end.setHours(0,0,0,0);

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1109,7 +1109,7 @@ function completeTask(taskId){
     if (typeof saveCloudNow === "function") saveCloudNow();
     else saveCloudDebounced();
     toast("Task completed");
-    route();
+    rerenderCalendarKeepScroll();
   }
 }
 
@@ -1231,7 +1231,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast((Number.isFinite(parsed) && parsed > 0) ? "Occurrence time saved" : "Occurrence time removed");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1246,7 +1246,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast((next || "").trim() ? "Occurrence note saved" : "Occurrence note removed");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1257,7 +1257,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast("Task marked complete");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1268,7 +1268,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast("Completion removed");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1291,7 +1291,7 @@ function showTaskBubble(taskId, anchor, options = {}){
           : "Removed from calendar";
       toast(toastMessage);
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   };
   b.querySelector("[data-bbl-remove-single]")?.addEventListener("click", ()=> runRemoveScope("single"));
@@ -1318,7 +1318,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast("Task removed");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -2380,8 +2380,8 @@ function renderCalendar(){
   const jobsMap = {};
   const activeJobs = Array.isArray(window.cuttingJobs) ? window.cuttingJobs : ((typeof cuttingJobs !== "undefined" && Array.isArray(cuttingJobs)) ? cuttingJobs : []);
   activeJobs.forEach(j => {
-    const start = parseDateLocal(j.startISO);
-    const end = parseDateLocal(j.dueISO || j.completedAtISO);
+    const start = parseDateLocal(j.startISO || j.startDate || j.start);
+    const end = parseDateLocal(j.dueISO || j.dueDate || j.endISO || j.completedAtISO);
     if (!start || !end) return;
     start.setHours(0,0,0,0);
     end.setHours(0,0,0,0);
@@ -2398,8 +2398,8 @@ function renderCalendar(){
   const completedJobs = Array.isArray(window.completedCuttingJobs) ? window.completedCuttingJobs : [];
   completedJobs.forEach(job => {
     if (!job) return;
-    const start = parseDateLocal(job.startISO);
-    const end = parseDateLocal(job.dueISO || job.completedAtISO);
+    const start = parseDateLocal(job.startISO || job.startDate || job.start);
+    const end = parseDateLocal(job.dueISO || job.dueDate || job.endISO || job.completedAtISO);
     if (start && end){
       start.setHours(0,0,0,0);
       end.setHours(0,0,0,0);

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -3,6 +3,16 @@ let bubbleTimer = null;
 const CALENDAR_DAY_MS = 24 * 60 * 60 * 1000;
 let calendarHoursEditing = false;
 let calendarHoursPending = new Map();
+function rerenderCalendarKeepScroll(){
+  if (typeof renderCalendar !== "function") return;
+  const scrollX = typeof window !== "undefined" ? window.scrollX : 0;
+  const scrollY = typeof window !== "undefined" ? window.scrollY : 0;
+  renderCalendar();
+  if (typeof window !== "undefined" && typeof window.scrollTo === "function"){
+    window.scrollTo(scrollX, scrollY);
+  }
+}
+
 if (typeof window !== "undefined"){
   if (typeof window.__calendarShowAllMonths !== "boolean"){
     window.__calendarShowAllMonths = true;
@@ -79,7 +89,7 @@ function startCalendarHoursEditing(){
   if (calendarHoursEditing) return false;
   calendarHoursEditing = true;
   calendarHoursPending = new Map();
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof updateCalendarHoursControls === "function") updateCalendarHoursControls();
   return true;
 }
@@ -88,7 +98,7 @@ function cancelCalendarHoursEditing(){
   if (!calendarHoursEditing) return false;
   calendarHoursEditing = false;
   calendarHoursPending = new Map();
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof updateCalendarHoursControls === "function") updateCalendarHoursControls();
   return true;
 }
@@ -110,7 +120,7 @@ function commitCalendarHoursEditing(){
   calendarHoursPending = new Map();
   calendarHoursEditing = false;
   if (changed && typeof saveCloudDebounced === "function") saveCloudDebounced();
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof updateCalendarHoursControls === "function") updateCalendarHoursControls();
   if (changed){
     if (typeof refreshDerivedDailyHours === "function") refreshDerivedDailyHours();
@@ -149,7 +159,7 @@ function promptCalendarDayHours(dateISO){
   }
   const updated = setCalendarPendingHours(key, next);
   if (updated){
-    renderCalendar();
+    rerenderCalendarKeepScroll();
   }
   return updated;
 }
@@ -1534,7 +1544,7 @@ function showJobBubble(jobId, anchor){
       saveCloudDebounced();
       toast("Job marked complete");
       hideBubble();
-      renderCalendar();
+      rerenderCalendarKeepScroll();
       if (typeof window.location === "object" && window.location.hash === "#/jobs" && typeof renderJobs === "function"){
         renderJobs();
       }
@@ -1563,7 +1573,7 @@ function toggleGarnetComplete(id){
   entry.completed = !entry.completed;
   saveCloudDebounced();
   toast(entry.completed ? "Garnet cleaning completed" : "Marked as scheduled");
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof window.__dashRefreshGarnetList === "function") window.__dashRefreshGarnetList();
 }
 
@@ -1579,7 +1589,7 @@ function removeGarnetEntry(id){
   entries.splice(idx,1);
   saveCloudDebounced();
   toast("Garnet cleaning removed");
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof window.__dashRefreshGarnetList === "function") window.__dashRefreshGarnetList();
 }
 
@@ -2371,11 +2381,14 @@ function renderCalendar(){
   const activeJobs = Array.isArray(window.cuttingJobs) ? window.cuttingJobs : ((typeof cuttingJobs !== "undefined" && Array.isArray(cuttingJobs)) ? cuttingJobs : []);
   activeJobs.forEach(j => {
     const start = parseDateLocal(j.startISO);
-    const end   = parseDateLocal(j.dueISO);
+    const end = parseDateLocal(j.dueISO || j.completedAtISO);
     if (!start || !end) return;
-    start.setHours(0,0,0,0); end.setHours(0,0,0,0);
-    const cur = new Date(start.getTime());
-    while (cur <= end){
+    start.setHours(0,0,0,0);
+    end.setHours(0,0,0,0);
+    const from = start.getTime() <= end.getTime() ? start : end;
+    const to = start.getTime() <= end.getTime() ? end : start;
+    const cur = new Date(from.getTime());
+    while (cur <= to){
       const key = ymd(cur);
       (jobsMap[key] ||= []).push({ type:"job", id:String(j.id), name:j.name, status:"active", cat:j.cat });
       cur.setDate(cur.getDate()+1);
@@ -2691,19 +2704,19 @@ function shiftCalendarMonthOffset(delta){
   const next = Math.min(12, Math.max(-12, Math.round(current + delta)));
   if (next === current) return false;
   window.__calendarMonthOffset = next;
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   return true;
 }
 
 function resetCalendarMonthOffset(){
   if ((Number(window.__calendarMonthOffset) || 0) === 0) return false;
   window.__calendarMonthOffset = 0;
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   return true;
 }
 
 function toggleCalendarShowAllMonths(){
   const next = !Boolean(window.__calendarShowAllMonths);
   window.__calendarShowAllMonths = next;
-  renderCalendar();
+  rerenderCalendarKeepScroll();
 }

--- a/js/core.js
+++ b/js/core.js
@@ -28,7 +28,11 @@ const WORKSPACE_ID = (() => {
 function isVercelPreviewRuntime(){
   if (typeof window === "undefined" || !window.location) return false;
   const params = new URLSearchParams(window.location.search || "");
-  return params.get("previewReadonly") === "1";
+  const readonlyFlag = params.get("previewReadonly") === "1";
+  if (!readonlyFlag) return false;
+  const host = String(window.location.hostname || "").toLowerCase();
+  const isVercelHost = host.endsWith(".vercel.app") || host === "vercel.app";
+  return isVercelHost;
 }
 
 if (typeof window !== "undefined") {
@@ -3263,7 +3267,10 @@ function getTrackedStateSignature(snapshot){
   return stableStringify(normalized);
 }
 function saveCloudDebounced(){
-  if (isVercelPreviewRuntime()) return;
+  if (isVercelPreviewRuntime()){
+    console.warn("Cloud save skipped: previewReadonly=1 on a Vercel preview host.");
+    return;
+  }
   hasPendingLocalChanges = true;
   lastLocalMutationAt = Date.now();
   try {
@@ -3279,7 +3286,10 @@ function saveCloudDebounced(){
   saveCloudInternal();
 }
 function saveCloudNow(){
-  if (isVercelPreviewRuntime()) return;
+  if (isVercelPreviewRuntime()){
+    console.warn("Cloud save skipped: previewReadonly=1 on a Vercel preview host.");
+    return;
+  }
   hasPendingLocalChanges = true;
   lastLocalMutationAt = Date.now();
   try {

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -6570,6 +6570,7 @@ function renderDashboard(){
     const list = Array.isArray(window.tasksAsReq) ? window.tasksAsReq : (window.tasksAsReq = []);
     list.unshift(task);
     setContextDate(targetISO);
+    if (typeof renderCalendar === "function") renderCalendar();
     if (typeof saveCloudNow === "function") saveCloudNow();
     else saveCloudDebounced();
     toast("One-time task added to the calendar");
@@ -6638,6 +6639,7 @@ function renderDashboard(){
       message = "As-required task linked from Maintenance Settings";
     }
     setContextDate(targetISO);
+    if (typeof renderCalendar === "function") renderCalendar();
     if (typeof saveCloudNow === "function") saveCloudNow();
     else saveCloudDebounced();
     toast(message);

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -898,6 +898,16 @@ if (typeof window !== "undefined"){
   window.recurrenceSummaryLabel = recurrenceSummaryLabel;
 }
 
+function renderCalendarPreservingScroll(){
+  if (typeof renderCalendar !== "function") return;
+  const scrollX = typeof window !== "undefined" ? window.scrollX : 0;
+  const scrollY = typeof window !== "undefined" ? window.scrollY : 0;
+  renderCalendar();
+  if (typeof window !== "undefined" && typeof window.scrollTo === "function"){
+    window.scrollTo(scrollX, scrollY);
+  }
+}
+
 function editingCompletedJobsSet(){
   if (typeof getEditingCompletedJobsSet === "function"){
     return getEditingCompletedJobsSet();
@@ -3009,7 +3019,7 @@ function applyConfigurationForm(){
   }
   if (typeof saveCloudDebounced === "function") saveCloudDebounced();
   if (typeof refreshTimeEfficiencyWidgets === "function") refreshTimeEfficiencyWidgets();
-  if (typeof renderCalendar === "function") renderCalendar();
+  renderCalendarPreservingScroll();
   if (typeof renderDashboard === "function") renderDashboard();
   if (typeof renderJobs === "function") renderJobs();
   if (typeof renderCosts === "function") renderCosts();
@@ -5208,7 +5218,7 @@ function renderDashboard(){
       if (location.hash !== "#/"){
         location.hash = "#/";
       }
-      if (typeof renderCalendar === "function") renderCalendar();
+      renderCalendarPreservingScroll();
       const months = document.getElementById("months");
       const cell = dueISO ? months?.querySelector(`[data-date-iso="${dueISO}"]`) : null;
       if (cell){
@@ -6533,7 +6543,7 @@ function renderDashboard(){
     if (typeof refreshDashboardWidgets === "function"){
       refreshDashboardWidgets({ full: true });
     }
-    if (typeof renderCalendar === "function") renderCalendar();
+    renderCalendarPreservingScroll();
     const hash = (location.hash || "#").toLowerCase();
     if (hash.startsWith("#/costs")){
       renderCosts();
@@ -6570,7 +6580,7 @@ function renderDashboard(){
     const list = Array.isArray(window.tasksAsReq) ? window.tasksAsReq : (window.tasksAsReq = []);
     list.unshift(task);
     setContextDate(targetISO);
-    if (typeof renderCalendar === "function") renderCalendar();
+    renderCalendarPreservingScroll();
     if (typeof saveCloudNow === "function") saveCloudNow();
     else saveCloudDebounced();
     toast("One-time task added to the calendar");
@@ -6578,7 +6588,7 @@ function renderDashboard(){
     if (typeof refreshDashboardWidgets === "function"){
       refreshDashboardWidgets({ full: true });
     }
-    if (typeof renderCalendar === "function") renderCalendar();
+    renderCalendarPreservingScroll();
     const hash = (location.hash || "#").toLowerCase();
     if (hash.startsWith("#/costs")){
       renderCosts();
@@ -6639,7 +6649,7 @@ function renderDashboard(){
       message = "As-required task linked from Maintenance Settings";
     }
     setContextDate(targetISO);
-    if (typeof renderCalendar === "function") renderCalendar();
+    renderCalendarPreservingScroll();
     if (typeof saveCloudNow === "function") saveCloudNow();
     else saveCloudDebounced();
     toast(message);
@@ -6647,7 +6657,7 @@ function renderDashboard(){
     if (typeof refreshDashboardWidgets === "function"){
       refreshDashboardWidgets({ full: true });
     }
-    if (typeof renderCalendar === "function") renderCalendar();
+    renderCalendarPreservingScroll();
     const hash = (location.hash || "#").toLowerCase();
     if (hash.startsWith("#/costs")){
       renderCosts();
@@ -6746,7 +6756,7 @@ function renderDashboard(){
     updateDashJobCategoryHint();
     window.jobCategoryFilter = previousCategoryFilter;
     saveCloudDebounced();
-    if (typeof renderCalendar === "function") renderCalendar();
+    renderCalendarPreservingScroll();
     toast("Cutting job added");
     closeModal();
     renderDashboard();
@@ -10092,7 +10102,7 @@ function renderSettings(){
       updateTaskFieldRelevance(holder);
       if (typeof refreshDashboardWidgets === "function") refreshDashboardWidgets({ full: true });
       persist();
-      if (typeof renderCalendar === "function") renderCalendar();
+      renderCalendarPreservingScroll();
       return;
     }
     if (selectKey === "mode"){
@@ -11110,7 +11120,7 @@ function renderCosts(){
     if (typeof hideBubble === "function") hideBubble();
     location.hash = "#/";
     const runFocus = ()=>{
-      if (typeof renderCalendar === "function") renderCalendar();
+      renderCalendarPreservingScroll();
       const months = document.getElementById("months");
       const cell = dueISO ? months?.querySelector(`[data-date-iso="${dueISO}"]`) : null;
       if (!cell) return false;
@@ -11145,7 +11155,7 @@ function renderCosts(){
     if (typeof hideBubble === "function") hideBubble();
     location.hash = "#/";
     const runFocus = ()=>{
-      if (typeof renderCalendar === "function") renderCalendar();
+      renderCalendarPreservingScroll();
       const months = document.getElementById("months");
       const cell = dueISO ? months?.querySelector(`[data-date-iso="${dueISO}"]`) : null;
       if (!cell) return false;
@@ -19862,7 +19872,7 @@ function renderJobs(){
     window.jobAddDraft = {};
     window.jobCategoryFilter = previousCategoryFilter;
     persistJobChanges();
-    if (typeof renderCalendar === "function") renderCalendar();
+    renderCalendarPreservingScroll();
     renderJobs();
   });
 
@@ -20192,7 +20202,7 @@ function renderJobs(){
       reorderPriorities(newJob.id, newJob.priority);
       window.cuttingJobs = cuttingJobs;
       saveCloudDebounced();
-      if (typeof renderCalendar === "function") renderCalendar();
+      renderCalendarPreservingScroll();
       toast("Active cutting job created");
       renderJobs();
       return;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -6741,6 +6741,7 @@ function renderDashboard(){
     updateDashJobCategoryHint();
     window.jobCategoryFilter = previousCategoryFilter;
     saveCloudDebounced();
+    if (typeof renderCalendar === "function") renderCalendar();
     toast("Cutting job added");
     closeModal();
     renderDashboard();
@@ -19856,6 +19857,7 @@ function renderJobs(){
     window.jobAddDraft = {};
     window.jobCategoryFilter = previousCategoryFilter;
     persistJobChanges();
+    if (typeof renderCalendar === "function") renderCalendar();
     renderJobs();
   });
 
@@ -20185,6 +20187,7 @@ function renderJobs(){
       reorderPriorities(newJob.id, newJob.priority);
       window.cuttingJobs = cuttingJobs;
       saveCloudDebounced();
+      if (typeof renderCalendar === "function") renderCalendar();
       toast("Active cutting job created");
       renderJobs();
       return;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -6533,6 +6533,7 @@ function renderDashboard(){
     if (typeof refreshDashboardWidgets === "function"){
       refreshDashboardWidgets({ full: true });
     }
+    if (typeof renderCalendar === "function") renderCalendar();
     const hash = (location.hash || "#").toLowerCase();
     if (hash.startsWith("#/costs")){
       renderCosts();
@@ -6576,6 +6577,7 @@ function renderDashboard(){
     if (typeof refreshDashboardWidgets === "function"){
       refreshDashboardWidgets({ full: true });
     }
+    if (typeof renderCalendar === "function") renderCalendar();
     const hash = (location.hash || "#").toLowerCase();
     if (hash.startsWith("#/costs")){
       renderCosts();
@@ -6643,6 +6645,7 @@ function renderDashboard(){
     if (typeof refreshDashboardWidgets === "function"){
       refreshDashboardWidgets({ full: true });
     }
+    if (typeof renderCalendar === "function") renderCalendar();
     const hash = (location.hash || "#").toLowerCase();
     if (hash.startsWith("#/costs")){
       renderCosts();


### PR DESCRIPTION
### Motivation
- Cloud writes were unintentionally blocked whenever the `previewReadonly=1` query parameter was present, causing UI/local changes to disappear after a refresh. 
- The goal is to restore save persistence on the live/main site without changing data models, paths, or existing Firebase data. 
- Keep the fix minimal and add a non-silent diagnostic when saves are intentionally skipped.

### Description
- Tighten `isVercelPreviewRuntime()` so it returns true only when `previewReadonly=1` is present and the host is a Vercel preview host (`*.vercel.app` or `vercel.app`).
- Add explicit `console.warn` messages in `saveCloudDebounced()` and `saveCloudNow()` when a save is skipped due to preview-readonly mode so the behavior is visible in the console. 
- No Firebase collection/document paths, schema, or migration logic were changed; writes continue to target `workspaces/<WORKSPACE_ID>/app/state` with `WORKSPACE_ID = "github-prod"`.
- Only `js/core.js` was modified and the change is scoped to the save-guard logic.

### Testing
- Ran `node --check js/core.js` to validate syntax and it completed successfully. 
- Inspected the diff and run `git` operations to create the hotfix branch `hotfix/save-persistence-live` and commit the change. 
- Verified by code review that the save guard now only blocks on Vercel preview hosts and that save paths remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0487c79530832583b6cb15553f4dfc)