### PR TITLE
Introduce Maintenance V2 model, compatibility stream, and calendar UI integration

### DIFF
--- a/docs/maintenance-compat-audit.md
+++ b/docs/maintenance-compat-audit.md
@@ -1,0 +1,180 @@
+# Maintenance Calendar Evolution Design (No Migration, Legacy Safe)
+
+## Fixed Constraints (must remain true)
+1. Existing Firebase records in `tasksInterval` and `tasksAsReq` are **legacy source-of-truth** for existing tasks.
+2. Legacy records must keep current mutation/write paths for completion, uncompletion, remove/skip, notes, hours, reporting, and Data Center rows.
+3. No bulk migration, no silent conversion, no rename/replace of legacy structures.
+4. New model applies only to newly created maintenance calendar records unless a user explicitly upgrades a specific legacy item.
+
+## Plain-English Domain Model
+- **Maintenance Settings Task** = reusable definition (“what this task is”).
+- **Calendar Instance** = user’s scheduling intent (“how this task behaves on calendar this time”).
+- **Occurrence/Event Record** = actual action or outcome on a date (“what happened”).
+
+## Option Comparison
+
+### Option 1: Versioned payload on each new maintenance task/calendar item
+**Shape:** Add `modelVersion: 2` and nested `calendarInstances` / `occurrences` directly under task records.
+
+**Pros**
+- Fewer top-level collections.
+- Easy task-centric reads.
+
+**Cons/Risks**
+- High collision risk with current task mutation functions that assume legacy fields on task object.
+- Harder to guarantee old/new write-path isolation.
+- Increased chance of accidental writes from legacy handlers.
+
+### Option 2: Sibling collections in state (recommended base)
+**Shape:** Keep legacy lists untouched; add separate top-level arrays/maps for new system.
+
+**Pros**
+- Strong blast-radius isolation from legacy code.
+- Clean separation of write paths.
+- Easier phased rollout and feature flagging.
+
+**Cons**
+- Requires adapter to join data at read time.
+- More moving parts initially.
+
+### Option 3: Hybrid (recommended overall)
+**Shape:**
+- New task definitions in their own collection.
+- New calendar instances + occurrence log in sibling collections.
+- Optional lightweight marker on related UI objects only (not mutating legacy records).
+
+**Pros**
+- Best balance of isolation and future extensibility.
+- Supports event-sourcing style history without touching legacy fields.
+- Clean path to unified reporting adapter.
+
+**Cons**
+- Slightly more conceptual complexity than Option 2 alone.
+
+## Recommended Conceptual Data Model (New Records Only)
+
+### A) `maintenanceTasksV2` (home base definitions)
+Each entry represents a reusable maintenance task definition.
+- `id`
+- `system`: `"v2"`
+- `name`
+- `taskType`: `"per_interval" | "as_required" | "downtime" | ...`
+- `intervalHours` (optional metadata, not forced behavior)
+- `defaultDurationHours` (optional)
+- `price`, `pn`, links, category, etc.
+- `createdAtISO`, `updatedAtISO`, `archivedAtISO?`
+
+### B) `maintenanceCalendarInstancesV2` (scheduling intent)
+Each entry represents one calendar usage of a task.
+- `id`
+- `system`: `"v2"`
+- `taskId` (FK to `maintenanceTasksV2.id`)
+- `instanceMode`: `"one_time" | "repeat" | "past_log"`
+- `startDateISO`
+- `timezone` (optional but recommended)
+- `repeatRule` (nullable)
+  - e.g. basis: `"calendar" | "machine_hours"`
+  - cadence details (daily/weekly/monthly or interval-hours tracker semantics)
+- `status`: `"active" | "stopped" | "archived"`
+- `stoppedAtISO?`, `stopReason?`
+- `createdAtISO`, `updatedAtISO`
+
+### C) `maintenanceOccurrencesV2` (what happened)
+Append-oriented history records tied to one calendar instance.
+- `id`
+- `system`: `"v2"`
+- `instanceId` (FK to `maintenanceCalendarInstancesV2.id`)
+- `taskId` (denormalized for reporting speed)
+- `eventType`: `"scheduled" | "completed" | "uncompleted" | "skipped" | "moved" | "removed" | "note_set" | "hours_set" | "past_logged"`
+- `effectiveDateISO` (date occurrence applies to)
+- `recordedAtISO` (when event was recorded)
+- `payload` (event-specific details)
+  - moved: from/to date
+  - note_set: note text (or cleared flag)
+  - hours_set: value (or cleared flag)
+  - completed/uncompleted: hours snapshot metadata, source
+- `supersedesEventId?` (optional linkage for corrections)
+- `actor?` / source metadata
+
+## Relationship Rules
+1. One task definition (`maintenanceTasksV2`) can have many calendar instances.
+2. One calendar instance can have many occurrence/event records.
+3. Calendar display state is derived from instance + ordered event log.
+4. Reporting rolls up from occurrence facts (plus task metadata), not from mutating task definitions.
+
+## Behavior Mapping
+
+### One-time reminder
+- Create instance with `instanceMode = one_time`, no repeat rule.
+- Occurrences can include scheduled/completed/skipped/moved/note/hours.
+- Once completed/removed/stopped, no future projections.
+
+### Repeat-tracking reminder
+- Create instance with `instanceMode = repeat` and `repeatRule`.
+- Interval metadata on task is advisory; instance decides repeat behavior.
+- Future reminders are projections from instance + event history.
+
+### Past completion record
+- Create instance with `instanceMode = past_log` (or one_time with past date).
+- Write `past_logged` and/or `completed` event with backdated `effectiveDateISO`.
+- Must appear in reporting/Data Center as historical completion.
+
+## Linking Lifecycle Actions
+- **Completed**: add `completed` event.
+- **Uncompleted**: add `uncompleted` event referencing prior completion date/event.
+- **Skipped**: add `skipped` event for date.
+- **Moved**: add `moved` event with `fromDateISO` + `toDateISO`.
+- **Stopped**: set instance status `stopped` (+ optional stop event).
+- **Removed**: append `removed` event; do not hard-delete history.
+
+This preserves auditability and avoids destructive rewrites.
+
+## Legacy + New Coexistence Strategy
+- Keep reading legacy `tasksInterval/tasksAsReq` exactly as now.
+- New items are created only in V2 collections.
+- No shared mutation functions at first.
+- Read adapter merges outputs from:
+  1) legacy task-derived occurrences
+  2) v2 instance/event-derived occurrences
+
+## Legacy vs New Marker
+- Use explicit discriminator field `system`:
+  - legacy items: implicit (no `system` or treated as `legacy`)
+  - new items: `system: "v2"`
+- Optional additional marker: `schemaVersion: 2` on V2 records.
+
+## Read Adapter (future integration contract)
+Output unified records in one stream with stable fields used by calendar/reporting:
+- `streamId` (unique)
+- `sourceSystem`: `"legacy" | "v2"`
+- `taskId`, `taskName`
+- `instanceId?`
+- `dateISO`
+- `status`: due/manual/completed/skipped/removed/etc.
+- `note`, `hours`, `price`, `categoryId`, links
+- `provenance` (pointer to original record ids)
+
+Calendar renderer and reporting/Data Center consume only this normalized stream.
+
+## Edge Cases to Resolve Before Coding
+1. Duplicate same-day events (complete then uncomplete then complete).
+2. Timezone/day-boundary drift for date-only records.
+3. Move + complete on same date ordering.
+4. Repeating instance stopped, then reactivated.
+5. Note/hours clears vs overwrites (audit trail).
+6. Deleting a task definition with active instances.
+7. Reporting dedupe when both projected and completed facts exist.
+8. Idempotency for retrying writes offline.
+9. Conflict resolution when multiple clients update same instance.
+10. Explicit user-triggered upgrade path for a single legacy task (future scope, opt-in only).
+
+## Recommendation
+Adopt **Hybrid (Option 3)**:
+- Sibling V2 collections for strict safety.
+- Event-style occurrence log for robust history/audit.
+- Adapter-driven unified read model for calendar/reporting.
+
+Why this is safest now:
+- Minimizes risk to legacy behavior.
+- Preserves existing Firebase contracts.
+- Enables gradual rollout by surface area (create → display → mutate → report) without migration.

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -184,6 +184,418 @@ function hideBubbleSoon(){
     hideBubble();
   }, 180);
 }
+
+function showV2OneTimeBubble(occurrenceId, anchorEl){
+  const lookup = (typeof window !== "undefined" && window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object")
+    ? window.__calendarV2OneTimeLookup
+    : {};
+  let ev = lookup && occurrenceId != null ? lookup[String(occurrenceId)] : null;
+  if (!ev && occurrenceId != null){
+    const rebuilt = getV2OneTimeOccurrenceView(String(occurrenceId));
+    if (rebuilt){
+      ev = rebuilt;
+      window.__calendarV2OneTimeLookup = window.__calendarV2OneTimeLookup || {};
+      window.__calendarV2OneTimeLookup[String(occurrenceId)] = rebuilt;
+      if (window.DEBUG_MODE) console.info("[maintenance-v2] rebuilt one-time lookup on demand", occurrenceId, rebuilt);
+    }
+  }
+  if (!ev){
+    if (window.DEBUG_MODE) console.warn("[maintenance-v2] bubble lookup miss", occurrenceId, lookup);
+    toast("V2 reminder details unavailable");
+    return;
+  }
+  ensureBubble();
+  clearTimeout(bubbleTimer);
+  const b = document.getElementById("bubble");
+  if (!b) return;
+  const dateText = parseDateLocal(ev.dateISO)?.toDateString() || ev.dateISO || "—";
+  const statusText = ev.status === "completed" ? "Completed" : "Scheduled";
+  b.innerHTML = `
+    <div class="bubble-title">${escapeHtml(ev.name || "Maintenance reminder")}</div>
+    <div class="bubble-kv"><span>Date:</span><span>${escapeHtml(dateText)}</span></div>
+    <div class="bubble-kv"><span>Mode:</span><span>One-time (V2)</span></div>
+    <div class="bubble-kv"><span>Status:</span><span>${escapeHtml(statusText)}</span></div>
+    <div class="bubble-kv"><span>Note:</span><span>${escapeHtml(ev.note || "—")}</span></div>
+    <div class="bubble-kv"><span>Logged hours:</span><span>${ev.hours != null ? escapeHtml(String(ev.hours)) : "—"}</span></div>
+    <div class="bubble-kv"><span>Info:</span><span>V2 one-time reminder actions are active.</span></div>
+    <div class="bubble-actions">
+      <button type="button" data-v2-complete ${ev.status === "completed" ? "disabled" : ""}>${ev.status === "completed" ? "Completed" : "Mark complete"}</button>
+      <button type="button" data-v2-uncomplete>Mark incomplete</button>
+      <button type="button" data-v2-note>Set note</button>
+      <button type="button" data-v2-hours>Set hours</button>
+      <button type="button" data-bubble-close>Close</button>
+    </div>
+  `;
+  const closeBtn = b.querySelector("[data-bubble-close]");
+  closeBtn?.addEventListener("click", ()=> hideBubbleSoon());
+  b.querySelector("[data-v2-complete]")?.addEventListener("click", ()=>{
+    if (typeof window.completeV2OneTimeOccurrence === "function") window.completeV2OneTimeOccurrence(String(occurrenceId));
+  });
+  b.querySelector("[data-v2-uncomplete]")?.addEventListener("click", ()=>{
+    if (typeof window.uncompleteV2OneTimeOccurrence === "function") window.uncompleteV2OneTimeOccurrence(String(occurrenceId));
+  });
+  b.querySelector("[data-v2-note]")?.addEventListener("click", ()=>{
+    if (typeof window.setV2OneTimeOccurrenceNote === "function") window.setV2OneTimeOccurrenceNote(String(occurrenceId));
+  });
+  b.querySelector("[data-v2-hours]")?.addEventListener("click", ()=>{
+    if (typeof window.setV2OneTimeOccurrenceHours === "function") window.setV2OneTimeOccurrenceHours(String(occurrenceId));
+  });
+  const rect = anchorEl.getBoundingClientRect();
+  b.style.top  = `${window.scrollY + rect.bottom + 8}px`;
+  b.style.left = `${window.scrollX + rect.left}px`;
+  b.classList.add("show");
+}
+
+function closeV2OneTimePanel(){
+  const existing = document.getElementById("v2OneTimePanel");
+  if (existing) existing.remove();
+}
+
+function openV2OneTimePanel(occurrenceId){
+  const ev = getV2OneTimeOccurrenceView(String(occurrenceId));
+  if (!ev){ toast("V2 reminder details unavailable"); return; }
+  closeV2OneTimePanel();
+  const overlay = document.createElement("div");
+  overlay.id = "v2OneTimePanel";
+  overlay.style.position = "fixed";
+  overlay.style.inset = "0";
+  overlay.style.background = "rgba(0,0,0,.35)";
+  overlay.style.display = "grid";
+  overlay.style.placeItems = "center";
+  overlay.style.zIndex = "9999";
+  const card = document.createElement("div");
+  card.style.width = "min(92vw, 460px)";
+  card.style.background = "#fff";
+  card.style.borderRadius = "12px";
+  card.style.padding = "14px";
+  card.style.boxShadow = "0 14px 35px rgba(0,0,0,.25)";
+  const dateText = parseDateLocal(ev.dateISO)?.toDateString() || ev.dateISO || "—";
+  const statusText = ev.status === "completed" ? "Completed" : "Scheduled";
+  card.innerHTML = `
+    <div class="bubble-title">${escapeHtml(ev.name || "Maintenance reminder")}</div>
+    <div class="bubble-kv"><span>Date:</span><span>${escapeHtml(dateText)}</span></div>
+    <div class="bubble-kv"><span>Status:</span><span>${escapeHtml(statusText)}</span></div>
+    <div class="bubble-kv"><span>Note:</span><span>${escapeHtml(ev.note || "—")}</span></div>
+    <div class="bubble-kv"><span>Logged hours:</span><span>${ev.hours != null ? escapeHtml(String(ev.hours)) : "—"}</span></div>
+    <div class="bubble-actions">
+      <button type="button" data-v2-panel-complete ${ev.status === "completed" ? "disabled" : ""}>${ev.status === "completed" ? "Completed" : "Mark complete"}</button>
+      <button type="button" data-v2-panel-uncomplete>Mark incomplete</button>
+      <button type="button" data-v2-panel-note>Set note</button>
+      <button type="button" data-v2-panel-hours>Set logged hours</button>
+      <button type="button" class="danger" data-v2-panel-remove>Remove from calendar</button>
+      <button type="button" data-v2-panel-close>Close</button>
+    </div>
+    <div class="small muted" style="margin-top:8px;">These hours are saved on this occurrence only.</div>
+  `;
+  overlay.appendChild(card);
+  document.body.appendChild(overlay);
+  const close = ()=> closeV2OneTimePanel();
+  overlay.addEventListener("click", (event)=>{ if (event.target === overlay) close(); });
+  card.querySelector("[data-v2-panel-close]")?.addEventListener("click", close);
+  card.querySelector("[data-v2-panel-complete]")?.addEventListener("click", ()=>{ window.completeV2OneTimeOccurrence?.(String(occurrenceId)); openV2OneTimePanel(occurrenceId); });
+  card.querySelector("[data-v2-panel-uncomplete]")?.addEventListener("click", ()=>{ window.uncompleteV2OneTimeOccurrence?.(String(occurrenceId)); openV2OneTimePanel(occurrenceId); });
+  card.querySelector("[data-v2-panel-note]")?.addEventListener("click", ()=>{ window.setV2OneTimeOccurrenceNote?.(String(occurrenceId)); openV2OneTimePanel(occurrenceId); });
+  card.querySelector("[data-v2-panel-hours]")?.addEventListener("click", ()=>{ window.setV2OneTimeOccurrenceHours?.(String(occurrenceId)); openV2OneTimePanel(occurrenceId); });
+  card.querySelector("[data-v2-panel-remove]")?.addEventListener("click", ()=>{
+    const ok = window.confirm ? window.confirm("Remove this V2 one-time reminder from the calendar?") : true;
+    if (!ok) return;
+    window.removeV2OneTimeOccurrence?.(String(occurrenceId));
+    close();
+  });
+}
+
+function getV2OneTimeOccurrenceView(occurrenceId){
+  const occId = String(occurrenceId || "");
+  if (!occId) return null;
+  const events = Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : [];
+  const scheduled = events.find(entry => entry && String(entry.id || "") === occId && String(entry.eventType || "") === "scheduled");
+  if (!scheduled) return null;
+  const instanceId = scheduled.instanceId != null ? String(scheduled.instanceId) : "";
+  const instance = (Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2 : []).find(entry => entry && String(entry.id || "") === instanceId) || null;
+  if (!instance || String(instance.instanceMode || "") !== "one_time") return null;
+  const taskId = String(instance.taskId || scheduled.taskId || "");
+  const task = (Array.isArray(window.maintenanceTasksV2) ? window.maintenanceTasksV2 : []).find(entry => entry && String(entry.id || "") === taskId) || null;
+  const dateISO = normalizeDateKey(scheduled.effectiveDateISO || scheduled.dateISO || instance.startDateISO || null);
+  if (!dateISO) return null;
+  const state = resolveV2OneTimeOccurrenceState(occId, scheduled);
+  return {
+    occurrenceId: occId,
+    eventType: "scheduled",
+    instanceId,
+    taskId,
+    dateISO,
+    name: String(scheduled.taskName || (task && task.name) || "Maintenance reminder"),
+    note: state.note,
+    hours: state.hours,
+    status: state.status
+  };
+}
+
+function makeV2RepeatOccurrenceKey(instanceId, dateISO){
+  return `repeat:${String(instanceId || "")}:${String(dateISO || "")}`;
+}
+
+function projectV2RepeatDates(instance, maxCount = 2){
+  const rule = instance && instance.repeatRule && typeof instance.repeatRule === "object" ? instance.repeatRule : null;
+  if (!rule || !rule.enabled) return [];
+  const basis = String(rule.basis || "").toLowerCase();
+  if (!["calendar_day", "calendar_week", "calendar_month", "machine_hours"].includes(basis)) return [];
+  if (basis === "machine_hours"){
+    const intervalHours = Math.max(1, Number(rule.intervalHours || rule.every) || 1);
+    const currentTotal = typeof getCurrentMachineHours === "function" ? Number(getCurrentMachineHours()) : null;
+    const anchorTotal = Number(instance.machineHourAnchorTotal);
+    const avgPerDay = (typeof configuredDailyHours === "function" ? Number(configuredDailyHours()) : 8) || 8;
+    const safeAvg = Number.isFinite(avgPerDay) && avgPerDay > 0 ? avgPerDay : 8;
+    const remain = (Number.isFinite(currentTotal) && Number.isFinite(anchorTotal))
+      ? (intervalHours - Math.max(0, currentTotal - anchorTotal))
+      : intervalHours;
+    const daysOut = remain <= 0 ? 0 : Math.ceil(remain / safeAvg);
+    const d = new Date();
+    d.setHours(0,0,0,0);
+    d.setDate(d.getDate() + daysOut);
+    const dueISO = ymd(d);
+    return dueISO ? [dueISO] : [];
+  }
+  const every = Math.max(1, Number(rule.every) || 1);
+  const startISO = normalizeDateKey(instance.startDateISO || rule.startISO || null);
+  const start = startISO ? parseDateLocal(startISO) : null;
+  if (!(start instanceof Date) || Number.isNaN(start.getTime())) return [];
+  start.setHours(0,0,0,0);
+  const today = new Date(); today.setHours(0,0,0,0);
+  const out = [];
+  for (let i = 0; i < 180 && out.length < maxCount; i++){
+    const d = new Date(start.getTime());
+    if (basis === "calendar_day") d.setDate(d.getDate() + (i * every));
+    if (basis === "calendar_week") d.setDate(d.getDate() + (i * every * 7));
+    if (basis === "calendar_month") d.setMonth(d.getMonth() + (i * every));
+    d.setHours(0,0,0,0);
+    if (d.getTime() < today.getTime()) continue;
+    const iso = ymd(d);
+    if (iso) out.push(iso);
+  }
+  return out;
+}
+
+function resolveV2RepeatOccurrenceState(instanceId, dateISO){
+  const key = makeV2RepeatOccurrenceKey(instanceId, dateISO);
+  const events = Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : [];
+  const related = events
+    .filter(entry => entry && typeof entry === "object" && String(entry.rootOccurrenceId || "") === key)
+    .sort((a,b)=> String(a.recordedAtISO || "").localeCompare(String(b.recordedAtISO || "")));
+  let status = "scheduled";
+  let note = "";
+  let hours = null;
+  related.forEach(entry => {
+    const t = String(entry.eventType || "");
+    if (t === "completed") status = "completed";
+    if (t === "uncompleted") status = "scheduled";
+    if (t === "removed") status = "removed";
+    if (t === "note_set" && entry.payload && Object.prototype.hasOwnProperty.call(entry.payload, "note")) note = String(entry.payload.note || "");
+    if (t === "hours_set" && entry.payload && Object.prototype.hasOwnProperty.call(entry.payload, "hours")){
+      const raw = entry.payload.hours;
+      hours = raw == null || raw === "" ? null : (Number.isFinite(Number(raw)) ? Number(raw) : hours);
+    }
+  });
+  return { key, status, note, hours };
+}
+
+function appendV2RepeatEvent(instanceId, taskId, dateISO, eventType, payload = {}){
+  const key = makeV2RepeatOccurrenceKey(instanceId, dateISO);
+  const list = Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : (window.maintenanceOccurrencesV2 = []);
+  list.unshift({
+    id: genId(`v2_repeat_${eventType}`),
+    system: "v2",
+    schemaVersion: 2,
+    instanceId: String(instanceId || ""),
+    taskId: String(taskId || ""),
+    eventType,
+    effectiveDateISO: normalizeDateKey(dateISO),
+    recordedAtISO: new Date().toISOString(),
+    rootOccurrenceId: key,
+    payload: { ...(payload || {}) }
+  });
+  if (eventType === "completed"){
+    const inst = (Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2 : []).find(entry => entry && String(entry.id || "") === String(instanceId));
+    if (inst && inst.repeatRule && String(inst.repeatRule.basis || "") === "machine_hours"){
+      const current = typeof getCurrentMachineHours === "function" ? Number(getCurrentMachineHours()) : null;
+      if (Number.isFinite(current)){
+        inst.machineHourAnchorTotal = current;
+        inst.machineHourAnchorDateISO = normalizeDateKey(ymd(new Date()));
+      }
+    }
+  }
+  if (typeof saveCloudNow === "function") saveCloudNow();
+  else saveCloudDebounced();
+  renderCalendar();
+}
+
+function openV2RepeatPanel(view){
+  if (!view) return;
+  const statusText = view.status === "completed" ? "Completed" : "Scheduled";
+  const dateText = parseDateLocal(view.dateISO)?.toDateString() || view.dateISO;
+  closeV2OneTimePanel();
+  const overlay = document.createElement("div");
+  overlay.id = "v2OneTimePanel";
+  overlay.style.position = "fixed"; overlay.style.inset = "0"; overlay.style.background = "rgba(0,0,0,.35)";
+  overlay.style.display = "grid"; overlay.style.placeItems = "center"; overlay.style.zIndex = "9999";
+  const card = document.createElement("div");
+  card.style.width = "min(92vw, 460px)"; card.style.background = "#fff"; card.style.borderRadius = "12px"; card.style.padding = "14px";
+  card.innerHTML = `<div class="bubble-title">${escapeHtml(view.name || "Maintenance repeat")}</div>
+  <div class="bubble-kv"><span>Date:</span><span>${escapeHtml(dateText)}</span></div>
+  <div class="bubble-kv"><span>Status:</span><span>${escapeHtml(statusText)}</span></div>
+  <div class="bubble-kv"><span>Note:</span><span>${escapeHtml(view.note || "—")}</span></div>
+  <div class="bubble-kv"><span>Logged hours:</span><span>${view.hours != null ? escapeHtml(String(view.hours)) : "—"}</span></div>
+  <div class="bubble-kv"><span>Repeat type:</span><span>${escapeHtml(view.repeatType || "Calendar repeat")}</span></div>
+  ${view.repeatType === "Machine-hour predicted repeat" ? `<div class="small muted">This due date is predicted from machine-hour usage and may move as hours change.</div>` : ""}
+  <div class="bubble-actions">
+    <button type="button" data-rpt-complete ${view.status==="completed"?"disabled":""}>${view.status==="completed"?"Completed":"Mark complete"}</button>
+    <button type="button" data-rpt-uncomplete>Mark incomplete</button>
+    <button type="button" data-rpt-note>Set note</button>
+    <button type="button" data-rpt-hours>Set logged hours</button>
+    <button type="button" class="danger" data-rpt-remove>Remove from calendar</button>
+    <button type="button" class="danger" data-rpt-stop>Stop repeat tracking</button>
+    <button type="button" data-rpt-close>Close</button>
+  </div>`;
+  overlay.appendChild(card); document.body.appendChild(overlay);
+  const reopen = ()=> openV2RepeatPanel({ ...view, ...resolveV2RepeatOccurrenceState(view.instanceId, view.dateISO) });
+  card.querySelector("[data-rpt-close]")?.addEventListener("click", ()=> closeV2OneTimePanel());
+  card.querySelector("[data-rpt-complete]")?.addEventListener("click", ()=>{ if (view.status!=="completed") appendV2RepeatEvent(view.instanceId, view.taskId, view.dateISO, "completed"); reopen(); });
+  card.querySelector("[data-rpt-uncomplete]")?.addEventListener("click", ()=>{ if (view.status==="completed") appendV2RepeatEvent(view.instanceId, view.taskId, view.dateISO, "uncompleted"); reopen(); });
+  card.querySelector("[data-rpt-note]")?.addEventListener("click", ()=>{ const v=window.prompt("Set note for this repeat occurrence:", view.note||""); if(v!==null) appendV2RepeatEvent(view.instanceId, view.taskId, view.dateISO, "note_set", { note:v }); reopen(); });
+  card.querySelector("[data-rpt-hours]")?.addEventListener("click", ()=>{ const v=window.prompt("Enter hours to record for this maintenance occurrence. Leave blank to clear.", view.hours!=null?String(view.hours):""); if(v!==null){ const t=String(v).trim(); const h=t===""?null:Number(t); if(t!=="" && (!Number.isFinite(h)||h<0)){ toast("Enter a valid non-negative number."); return; } appendV2RepeatEvent(view.instanceId, view.taskId, view.dateISO, "hours_set", { hours:h }); reopen(); } });
+  card.querySelector("[data-rpt-remove]")?.addEventListener("click", ()=>{ const ok=window.confirm?window.confirm("Remove this repeat occurrence from calendar?"):true; if(!ok) return; appendV2RepeatEvent(view.instanceId, view.taskId, view.dateISO, "removed", { source:"repeat_panel" }); closeV2OneTimePanel(); });
+  card.querySelector("[data-rpt-stop]")?.addEventListener("click", ()=>{
+    const ok = window.confirm ? window.confirm("Stop repeat tracking for this chain?") : true;
+    if (!ok) return;
+    if (typeof window.stopV2RepeatTracking === "function") window.stopV2RepeatTracking(String(view.instanceId), String(view.taskId), String(view.dateISO));
+    closeV2OneTimePanel();
+  });
+}
+
+window.stopV2RepeatTracking = (instanceId, taskId, dateISO)=>{
+  const instances = Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2 : [];
+  const inst = instances.find(entry => entry && String(entry.id || "") === String(instanceId));
+  if (!inst) return;
+  if (String(inst.status || "") === "stopped"){ toast("Repeat tracking already stopped"); return; }
+  inst.status = "stopped";
+  inst.stoppedAtISO = new Date().toISOString();
+  appendV2RepeatEvent(instanceId, taskId, dateISO, "stopped", { source: "repeat_panel" });
+  toast("Repeat tracking stopped");
+};
+
+function appendV2OccurrenceEvent(baseOccurrenceId, eventType, payload = {}, supersedesEventId = null){
+  const list = Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : (window.maintenanceOccurrencesV2 = []);
+  const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};
+  const base = lookup[String(baseOccurrenceId)];
+  if (!base) return false;
+  const next = {
+    id: genId(`v2_${eventType}`),
+    system: "v2",
+    schemaVersion: 2,
+    instanceId: base.instanceId,
+    taskId: base.taskId,
+    eventType,
+    effectiveDateISO: base.dateISO,
+    recordedAtISO: new Date().toISOString(),
+    supersedesEventId: supersedesEventId || null,
+    rootOccurrenceId: String(baseOccurrenceId),
+    payload: { ...(payload || {}) }
+  };
+  list.unshift(next);
+  if (typeof saveCloudNow === "function") saveCloudNow();
+  else saveCloudDebounced();
+  renderCalendar();
+  return true;
+}
+
+function resolveV2OneTimeOccurrenceState(rootOccurrenceId, scheduledEvent){
+  const rootId = String(rootOccurrenceId || "");
+  const events = Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : [];
+  const relevant = events
+    .map((entry, index)=>({ entry, index }))
+    .filter(({ entry })=>{
+      if (!entry || typeof entry !== "object") return false;
+      const id = entry.id != null ? String(entry.id) : "";
+      if (id === rootId) return true;
+      if (entry.rootOccurrenceId != null && String(entry.rootOccurrenceId) === rootId) return true;
+      if (entry.supersedesEventId != null && String(entry.supersedesEventId) === rootId) return true;
+      return false;
+    })
+    .sort((a,b)=>{
+      const aTime = Date.parse(String(a.entry.recordedAtISO || ""));
+      const bTime = Date.parse(String(b.entry.recordedAtISO || ""));
+      const aValid = Number.isFinite(aTime);
+      const bValid = Number.isFinite(bTime);
+      if (aValid && bValid && aTime !== bTime) return aTime - bTime;
+      if (aValid && !bValid) return 1;
+      if (!aValid && bValid) return -1;
+      return a.index - b.index;
+    });
+  let status = "scheduled";
+  let note = scheduledEvent?.payload && Object.prototype.hasOwnProperty.call(scheduledEvent.payload, "note")
+    ? (scheduledEvent.payload.note == null ? "" : String(scheduledEvent.payload.note))
+    : "";
+  let hours = scheduledEvent?.payload && Object.prototype.hasOwnProperty.call(scheduledEvent.payload, "hours")
+    ? (scheduledEvent.payload.hours == null || scheduledEvent.payload.hours === "" ? null : Number(scheduledEvent.payload.hours))
+    : null;
+  relevant.forEach(({ entry })=>{
+    const type = String(entry.eventType || "");
+    if (type === "completed") status = "completed";
+    if (type === "uncompleted") status = "scheduled";
+    if (type === "removed") status = "removed";
+    if (type === "note_set" && entry.payload && Object.prototype.hasOwnProperty.call(entry.payload, "note")){
+      note = entry.payload.note == null ? "" : String(entry.payload.note);
+    }
+    if (type === "hours_set" && entry.payload && Object.prototype.hasOwnProperty.call(entry.payload, "hours")){
+      const raw = entry.payload.hours;
+      hours = raw == null || raw === "" ? null : (Number.isFinite(Number(raw)) ? Number(raw) : hours);
+    }
+  });
+  return { status, note, hours };
+}
+
+window.completeV2OneTimeOccurrence = (occurrenceId)=>{
+  const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};
+  const base = lookup[String(occurrenceId)];
+  if (!base) return;
+  if (base.status === "completed"){ toast("Already completed"); return; }
+  if (appendV2OccurrenceEvent(occurrenceId, "completed", {}, String(occurrenceId))) toast("Marked complete");
+};
+window.uncompleteV2OneTimeOccurrence = (occurrenceId)=>{
+  const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};
+  const base = lookup[String(occurrenceId)];
+  if (!base) return;
+  if (base.status !== "completed"){ toast("Already incomplete"); return; }
+  if (appendV2OccurrenceEvent(occurrenceId, "uncompleted", {}, String(occurrenceId))) toast("Marked incomplete");
+};
+window.setV2OneTimeOccurrenceNote = (occurrenceId)=>{
+  const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};
+  const base = lookup[String(occurrenceId)];
+  if (!base) return;
+  const input = window.prompt("Set note for this V2 reminder:", base.note || "");
+  if (input === null) return;
+  if (appendV2OccurrenceEvent(occurrenceId, "note_set", { note: String(input) }, String(occurrenceId))) toast("Note saved");
+};
+window.setV2OneTimeOccurrenceHours = (occurrenceId)=>{
+  const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};
+  const base = lookup[String(occurrenceId)];
+  if (!base) return;
+  const input = window.prompt("Enter hours to record for this maintenance occurrence. Leave blank to clear.", base.hours != null ? String(base.hours) : "");
+  if (input === null) return;
+  const trimmed = String(input).trim();
+  const hours = trimmed === "" ? null : Number(trimmed);
+  if (trimmed !== "" && (!Number.isFinite(hours) || hours < 0)){ toast("Enter a valid non-negative number."); return; }
+  if (appendV2OccurrenceEvent(occurrenceId, "hours_set", { hours }, String(occurrenceId))) toast("Hours saved");
+};
+window.removeV2OneTimeOccurrence = (occurrenceId)=>{
+  const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};
+  const base = lookup[String(occurrenceId)] || getV2OneTimeOccurrenceView(String(occurrenceId));
+  if (!base) return;
+  if (base.status === "removed"){ toast("Already removed"); return; }
+  if (appendV2OccurrenceEvent(occurrenceId, "removed", { source: "calendar_panel" }, String(occurrenceId))){
+    toast("Removed from calendar");
+  }
+};
 function triggerDashboardAddPicker(opts){
   const detail = (opts && typeof opts === "object") ? { ...opts } : {};
   const enqueueRequest = ()=>{
@@ -1640,25 +2052,27 @@ function wireCalendarBubbles(){
 
   months.addEventListener("mouseover", (e)=>{
     if (typeof isCalendarHoursEditing === "function" && isCalendarHoursEditing()) return;
-    const el = e.target.closest("[data-cal-job], [data-cal-task], [data-cal-garnet]");
+    const el = e.target.closest("[data-cal-job], [data-cal-task], [data-cal-v2-one-time], [data-cal-garnet]");
     if (!el || el === hoverTarget) return;
     hoverTarget = el;
     if (el.dataset.calJob)  showJobBubble(el.dataset.calJob, el);
     if (el.dataset.calTask) showTaskBubble(el.dataset.calTask, el, extractTaskOptions(el));
+    if (el.dataset.calV2OneTime) showV2OneTimeBubble(el.dataset.calV2OneTime, el);
     if (el.dataset.calGarnet) showGarnetBubble(el.dataset.calGarnet, el);
   });
   months.addEventListener("mouseout", (e)=>{
     if (typeof isCalendarHoursEditing === "function" && isCalendarHoursEditing()) return;
-    const from = e.target.closest("[data-cal-job], [data-cal-task], [data-cal-garnet]");
-    const to   = e.relatedTarget && e.relatedTarget.closest && e.relatedTarget.closest("[data-cal-job], [data-cal-task], [data-cal-garnet]");
+    const from = e.target.closest("[data-cal-job], [data-cal-task], [data-cal-v2-one-time], [data-cal-garnet]");
+    const to   = e.relatedTarget && e.relatedTarget.closest && e.relatedTarget.closest("[data-cal-job], [data-cal-task], [data-cal-v2-one-time], [data-cal-garnet]");
     if (from && !to) { hoverTarget = null; hideBubbleSoon(); }
   });
   months.addEventListener("click", (e)=>{
     if (typeof isCalendarHoursEditing === "function" && isCalendarHoursEditing()) return;
-    const el = e.target.closest("[data-cal-job], [data-cal-task], [data-cal-garnet]");
+    const el = e.target.closest("[data-cal-job], [data-cal-task], [data-cal-v2-one-time], [data-cal-garnet]");
     if (!el) return;
     if (el.dataset.calJob)  showJobBubble(el.dataset.calJob, el);
     if (el.dataset.calTask) showTaskBubble(el.dataset.calTask, el, extractTaskOptions(el));
+    if (el.dataset.calV2OneTime) showV2OneTimeBubble(el.dataset.calV2OneTime, el);
     if (el.dataset.calGarnet) showGarnetBubble(el.dataset.calGarnet, el);
   });
 }
@@ -2367,6 +2781,97 @@ function renderCalendar(){
     }
   });
 
+  const v2TaskLookup = new Map();
+  (Array.isArray(window.maintenanceTasksV2) ? window.maintenanceTasksV2 : []).forEach(entry => {
+    if (!entry || entry.id == null) return;
+    v2TaskLookup.set(String(entry.id), entry);
+  });
+  const v2InstanceLookup = new Map();
+  (Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2 : []).forEach(entry => {
+    if (!entry || entry.id == null) return;
+    if (String(entry.system || "") !== "v2" && Number(entry.schemaVersion || 0) < 2) return;
+    if (String(entry.instanceMode || "") !== "one_time") return;
+    v2InstanceLookup.set(String(entry.id), entry);
+  });
+  const oneTimeLookup = {};
+  const seenV2ChipKeys = new Set();
+  (Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : []).forEach(event => {
+    if (!event || event.id == null) return;
+    if (String(event.system || "") !== "v2" && Number(event.schemaVersion || 0) < 2) return;
+    const instanceId = event.instanceId != null ? String(event.instanceId) : "";
+    const instance = v2InstanceLookup.get(instanceId);
+    if (!instance) return;
+    const eventType = String(event.eventType || "");
+    if (eventType !== "scheduled") return;
+    const dateISO = normalizeDateKey(event.effectiveDateISO || event.dateISO || instance.startDateISO || null);
+    if (!dateISO) return;
+    const task = v2TaskLookup.get(String(instance.taskId || event.taskId || "")) || null;
+    const name = String(event.taskName || (task && task.name) || "Maintenance reminder");
+    const occurrenceId = String(event.id);
+    const rootOccurrenceId = occurrenceId;
+    const { status, note, hours } = resolveV2OneTimeOccurrenceState(rootOccurrenceId, event);
+    const mapKey = `${occurrenceId}:${dateISO}`;
+    if (seenV2ChipKeys.has(mapKey)) return;
+    seenV2ChipKeys.add(mapKey);
+    oneTimeLookup[occurrenceId] = {
+      occurrenceId,
+      eventType,
+      instanceId,
+      taskId: String(instance.taskId || event.taskId || ""),
+      dateISO,
+      name,
+      note,
+      hours,
+      status
+    };
+    if (status === "removed") return;
+    (dueMap[dateISO] ||= []).push({
+      type: "v2task",
+      id: `v2-one-time:${occurrenceId}`,
+      occurrenceId,
+      instanceId,
+      name,
+      status: status === "completed" ? "completed" : "manual",
+      mode: "one_time_v2",
+      dateISO
+    });
+  });
+  window.__calendarV2OneTimeLookup = oneTimeLookup;
+
+  const repeatInstances = (Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2 : [])
+    .filter(entry => entry
+      && String(entry.instanceMode || "") === "repeat"
+      && String(entry.status || "active") !== "stopped"
+      && (String(entry.system || "") === "v2" || Number(entry.schemaVersion || 0) >= 2));
+  repeatInstances.forEach(instance => {
+    const dates = projectV2RepeatDates(instance, 2);
+    dates.forEach(dateISO => {
+      const state = resolveV2RepeatOccurrenceState(instance.id, dateISO);
+      if (state.status === "removed") return;
+      const task = v2TaskLookup.get(String(instance.taskId || "")) || null;
+      (dueMap[dateISO] ||= []).push({
+        type: "v2repeat",
+        id: state.key,
+        instanceId: String(instance.id),
+        taskId: String(instance.taskId || ""),
+        dateISO,
+        name: String((task && task.name) || "Maintenance repeat"),
+        status: state.status === "completed" ? "completed" : "manual",
+        mode: "repeat_v2",
+        repeatView: {
+          instanceId: String(instance.id),
+          taskId: String(instance.taskId || ""),
+          dateISO,
+          name: String((task && task.name) || "Maintenance repeat"),
+          note: state.note,
+          hours: state.hours,
+          status: state.status,
+          repeatType: String(instance.repeatRule?.basis || "") === "machine_hours" ? "Machine-hour predicted repeat" : "Calendar repeat"
+        }
+      });
+    });
+  });
+
   const jobsMap = {};
   cuttingJobs.forEach(j => {
     const start = parseDateLocal(j.startISO);
@@ -2579,10 +3084,29 @@ function renderCalendar(){
       (dueMap[key]||[]).forEach(ev=>{
         const chip = document.createElement("div");
         let cls = "event generic cal-task";
+        if (ev.type === "v2task") cls += " v2-event";
         if (ev.status === "completed") cls += " is-complete";
         chip.className = cls;
         const baseTaskId = ev.taskId || ev.id;
-        chip.dataset.calTask = baseTaskId;
+        if (ev.type === "v2task" && ev.occurrenceId){
+          chip.dataset.calV2OneTime = String(ev.occurrenceId);
+          chip.addEventListener("click", (event)=>{
+            event.preventDefault();
+            event.stopPropagation();
+            openV2OneTimePanel(String(ev.occurrenceId));
+          });
+          chip.addEventListener("mouseenter", ()=>{
+            showV2OneTimeBubble(String(ev.occurrenceId), chip);
+          });
+        }else if (ev.type === "v2repeat" && ev.repeatView){
+          chip.addEventListener("click", (event)=>{
+            event.preventDefault(); event.stopPropagation();
+            openV2RepeatPanel(ev.repeatView);
+          });
+          chip.dataset.calV2OneTime = `repeat:${ev.instanceId}:${ev.dateISO}`;
+        } else {
+          chip.dataset.calTask = baseTaskId;
+        }
         chip.dataset.calStatus = ev.status || "due";
         if (ev.mode) chip.dataset.calMode = ev.mode;
         chip.dataset.calDate = ev.dateISO || key;

--- a/js/core.js
+++ b/js/core.js
@@ -1652,6 +1652,9 @@ if (!Array.isArray(window.dailyCutHours)) window.dailyCutHours = [];
 if (!Array.isArray(window.opportunityRollups)) window.opportunityRollups = [];
 if (!Array.isArray(window.weeklyCostReports)) window.weeklyCostReports = [];
 if (!Array.isArray(window.receiptTrackerWeeks)) window.receiptTrackerWeeks = [];
+if (!Array.isArray(window.maintenanceTasksV2)) window.maintenanceTasksV2 = [];
+if (!Array.isArray(window.maintenanceCalendarInstancesV2)) window.maintenanceCalendarInstancesV2 = [];
+if (!Array.isArray(window.maintenanceOccurrencesV2)) window.maintenanceOccurrencesV2 = [];
 if (!Array.isArray(window.jobFolders)) window.jobFolders = defaultJobFolders();
 if (typeof window.orderRequestTab !== "string") window.orderRequestTab = "active";
 
@@ -1672,6 +1675,9 @@ let orderRequests = window.orderRequests;
 let orderRequestTab = window.orderRequestTab;
 let garnetCleanings = window.garnetCleanings;
 let dailyCutHours = window.dailyCutHours;
+let maintenanceTasksV2 = window.maintenanceTasksV2;
+let maintenanceCalendarInstancesV2 = window.maintenanceCalendarInstancesV2;
+let maintenanceOccurrencesV2 = window.maintenanceOccurrencesV2;
 let jobFolders = window.jobFolders;
 let weeklyCostReports = window.weeklyCostReports;
 let receiptTrackerWeeks = window.receiptTrackerWeeks;
@@ -1848,6 +1854,15 @@ function refreshGlobalCollections(){
   if (!Array.isArray(window.dailyCutHours)) window.dailyCutHours = [];
   dailyCutHours = window.dailyCutHours;
 
+  if (!Array.isArray(window.maintenanceTasksV2)) window.maintenanceTasksV2 = [];
+  maintenanceTasksV2 = window.maintenanceTasksV2;
+
+  if (!Array.isArray(window.maintenanceCalendarInstancesV2)) window.maintenanceCalendarInstancesV2 = [];
+  maintenanceCalendarInstancesV2 = window.maintenanceCalendarInstancesV2;
+
+  if (!Array.isArray(window.maintenanceOccurrencesV2)) window.maintenanceOccurrencesV2 = [];
+  maintenanceOccurrencesV2 = window.maintenanceOccurrencesV2;
+
   if (!Array.isArray(window.jobFolders)) window.jobFolders = defaultJobFolders();
   jobFolders = window.jobFolders;
 }
@@ -1944,6 +1959,9 @@ window.defaultAsReqTasks = defaultAsReqTasks;
     copyArr("orderRequests");
     copyArr("receiptTrackerWeeks");
     copyArr("garnetCleanings");
+    copyArr("maintenanceTasksV2");
+    copyArr("maintenanceCalendarInstancesV2");
+    copyArr("maintenanceOccurrencesV2");
     copyArr("totalHistory");
     copyObj("appConfig");
     copyObj("settingsFolders");
@@ -1970,6 +1988,9 @@ window.defaultAsReqTasks = defaultAsReqTasks;
     if (!Array.isArray(sanitized.orderRequests) && Array.isArray(window.orderRequests)) sanitized.orderRequests = window.orderRequests.slice();
     if (!Array.isArray(sanitized.receiptTrackerWeeks) && Array.isArray(window.receiptTrackerWeeks)) sanitized.receiptTrackerWeeks = window.receiptTrackerWeeks.slice();
     if (!Array.isArray(sanitized.garnetCleanings) && Array.isArray(window.garnetCleanings)) sanitized.garnetCleanings = window.garnetCleanings.slice();
+    if (!Array.isArray(sanitized.maintenanceTasksV2) && Array.isArray(window.maintenanceTasksV2)) sanitized.maintenanceTasksV2 = window.maintenanceTasksV2.slice();
+    if (!Array.isArray(sanitized.maintenanceCalendarInstancesV2) && Array.isArray(window.maintenanceCalendarInstancesV2)) sanitized.maintenanceCalendarInstancesV2 = window.maintenanceCalendarInstancesV2.slice();
+    if (!Array.isArray(sanitized.maintenanceOccurrencesV2) && Array.isArray(window.maintenanceOccurrencesV2)) sanitized.maintenanceOccurrencesV2 = window.maintenanceOccurrencesV2.slice();
     if (!Array.isArray(sanitized.totalHistory) && Array.isArray(window.totalHistory)) sanitized.totalHistory = window.totalHistory.slice();
     if (!Array.isArray(sanitized.deletedItems) && Array.isArray(window.deletedItems)) sanitized.deletedItems = window.deletedItems.slice();
     if (!Array.isArray(sanitized.jobFolders) && Array.isArray(window.jobFolders)) sanitized.jobFolders = window.jobFolders.slice();
@@ -1991,6 +2012,9 @@ window.defaultAsReqTasks = defaultAsReqTasks;
     if (!Array.isArray(window.orderRequests)) window.orderRequests = [];
     if (!Array.isArray(window.receiptTrackerWeeks)) window.receiptTrackerWeeks = [];
     if (!Array.isArray(window.garnetCleanings)) window.garnetCleanings = [];
+    if (!Array.isArray(window.maintenanceTasksV2)) window.maintenanceTasksV2 = [];
+    if (!Array.isArray(window.maintenanceCalendarInstancesV2)) window.maintenanceCalendarInstancesV2 = [];
+    if (!Array.isArray(window.maintenanceOccurrencesV2)) window.maintenanceOccurrencesV2 = [];
     if (!Array.isArray(window.totalHistory)) window.totalHistory = [];
     if (!window.settingsFolders || !Array.isArray(window.settingsFolders)) window.settingsFolders = typeof defaultSettingsFolders === "function" ? defaultSettingsFolders() : [];
     if (!window.folders || typeof window.folders !== "object") window.folders = Array.isArray(window.settingsFolders) ? JSON.parse(JSON.stringify(window.settingsFolders)) : [];
@@ -2037,6 +2061,9 @@ function stateHasMeaningfulData(data){
     "pumpEff",
     "jobFolders",
     "orderRequestTab",
+    "maintenanceTasksV2",
+    "maintenanceCalendarInstancesV2",
+    "maintenanceOccurrencesV2",
     "schema"
   ]);
   return keys.some(key => meaningfulKeys.has(key));
@@ -2158,6 +2185,9 @@ function snapshotState(){
     weeklyCostReports: Array.isArray(window.weeklyCostReports)
       ? window.weeklyCostReports.map(entry => ({ ...entry }))
       : [],
+    maintenanceTasksV2: Array.isArray(maintenanceTasksV2) ? maintenanceTasksV2.map(entry => ({ ...entry })) : [],
+    maintenanceCalendarInstancesV2: Array.isArray(maintenanceCalendarInstancesV2) ? maintenanceCalendarInstancesV2.map(entry => ({ ...entry })) : [],
+    maintenanceOccurrencesV2: Array.isArray(maintenanceOccurrencesV2) ? maintenanceOccurrencesV2.map(entry => ({ ...entry })) : [],
     syncProcessLog: Array.isArray(window.syncProcessLog)
       ? window.syncProcessLog.map(entry => ({ ...entry }))
       : [],
@@ -2339,6 +2369,226 @@ function ensureTaskCategories(){
     }
   });
 }
+
+function detectMaintenanceRecordSystem(record){
+  if (!record || typeof record !== "object") return "legacy";
+  if (record.system === "v2") return "v2";
+  if ("eventType" in record || "effectiveDateISO" in record || "recordedAtISO" in record || "payload" in record) return "v2";
+  if (Number(record.schemaVersion) >= 2) return "v2";
+  return "legacy";
+}
+
+function createMaintenanceCompatibilityRow(base){
+  return {
+    streamId: base.streamId || "",
+    sourceSystem: base.sourceSystem || "legacy",
+    taskId: base.taskId || null,
+    taskName: base.taskName || "",
+    instanceId: base.instanceId || null,
+    occurrenceId: base.occurrenceId || null,
+    eventId: base.eventId || base.occurrenceId || null,
+    dateISO: normalizeDateISO(base.dateISO || ""),
+    status: base.status || "unknown",
+    eventType: base.eventType || null,
+    instanceMode: base.instanceMode || null,
+    note: base.note != null ? String(base.note) : null,
+    hours: base.hours != null && Number.isFinite(Number(base.hours)) ? Number(base.hours) : null,
+    categoryRef: base.categoryRef || null,
+    inventoryRef: base.inventoryRef || null,
+    costRef: base.costRef ?? null,
+    linkRef: base.linkRef || null,
+    provenance: base.provenance && typeof base.provenance === "object" ? { ...base.provenance } : {}
+  };
+}
+
+function normalizeLegacyMaintenanceTask(task, mode){
+  if (!task || typeof task !== "object") return null;
+  const taskId = task.id != null ? String(task.id) : "";
+  if (!taskId) return null;
+  return createMaintenanceCompatibilityRow({
+    streamId: `legacy-task:${mode}:${taskId}`,
+    sourceSystem: "legacy",
+    taskId,
+    taskName: String(task.name || "").trim(),
+    instanceId: null,
+    occurrenceId: null,
+    dateISO: normalizeDateISO(task.calendarDateISO || task.nextDueISO || task.lastDoneISO || ""),
+    status: "task_definition",
+    instanceMode: mode === "asreq" ? "one_time" : "repeat",
+    note: null,
+    hours: null,
+    categoryRef: task.cat != null ? String(task.cat) : null,
+    inventoryRef: task.inventoryId != null ? String(task.inventoryId) : null,
+    costRef: task.price != null ? Number(task.price) : null,
+    linkRef: task.storeLink != null ? String(task.storeLink) : null,
+    provenance: {
+      taskMode: mode,
+      taskId,
+      sourceField: "tasksInterval/tasksAsReq"
+    }
+  });
+}
+
+function buildMaintenanceCompatibilityStream(){
+  const out = [];
+  const normalizeLegacyEvents = (task, mode)=>{
+    if (!task || typeof task !== "object") return;
+    const taskId = task.id != null ? String(task.id) : "";
+    if (!taskId) return;
+    const taskName = String(task.name || "").trim();
+    const instanceMode = mode === "asreq" ? "one_time" : "repeat";
+    const categoryRef = task.cat != null ? String(task.cat) : null;
+    const inventoryRef = task.inventoryId != null ? String(task.inventoryId) : null;
+    const costRef = task.price != null ? Number(task.price) : null;
+    const linkRef = task.storeLink != null ? String(task.storeLink) : null;
+    const instanceId = task.templateId != null ? String(task.templateId) : null;
+    const variant = task.variant != null ? String(task.variant) : null;
+    const common = { sourceSystem: "legacy", taskId, taskName, instanceMode, categoryRef, inventoryRef, costRef, linkRef, instanceId };
+    const pushEvent = (input)=> out.push(createMaintenanceCompatibilityRow({ ...common, ...input }));
+
+    if (task.calendarDateISO){
+      pushEvent({
+        streamId: `legacy-calendar:${mode}:${taskId}:${task.calendarDateISO}`,
+        status: "scheduled",
+        eventType: "scheduled",
+        dateISO: task.calendarDateISO,
+        provenance: { sourceField: "calendarDateISO", taskMode: mode, taskId, templateId: instanceId, variant }
+      });
+    }
+    (Array.isArray(task.completedDates) ? task.completedDates : []).forEach((date, idx)=>{
+      pushEvent({
+        streamId: `legacy-completed:${mode}:${taskId}:${idx}:${String(date)}`,
+        occurrenceId: `legacy-completed:${taskId}:${String(date)}:${idx}`,
+        status: "completed",
+        eventType: "completed",
+        dateISO: date,
+        provenance: { sourceField: "completedDates", index: idx, taskMode: mode, taskId, templateId: instanceId, variant }
+      });
+    });
+    (Array.isArray(task.manualHistory) ? task.manualHistory : []).forEach((entry, idx)=>{
+      const dateISO = entry && typeof entry === "object" ? (entry.dateISO || entry.date || entry.doneDateISO) : entry;
+      const note = entry && typeof entry === "object" ? (entry.note || entry.notes || null) : null;
+      const hours = entry && typeof entry === "object" ? (entry.hours ?? entry.timeHours ?? null) : null;
+      pushEvent({
+        streamId: `legacy-manual:${mode}:${taskId}:${idx}`,
+        occurrenceId: `legacy-manual:${taskId}:${idx}`,
+        status: "completed",
+        eventType: "manual_history",
+        dateISO,
+        note,
+        hours,
+        provenance: { sourceField: "manualHistory", index: idx, rawId: entry && entry.id != null ? String(entry.id) : null, taskMode: mode, taskId, templateId: instanceId, variant }
+      });
+    });
+    (Array.isArray(task.removedOccurrences) ? task.removedOccurrences : []).forEach((entry, idx)=>{
+      const dateISO = entry && typeof entry === "object" ? (entry.dateISO || entry.date || entry.when) : entry;
+      pushEvent({
+        streamId: `legacy-removed:${mode}:${taskId}:${idx}`,
+        occurrenceId: `legacy-removed:${taskId}:${idx}`,
+        status: "removed",
+        eventType: "removed",
+        dateISO,
+        provenance: { sourceField: "removedOccurrences", index: idx, taskMode: mode, taskId, templateId: instanceId, variant }
+      });
+    });
+    const notesMap = task.occurrenceNotes && typeof task.occurrenceNotes === "object" ? task.occurrenceNotes : {};
+    Object.entries(notesMap).forEach(([dateKey, note])=>{
+      pushEvent({
+        streamId: `legacy-note:${mode}:${taskId}:${dateKey}`,
+        occurrenceId: `legacy-note:${taskId}:${dateKey}`,
+        status: "annotated",
+        eventType: "note",
+        dateISO: dateKey,
+        note,
+        provenance: { sourceField: "occurrenceNotes", key: dateKey, taskMode: mode, taskId, templateId: instanceId, variant }
+      });
+    });
+    const hoursMap = task.occurrenceHours && typeof task.occurrenceHours === "object" ? task.occurrenceHours : {};
+    Object.entries(hoursMap).forEach(([dateKey, hours])=>{
+      pushEvent({
+        streamId: `legacy-hours:${mode}:${taskId}:${dateKey}`,
+        occurrenceId: `legacy-hours:${taskId}:${dateKey}`,
+        status: "annotated",
+        eventType: "hours",
+        dateISO: dateKey,
+        hours,
+        provenance: { sourceField: "occurrenceHours", key: dateKey, taskMode: mode, taskId, templateId: instanceId, variant }
+      });
+    });
+  };
+  const intervalList = Array.isArray(window.tasksInterval) ? window.tasksInterval : [];
+  const asReqList = Array.isArray(window.tasksAsReq) ? window.tasksAsReq : [];
+  intervalList.forEach(task => {
+    const row = normalizeLegacyMaintenanceTask(task, "interval");
+    if (row) out.push(row);
+    normalizeLegacyEvents(task, "interval");
+  });
+  asReqList.forEach(task => {
+    const row = normalizeLegacyMaintenanceTask(task, "asreq");
+    if (row) out.push(row);
+    normalizeLegacyEvents(task, "asreq");
+  });
+
+  const v2Tasks = Array.isArray(window.maintenanceTasksV2) ? window.maintenanceTasksV2 : [];
+  const v2Instances = Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2 : [];
+  const v2Occurrences = Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : [];
+  const taskMap = new Map();
+  v2Tasks.forEach(task => {
+    if (!task || typeof task !== "object") return;
+    const id = task.id != null ? String(task.id) : "";
+    if (!id) return;
+    taskMap.set(id, task);
+  });
+  const instanceMap = new Map();
+  v2Instances.forEach(instance => {
+    if (!instance || typeof instance !== "object") return;
+    const id = instance.id != null ? String(instance.id) : "";
+    if (!id) return;
+    instanceMap.set(id, instance);
+  });
+  v2Occurrences.forEach(event => {
+    if (!event || typeof event !== "object") return;
+    if (detectMaintenanceRecordSystem(event) !== "v2") return;
+    const occurrenceId = event.id != null ? String(event.id) : "";
+    const instanceId = event.instanceId != null ? String(event.instanceId) : "";
+    const inst = instanceMap.get(instanceId) || null;
+    const taskId = event.taskId != null ? String(event.taskId) : (inst && inst.taskId != null ? String(inst.taskId) : "");
+    const task = taskMap.get(taskId) || null;
+    out.push({
+      streamId: `v2-occurrence:${occurrenceId || `${instanceId}:unknown`}`,
+      sourceSystem: "v2",
+      taskId: taskId || null,
+      taskName: String(event.taskName || (task && task.name) || "").trim(),
+      instanceId: instanceId || null,
+      occurrenceId: occurrenceId || null,
+      dateISO: normalizeDateISO(event.effectiveDateISO || event.dateISO || event.completedAtISO || event.occurredAtISO || ""),
+      status: String(event.status || event.eventType || event.type || "unknown"),
+      eventType: event.eventType != null ? String(event.eventType) : (event.type != null ? String(event.type) : null),
+      instanceMode: inst && inst.instanceMode ? String(inst.instanceMode) : null,
+      note: event.note != null ? String(event.note) : (event.payload && event.payload.note != null ? String(event.payload.note) : null),
+      hours: event.hours != null && Number.isFinite(Number(event.hours)) ? Number(event.hours) : (event.payload && Number.isFinite(Number(event.payload.hours)) ? Number(event.payload.hours) : null),
+      categoryRef: task && task.folderId != null ? String(task.folderId) : null,
+      inventoryRef: task && task.inventoryId != null ? String(task.inventoryId) : null,
+      costRef: task && task.costProfileId != null ? String(task.costProfileId) : null,
+      linkRef: task && task.linkRef != null ? String(task.linkRef) : null,
+      provenance: {
+        taskId: taskId || null,
+        instanceId: instanceId || null,
+        occurrenceId: occurrenceId || null,
+        supersedesEventId: event.supersedesEventId != null ? String(event.supersedesEventId) : null,
+        recordedAtISO: event.recordedAtISO != null ? String(event.recordedAtISO) : null,
+        sourceField: "maintenanceOccurrencesV2",
+        taskRecordSystem: task ? detectMaintenanceRecordSystem(task) : null,
+        instanceRecordSystem: inst ? detectMaintenanceRecordSystem(inst) : null,
+        occurrenceRecordSystem: detectMaintenanceRecordSystem(event)
+      }
+    });
+  });
+  return out;
+}
+
+window.detectMaintenanceRecordSystem = detectMaintenanceRecordSystem;
+window.buildMaintenanceCompatibilityStream = buildMaintenanceCompatibilityStream;
 
 function ensureJobCategories(){
   const folders = Array.isArray(window.jobFolders) ? window.jobFolders : defaultJobFolders();
@@ -2852,6 +3102,9 @@ function adoptState(doc){
   opportunityRollups = Array.isArray(data.opportunityRollups) ? data.opportunityRollups : [];
   weeklyCostReports = Array.isArray(data.weeklyCostReports) ? data.weeklyCostReports.map(entry => ({ ...entry })) : [];
   receiptTrackerWeeks = Array.isArray(data.receiptTrackerWeeks) ? data.receiptTrackerWeeks.map(entry => ({ ...entry })) : [];
+  maintenanceTasksV2 = Array.isArray(data.maintenanceTasksV2) ? data.maintenanceTasksV2.map(entry => ({ ...entry })) : [];
+  maintenanceCalendarInstancesV2 = Array.isArray(data.maintenanceCalendarInstancesV2) ? data.maintenanceCalendarInstancesV2.map(entry => ({ ...entry })) : [];
+  maintenanceOccurrencesV2 = Array.isArray(data.maintenanceOccurrencesV2) ? data.maintenanceOccurrencesV2.map(entry => ({ ...entry })) : [];
   window.syncProcessLog = Array.isArray(data.syncProcessLog) ? data.syncProcessLog.map(entry => ({ ...entry })) : (Array.isArray(window.syncProcessLog) ? window.syncProcessLog : []);
 
   window.totalHistory = totalHistory;
@@ -2866,6 +3119,9 @@ function adoptState(doc){
   window.opportunityRollups = opportunityRollups;
   window.weeklyCostReports = weeklyCostReports;
   window.receiptTrackerWeeks = receiptTrackerWeeks;
+  window.maintenanceTasksV2 = maintenanceTasksV2;
+  window.maintenanceCalendarInstancesV2 = maintenanceCalendarInstancesV2;
+  window.maintenanceOccurrencesV2 = maintenanceOccurrencesV2;
   deletedItems = normalizeDeletedItems(Array.isArray(data.deletedItems) ? data.deletedItems : deletedItems);
   window.deletedItems = deletedItems;
   purgeExpiredDeletedItems();
@@ -2879,6 +3135,14 @@ function adoptState(doc){
     window.orderRequestTab = orderRequestTab || "active";
   }
   orderRequestTab = window.orderRequestTab;
+
+  if (window.DEBUG_MODE){
+    console.info("V2 maintenance storage ready", {
+      tasks: Array.isArray(window.maintenanceTasksV2) ? window.maintenanceTasksV2.length : 0,
+      instances: Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2.length : 0,
+      occurrences: Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2.length : 0
+    });
+  }
 
   const rawFolders = Array.isArray(data.settingsFolders)
     ? data.settingsFolders
@@ -3093,7 +3357,7 @@ function recordDataFlowEvent(trigger = "save", nextSnapshot = null){
     if (!Array.isArray(window.syncProcessLog)) window.syncProcessLog = [];
     const prev = window.__lastSnapshotForFlow && typeof window.__lastSnapshotForFlow === "object" ? window.__lastSnapshotForFlow : null;
     const next = nextSnapshot && typeof nextSnapshot === "object" ? nextSnapshot : null;
-    const trackedKeys = ["totalHistory", "tasksInterval", "tasksAsReq", "inventory", "inventoryFolders", "receiptTrackerWeeks", "orderRequests", "cuttingJobs", "completedCuttingJobs", "dailyCutHours", "garnetCleanings", "settingsFolders"];
+    const trackedKeys = ["totalHistory", "tasksInterval", "tasksAsReq", "inventory", "inventoryFolders", "receiptTrackerWeeks", "orderRequests", "cuttingJobs", "completedCuttingJobs", "dailyCutHours", "garnetCleanings", "maintenanceTasksV2", "maintenanceCalendarInstancesV2", "maintenanceOccurrencesV2", "settingsFolders"];
     const skipTrigger = /history|syncprocesslog|data_flow_save/i.test(String(trigger || ""));
     if (skipTrigger){
       if (next) window.__lastSnapshotForFlow = next;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -5301,6 +5301,9 @@ function renderDashboard(){
   const existingTaskEmpty  = taskExistingForm?.querySelector('[data-task-existing-empty]');
   const existingTaskSearchEmpty = taskExistingForm?.querySelector('[data-task-existing-search-empty]');
   const taskExistingNoteInput = document.getElementById("dashTaskExistingNote");
+  const taskExistingAddModeInput = document.getElementById("dashTaskExistingAddMode");
+  const taskExistingModeHint = document.getElementById("dashTaskExistingModeHint");
+  const taskExistingRepeatRows = Array.from(taskExistingForm?.querySelectorAll("[data-existing-repeat-row]") || []);
   const taskExistingRepeatInput = document.getElementById("dashTaskExistingRepeat");
   const taskExistingBasisInput = document.getElementById("dashTaskExistingRepeatBasis");
   const taskExistingEveryInput = document.getElementById("dashTaskExistingRepeatEvery");
@@ -5463,7 +5466,7 @@ function renderDashboard(){
     }
     if (taskExistingRepeatInput){
       taskExistingRepeatInput.value = task?.mode === "interval" ? "yes" : "no";
-      taskExistingRepeatInput.disabled = true;
+      taskExistingRepeatInput.disabled = false;
     }
     if (taskExistingEveryInput){
       taskExistingEveryInput.value = String(Math.max(1, Number(recurrence?.every) || 1));
@@ -5478,6 +5481,7 @@ function renderDashboard(){
       taskExistingEndCountInput.value = String(Math.max(1, Number(recurrence?.endCount) || 1));
     }
     toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
+    syncExistingAddModeUi();
   }
 
   function setTaskOptionPage(target){
@@ -5565,6 +5569,7 @@ function renderDashboard(){
   function resetExistingTaskForm(){
     if (taskExistingSearchInput) taskExistingSearchInput.value = "";
     if (taskExistingNoteInput) taskExistingNoteInput.value = "";
+    if (taskExistingAddModeInput) taskExistingAddModeInput.value = "one_time";
     if (taskExistingRepeatInput) taskExistingRepeatInput.value = "no";
     if (taskExistingRepeatInput) taskExistingRepeatInput.disabled = true;
     if (taskExistingBasisInput) taskExistingBasisInput.value = "calendar_day";
@@ -5573,6 +5578,45 @@ function renderDashboard(){
     if (taskExistingEndInput) taskExistingEndInput.value = "never";
     setSelectedExistingTask(null);
     refreshExistingTaskOptions("");
+    toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
+    syncExistingAddModeUi();
+  }
+
+  function syncExistingAddModeUi(){
+    const mode = String(taskExistingAddModeInput?.value || "one_time");
+    const showRepeat = mode === "repeat";
+    const selectedMeta = selectedExistingTaskId ? findMaintenanceTaskById(selectedExistingTaskId) : null;
+    const selectedMode = selectedMeta?.task?.mode === "interval" ? "interval" : "asreq";
+    const allowMachineHours = showRepeat && selectedMode === "interval";
+    taskExistingRepeatRows.forEach(row => { row.hidden = !showRepeat; });
+    if (taskExistingModeHint){
+      if (mode === "repeat"){
+        taskExistingModeHint.textContent = "Repeat tracking stores V2 repeat intent. Full repeat projection is coming later.";
+      }else if (mode === "past_log"){
+        taskExistingModeHint.textContent = "Past completion saves V2 history only and does not start future repeats.";
+      }else{
+        taskExistingModeHint.textContent = "One-time creates one scheduled V2 reminder on the selected date.";
+      }
+    }
+    if (taskExistingBasisInput){
+      const machineOpt = taskExistingBasisInput.querySelector('option[value=\"machine_hours\"]');
+      if (machineOpt){
+        machineOpt.disabled = !allowMachineHours;
+        machineOpt.textContent = allowMachineHours ? "By machine cutting hours (predicted)" : "By machine cutting hours (interval tasks only)";
+      }
+    }
+    if (!showRepeat){
+      if (taskExistingRepeatInput) taskExistingRepeatInput.value = "no";
+      if (taskExistingRepeatInput) taskExistingRepeatInput.disabled = true;
+      toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
+      return;
+    }
+    if (taskExistingRepeatInput) taskExistingRepeatInput.value = "yes";
+    if (taskExistingRepeatInput) taskExistingRepeatInput.disabled = false;
+    if (taskExistingBasisInput && taskExistingBasisInput.value === "machine_hours" && taskExistingBasisInput.querySelector('option[value=\"machine_hours\"]')?.disabled){
+      taskExistingBasisInput.value = "calendar_day";
+    }
+    if (taskExistingBasisInput) taskExistingBasisInput.disabled = false;
     toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
   }
 
@@ -6066,6 +6110,99 @@ function renderDashboard(){
     showStep(step);
   }
 
+  function ensureMaintenanceV2Collections(){
+    if (!Array.isArray(window.maintenanceTasksV2)) window.maintenanceTasksV2 = [];
+    if (!Array.isArray(window.maintenanceCalendarInstancesV2)) window.maintenanceCalendarInstancesV2 = [];
+    if (!Array.isArray(window.maintenanceOccurrencesV2)) window.maintenanceOccurrencesV2 = [];
+    return {
+      tasks: window.maintenanceTasksV2,
+      instances: window.maintenanceCalendarInstancesV2,
+      occurrences: window.maintenanceOccurrencesV2
+    };
+  }
+
+  function createMaintenanceV2FromTemplate(task, opts = {}){
+    if (!task || task.id == null) return null;
+    const collections = ensureMaintenanceV2Collections();
+    const mode = String(opts.mode || "one_time");
+    const eventType = String(opts.eventType || "scheduled");
+    const effectiveDateISO = normalizeDateKey(opts.effectiveDateISO || addContextDateISO || ymd(new Date()));
+    const nowISO = new Date().toISOString();
+    const legacyTaskId = String(task.id);
+    const existingTask = collections.tasks.find(entry => entry && String(entry.legacyTaskId || "") === legacyTaskId) || null;
+    const taskRecord = existingTask || {
+      id: genId("maintenance_task_v2"),
+      system: "v2",
+      schemaVersion: 2,
+      legacyTaskId,
+      name: task.name || "Maintenance task",
+      categoryRef: task.cat != null ? String(task.cat) : null,
+      inventoryId: task.inventoryId != null ? String(task.inventoryId) : null,
+      storeLink: task.storeLink || "",
+      manualLink: task.manualLink || "",
+      pn: task.pn || "",
+      price: task.price != null ? Number(task.price) : null,
+      createdAtISO: nowISO,
+      updatedAtISO: nowISO
+    };
+    if (!existingTask){
+      collections.tasks.unshift(taskRecord);
+    }else{
+      taskRecord.updatedAtISO = nowISO;
+    }
+    const instance = {
+      id: genId("maintenance_instance_v2"),
+      system: "v2",
+      schemaVersion: 2,
+      taskId: taskRecord.id,
+      legacyTaskId,
+      instanceMode: mode,
+      startDateISO: effectiveDateISO,
+      status: "active",
+      repeatRule: mode === "repeat" ? (opts.repeatRule || null) : null,
+      createdAtISO: nowISO,
+      updatedAtISO: nowISO
+    };
+    if (mode === "repeat" && instance.repeatRule && String(instance.repeatRule.basis || "") === "machine_hours"){
+      const currentHours = typeof getCurrentMachineHours === "function" ? Number(getCurrentMachineHours()) : null;
+      if (Number.isFinite(currentHours)){
+        instance.machineHourAnchorTotal = currentHours;
+        instance.machineHourAnchorDateISO = normalizeDateKey(effectiveDateISO || ymd(new Date()));
+      }
+      if (!Number.isFinite(Number(instance.repeatRule.intervalHours)) || Number(instance.repeatRule.intervalHours) <= 0){
+        instance.repeatRule.intervalHours = Math.max(1, Number(instance.repeatRule.every) || 1);
+      }
+    }
+    collections.instances.unshift(instance);
+    const occurrence = {
+      id: genId("maintenance_occurrence_v2"),
+      system: "v2",
+      schemaVersion: 2,
+      instanceId: instance.id,
+      taskId: taskRecord.id,
+      legacyTaskId,
+      eventType,
+      effectiveDateISO,
+      recordedAtISO: nowISO,
+      payload: {
+        note: opts.note || "",
+        hours: Number.isFinite(Number(opts.hours)) ? Number(opts.hours) : null
+      }
+    };
+    collections.occurrences.unshift(occurrence);
+    if (window.DEBUG_MODE){
+      console.info("[maintenance-v2] created records", {
+        legacyTaskId,
+        taskId: taskRecord.id,
+        instanceId: instance.id,
+        occurrenceId: occurrence.id,
+        instanceMode: mode,
+        eventType
+      });
+    }
+    return { taskRecord, instance, occurrence };
+  }
+
   function hideBackdrop(){
     if (!modal) return;
     modal.classList.remove("is-visible");
@@ -6336,6 +6473,7 @@ function renderDashboard(){
     if (taskExistingWeekdaysRow) taskExistingWeekdaysRow.hidden = !(taskExistingRepeatInput?.value === "yes" && weekly);
   });
   taskExistingEndInput?.addEventListener("change", ()=> toggleRepeatEndFields(taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput));
+  taskExistingAddModeInput?.addEventListener("change", syncExistingAddModeUi);
   syncTaskMode(taskTypeSelect?.value || "interval");
   toggleRepeatFields(taskRepeatInput, taskRepeatBasisInput, taskRepeatEveryInput, taskRepeatEndInput, taskRepeatEndDateInput, taskRepeatEndCountInput);
   toggleRepeatFields(taskExistingRepeatInput, taskExistingBasisInput, taskExistingEveryInput, taskExistingEndInput, taskExistingEndDateInput, taskExistingEndCountInput);
@@ -6604,40 +6742,69 @@ function renderDashboard(){
       endCountInput: taskExistingEndCountInput,
       defaultBasis: task.mode === "interval" ? "machine_hours" : "calendar_day"
     });
+    let choice = String(taskExistingAddModeInput?.value || "").trim();
+    if (!choice){
+      const choiceRaw = window.prompt(
+        "Temporary chooser fallback:\n1) One-time reminder\n2) Start repeat tracking\n3) Log past completion",
+        "1"
+      );
+      const mapped = { "1": "one_time", "2": "repeat", "3": "past_log" };
+      choice = mapped[String(choiceRaw || "").trim()] || "";
+    }
+    if (!choice || !["one_time", "repeat", "past_log"].includes(choice)){
+      toast("Add to calendar cancelled");
+      return;
+    }
     let message = "Maintenance task added";
-    if (task.mode === "interval"){
-      const instance = scheduleExistingIntervalTask(task, {
-        dateISO: targetISO,
-        note: occurrenceNote,
-        refreshDashboard: true,
-        recurrence: repeatConfig
-      }) || task;
-      const parsed = parseDateLocal(targetISO);
-      const todayMidnight = new Date(); todayMidnight.setHours(0,0,0,0);
-      let dateLabel = targetISO;
-      let completed = false;
-      if (parsed instanceof Date && !Number.isNaN(parsed.getTime())){
-        const display = new Date(parsed.getTime());
-        dateLabel = display.toLocaleDateString();
-        const compare = new Date(parsed.getTime());
-        compare.setHours(0,0,0,0);
-        completed = compare.getTime() <= todayMidnight.getTime();
+    if (choice === "one_time"){
+      createMaintenanceV2FromTemplate(task, {
+        mode: "one_time",
+        eventType: "scheduled",
+        effectiveDateISO: targetISO,
+        note: occurrenceNote
+      });
+      const targetDate = parseDateLocal(targetISO);
+      if (targetDate instanceof Date && !Number.isNaN(targetDate.getTime())){
+        const today = new Date();
+        today.setHours(0,0,0,0);
+        const diffMonths = (targetDate.getFullYear() - today.getFullYear()) * 12
+          + (targetDate.getMonth() - today.getMonth());
+        window.__calendarMonthOffset = Math.max(-12, Math.min(12, Math.round(diffMonths)));
       }
-      message = completed
-        ? `Logged "${instance.name || "Task"}" as completed on ${dateLabel}`
-        : `Scheduled "${instance.name || "Task"}" for ${dateLabel}`;
-    }else{
-      const instance = scheduleExistingAsReqTask(task, {
-        dateISO: targetISO,
+      message = `One-time reminder created for "${task.name || "Task"}"`;
+    }else if (choice === "repeat"){
+      const normalizedRepeatConfig = (repeatConfig && typeof repeatConfig === "object") ? { ...repeatConfig } : {};
+      normalizedRepeatConfig.enabled = true;
+      if (!normalizedRepeatConfig.basis) normalizedRepeatConfig.basis = "calendar_day";
+      if (normalizedRepeatConfig.basis === "machine_hours"){
+        const rawEvery = Number(taskExistingEveryInput?.value);
+        const configuredHours = Number.isFinite(rawEvery) && rawEvery > 0
+          ? rawEvery
+          : Number(normalizedRepeatConfig.intervalHours || normalizedRepeatConfig.every || 1);
+        normalizedRepeatConfig.intervalHours = Math.max(1, configuredHours);
+        normalizedRepeatConfig.every = normalizedRepeatConfig.intervalHours;
+      }
+      createMaintenanceV2FromTemplate(task, {
+        mode: "repeat",
+        eventType: "repeat_started",
+        effectiveDateISO: targetISO,
         note: occurrenceNote,
-        refreshDashboard: true,
-        recurrence: repeatConfig
-      }) || task;
-      message = "As-required task linked from Maintenance Settings";
+        repeatRule: normalizedRepeatConfig
+      });
+      message = `Repeat tracking started for "${task.name || "Task"}"`;
+    }else{
+      createMaintenanceV2FromTemplate(task, {
+        mode: "past_log",
+        eventType: "completed",
+        effectiveDateISO: targetISO,
+        note: occurrenceNote
+      });
+      message = `Past completion logged for "${task.name || "Task"}"`;
     }
     setContextDate(targetISO);
     if (typeof saveCloudNow === "function") saveCloudNow();
     else saveCloudDebounced();
+    if (typeof renderCalendar === "function") renderCalendar();
     toast(message);
     closeModal();
     if (typeof refreshDashboardWidgets === "function"){

--- a/js/views.js
+++ b/js/views.js
@@ -364,18 +364,24 @@ function viewDashboard(){
           <p class="small muted" data-task-existing-empty hidden>No maintenance tasks yet. Create one below to get started.</p>
           <p class="small muted" data-task-existing-search-empty hidden>No tasks match your search. Try a different name.</p>
           <label>Occurrence note<textarea id="dashTaskExistingNote" rows="3" placeholder="Optional note for this calendar date"></textarea></label>
-          <label>Repeat<select id="dashTaskExistingRepeat">
+          <label>Add mode<select id="dashTaskExistingAddMode">
+            <option value="one_time">One-time reminder</option>
+            <option value="repeat">Start repeat tracking</option>
+            <option value="past_log">Log past completion</option>
+          </select></label>
+          <p class="small muted" id="dashTaskExistingModeHint">One-time creates one scheduled V2 reminder on the selected date.</p>
+          <label data-existing-repeat-row>Repeat tracking<select id="dashTaskExistingRepeat">
             <option value="no">Does not repeat</option>
             <option value="yes">Repeats</option>
           </select></label>
-          <label>Repeat basis<select id="dashTaskExistingRepeatBasis">
+          <label data-existing-repeat-row>Repeat basis<select id="dashTaskExistingRepeatBasis">
             <option value="machine_hours">By machine cutting hours</option>
             <option value="calendar_day">By calendar day</option>
             <option value="calendar_week">By calendar week</option>
             <option value="calendar_month">By calendar month</option>
           </select></label>
-          <label>Repeat every<input type="number" min="1" step="1" id="dashTaskExistingRepeatEvery" value="1"></label>
-          <label>Repeat ends<select id="dashTaskExistingRepeatEnd">
+          <label data-existing-repeat-row>Repeat every<input type="number" min="1" step="1" id="dashTaskExistingRepeatEvery" value="1"></label>
+          <label data-existing-repeat-row>Repeat ends<select id="dashTaskExistingRepeatEnd">
             <option value="never">Never</option>
             <option value="on_date">On date</option>
             <option value="after_count">After count</option>


### PR DESCRIPTION
### Motivation
- Add a safe, non-destructive V2 maintenance model (task definitions, calendar instances, occurrence/event log) that can coexist with existing legacy task structures. 
- Surface V2 one-time reminders and repeat tracking in the calendar UI without migrating or mutating legacy `tasksInterval`/`tasksAsReq` records. 
- Provide a normalized compatibility stream so calendar and reporting can unify legacy and V2 records at read time.

### Description
- Added design doc `docs/maintenance-compat-audit.md` describing the hybrid V2 data model and rollout strategy. 
- Introduced V2 client-side storage arrays `maintenanceTasksV2`, `maintenanceCalendarInstancesV2`, and `maintenanceOccurrencesV2` and wired them into snapshot/save/load (`snapshotState`, `adoptState`, `snapshotJobFolders`, `refreshGlobalCollections`, `snapshotState`, etc.).
- Implemented a compatibility adapter: `detectMaintenanceRecordSystem`, `createMaintenanceCompatibilityRow`, and `buildMaintenanceCompatibilityStream` to normalize legacy and V2 records into a single stream for calendar/reporting consumption.
- Integrated V2 occurrences into calendar rendering (`renderCalendar`) including projection for repeats, per-occurrence resolution (`resolveV2OneTimeOccurrenceState`, `resolveV2RepeatOccurrenceState`), event appenders (`appendV2OccurrenceEvent`, `appendV2RepeatEvent`), and a lookup `window.__calendarV2OneTimeLookup` for UI interactions.
- Added interactive UI for V2 items: `showV2OneTimeBubble`, `openV2OneTimePanel`, `openV2RepeatPanel`, `createMaintenanceV2FromTemplate`, and related `window.*` helper functions (`completeV2OneTimeOccurrence`, `uncompleteV2OneTimeOccurrence`, `setV2OneTimeOccurrenceNote`, `setV2OneTimeOccurrenceHours`, `removeV2OneTimeOccurrence`, `stopV2RepeatTracking`, etc.).
- Dashboard task picker updated to allow adding existing maintenance tasks as V2 `one_time`, `repeat`, or `past_log` via the new `dashTaskExistingAddMode` UI and `taskExistingAddModeInput` handling.
- Extended data-flow tracking to include the new V2 collections in `recordDataFlowEvent` tracked keys and added debug logging when V2 storage is adopted.

### Testing
- No automated tests were added or executed as part of this change; the repository did not include an automated test run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcba07af2083259f7b70eec4b91854)