### PR TITLE
Preserve scroll on calendar re-render, normalize job inputs, and skip cloud saves on Vercel preview hosts

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -3,6 +3,22 @@ let bubbleTimer = null;
 const CALENDAR_DAY_MS = 24 * 60 * 60 * 1000;
 let calendarHoursEditing = false;
 let calendarHoursPending = new Map();
+function rerenderCalendarKeepScroll(){
+  if (typeof renderCalendar !== "function") return;
+  const scrollX = typeof window !== "undefined" ? window.scrollX : 0;
+  const scrollY = typeof window !== "undefined" ? window.scrollY : 0;
+  renderCalendar();
+  if (typeof window !== "undefined" && typeof window.scrollTo === "function"){
+    window.scrollTo(scrollX, scrollY);
+  }
+}
+
+function normalizeJobList(source){
+  if (Array.isArray(source)) return source.filter(Boolean);
+  if (source && typeof source === "object") return Object.values(source).filter(Boolean);
+  return [];
+}
+
 if (typeof window !== "undefined"){
   if (typeof window.__calendarShowAllMonths !== "boolean"){
     window.__calendarShowAllMonths = true;
@@ -79,7 +95,7 @@ function startCalendarHoursEditing(){
   if (calendarHoursEditing) return false;
   calendarHoursEditing = true;
   calendarHoursPending = new Map();
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof updateCalendarHoursControls === "function") updateCalendarHoursControls();
   return true;
 }
@@ -88,7 +104,7 @@ function cancelCalendarHoursEditing(){
   if (!calendarHoursEditing) return false;
   calendarHoursEditing = false;
   calendarHoursPending = new Map();
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof updateCalendarHoursControls === "function") updateCalendarHoursControls();
   return true;
 }
@@ -110,7 +126,7 @@ function commitCalendarHoursEditing(){
   calendarHoursPending = new Map();
   calendarHoursEditing = false;
   if (changed && typeof saveCloudDebounced === "function") saveCloudDebounced();
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof updateCalendarHoursControls === "function") updateCalendarHoursControls();
   if (changed){
     if (typeof refreshDerivedDailyHours === "function") refreshDerivedDailyHours();
@@ -149,7 +165,7 @@ function promptCalendarDayHours(dateISO){
   }
   const updated = setCalendarPendingHours(key, next);
   if (updated){
-    renderCalendar();
+    rerenderCalendarKeepScroll();
   }
   return updated;
 }
@@ -1099,7 +1115,7 @@ function completeTask(taskId){
     if (typeof saveCloudNow === "function") saveCloudNow();
     else saveCloudDebounced();
     toast("Task completed");
-    route();
+    rerenderCalendarKeepScroll();
   }
 }
 
@@ -1221,7 +1237,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast((Number.isFinite(parsed) && parsed > 0) ? "Occurrence time saved" : "Occurrence time removed");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1236,7 +1252,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast((next || "").trim() ? "Occurrence note saved" : "Occurrence note removed");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1247,7 +1263,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast("Task marked complete");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1258,7 +1274,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast("Completion removed");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1281,7 +1297,7 @@ function showTaskBubble(taskId, anchor, options = {}){
           : "Removed from calendar";
       toast(toastMessage);
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   };
   b.querySelector("[data-bbl-remove-single]")?.addEventListener("click", ()=> runRemoveScope("single"));
@@ -1308,7 +1324,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast("Task removed");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1350,7 +1366,7 @@ function showJobBubble(jobId, anchor){
   };
   try{
     const active = cuttingJobs.find(x => String(x.id) === String(jobId));
-    const completedJobs = Array.isArray(window.completedCuttingJobs) ? window.completedCuttingJobs : [];
+    const completedJobs = normalizeJobList(window.completedCuttingJobs);
     const completed = completedJobs.find(x => String(x?.id) === String(jobId));
     const prioritySchedule = typeof computePrioritySchedule === "function"
       ? computePrioritySchedule(cuttingJobs)
@@ -1534,7 +1550,7 @@ function showJobBubble(jobId, anchor){
       saveCloudDebounced();
       toast("Job marked complete");
       hideBubble();
-      renderCalendar();
+      rerenderCalendarKeepScroll();
       if (typeof window.location === "object" && window.location.hash === "#/jobs" && typeof renderJobs === "function"){
         renderJobs();
       }
@@ -1563,7 +1579,7 @@ function toggleGarnetComplete(id){
   entry.completed = !entry.completed;
   saveCloudDebounced();
   toast(entry.completed ? "Garnet cleaning completed" : "Marked as scheduled");
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof window.__dashRefreshGarnetList === "function") window.__dashRefreshGarnetList();
 }
 
@@ -1579,7 +1595,7 @@ function removeGarnetEntry(id){
   entries.splice(idx,1);
   saveCloudDebounced();
   toast("Garnet cleaning removed");
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof window.__dashRefreshGarnetList === "function") window.__dashRefreshGarnetList();
 }
 
@@ -2368,22 +2384,54 @@ function renderCalendar(){
   });
 
   const jobsMap = {};
-  cuttingJobs.forEach(j => {
-    const start = parseDateLocal(j.startISO);
-    const end   = parseDateLocal(j.dueISO);
+  const activeJobs = normalizeJobList(
+    Array.isArray(window.cuttingJobs) || (window.cuttingJobs && typeof window.cuttingJobs === "object")
+      ? window.cuttingJobs
+      : ((typeof cuttingJobs !== "undefined") ? cuttingJobs : [])
+  );
+  const resolveJobRange = (job)=>{
+    if (!job || typeof job !== "object") return { start:null, end:null };
+    const startCandidate = job.startISO ?? job.startDate ?? job.start ?? job.startAtISO ?? job.start_at ?? job.createdAt ?? null;
+    const endCandidate = job.dueISO ?? job.dueDate ?? job.endISO ?? job.endDate ?? job.end ?? job.completedAtISO ?? job.completedAt ?? null;
+    const start = parseDateLocal(startCandidate);
+    const end = parseDateLocal(endCandidate);
+    if (start && end) return { start, end };
+    if (start && !end) return { start, end: new Date(start.getTime()) };
+    if (!start && end) return { start: new Date(end.getTime()), end };
+    return { start:null, end:null };
+  };
+  activeJobs.forEach(j => {
+    const { start, end } = resolveJobRange(j);
     if (!start || !end) return;
-    start.setHours(0,0,0,0); end.setHours(0,0,0,0);
-    const cur = new Date(start.getTime());
-    while (cur <= end){
+    start.setHours(0,0,0,0);
+    end.setHours(0,0,0,0);
+    const from = start.getTime() <= end.getTime() ? start : end;
+    const to = start.getTime() <= end.getTime() ? end : start;
+    const cur = new Date(from.getTime());
+    while (cur <= to){
       const key = ymd(cur);
       (jobsMap[key] ||= []).push({ type:"job", id:String(j.id), name:j.name, status:"active", cat:j.cat });
       cur.setDate(cur.getDate()+1);
     }
   });
 
-  const completedJobs = Array.isArray(window.completedCuttingJobs) ? window.completedCuttingJobs : [];
+  const completedJobs = normalizeJobList(window.completedCuttingJobs);
   completedJobs.forEach(job => {
     if (!job) return;
+    const { start, end } = resolveJobRange(job);
+    if (start && end){
+      start.setHours(0,0,0,0);
+      end.setHours(0,0,0,0);
+      const from = start.getTime() <= end.getTime() ? start : end;
+      const to = start.getTime() <= end.getTime() ? end : start;
+      const cur = new Date(from.getTime());
+      while (cur <= to){
+        const key = ymd(cur);
+        (jobsMap[key] ||= []).push({ type:"job", id:String(job.id), name:job.name, status:"completed", cat:job.cat });
+        cur.setDate(cur.getDate()+1);
+      }
+      return;
+    }
     const completionKey = job.completedAtISO ? ymd(job.completedAtISO) : (job.dueISO ? ymd(job.dueISO) : null);
     if (!completionKey) return;
     (jobsMap[completionKey] ||= []).push({ type:"job", id:String(job.id), name:job.name, status:"completed", cat:job.cat });
@@ -2675,19 +2723,19 @@ function shiftCalendarMonthOffset(delta){
   const next = Math.min(12, Math.max(-12, Math.round(current + delta)));
   if (next === current) return false;
   window.__calendarMonthOffset = next;
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   return true;
 }
 
 function resetCalendarMonthOffset(){
   if ((Number(window.__calendarMonthOffset) || 0) === 0) return false;
   window.__calendarMonthOffset = 0;
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   return true;
 }
 
 function toggleCalendarShowAllMonths(){
   const next = !Boolean(window.__calendarShowAllMonths);
   window.__calendarShowAllMonths = next;
-  renderCalendar();
+  rerenderCalendarKeepScroll();
 }

--- a/js/core.js
+++ b/js/core.js
@@ -3270,7 +3270,8 @@ function getTrackedStateSignature(snapshot){
 }
 function saveCloudDebounced(){
   if (isVercelPreviewRuntime()){
-    console.warn("Cloud save skipped: previewReadonly=1 on a Vercel preview deployment host.");
+    const host = (typeof window !== "undefined" && window.location) ? String(window.location.hostname || "") : "";
+    console.warn(`Cloud save skipped: previewReadonly=1 on preview host (${host}) for workspace ${WORKSPACE_ID}.`);
     return;
   }
   hasPendingLocalChanges = true;
@@ -3289,7 +3290,8 @@ function saveCloudDebounced(){
 }
 function saveCloudNow(){
   if (isVercelPreviewRuntime()){
-    console.warn("Cloud save skipped: previewReadonly=1 on a Vercel preview deployment host.");
+    const host = (typeof window !== "undefined" && window.location) ? String(window.location.hostname || "") : "";
+    console.warn(`Cloud save skipped: previewReadonly=1 on preview host (${host}) for workspace ${WORKSPACE_ID}.`);
     return;
   }
   hasPendingLocalChanges = true;

--- a/js/core.js
+++ b/js/core.js
@@ -28,7 +28,13 @@ const WORKSPACE_ID = (() => {
 function isVercelPreviewRuntime(){
   if (typeof window === "undefined" || !window.location) return false;
   const params = new URLSearchParams(window.location.search || "");
-  return params.get("previewReadonly") === "1";
+  const readonlyFlag = params.get("previewReadonly") === "1";
+  if (!readonlyFlag) return false;
+  const host = String(window.location.hostname || "").toLowerCase();
+  if (!(host.endsWith(".vercel.app") || host === "vercel.app")) return false;
+  const subdomain = host.split(".")[0] || "";
+  const isPreviewHost = subdomain.includes("-git-") || subdomain.includes("---");
+  return isPreviewHost;
 }
 
 if (typeof window !== "undefined") {
@@ -3263,7 +3269,10 @@ function getTrackedStateSignature(snapshot){
   return stableStringify(normalized);
 }
 function saveCloudDebounced(){
-  if (isVercelPreviewRuntime()) return;
+  if (isVercelPreviewRuntime()){
+    console.warn("Cloud save skipped: previewReadonly=1 on a Vercel preview deployment host.");
+    return;
+  }
   hasPendingLocalChanges = true;
   lastLocalMutationAt = Date.now();
   try {
@@ -3279,7 +3288,10 @@ function saveCloudDebounced(){
   saveCloudInternal();
 }
 function saveCloudNow(){
-  if (isVercelPreviewRuntime()) return;
+  if (isVercelPreviewRuntime()){
+    console.warn("Cloud save skipped: previewReadonly=1 on a Vercel preview deployment host.");
+    return;
+  }
   hasPendingLocalChanges = true;
   lastLocalMutationAt = Date.now();
   try {

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -898,6 +898,16 @@ if (typeof window !== "undefined"){
   window.recurrenceSummaryLabel = recurrenceSummaryLabel;
 }
 
+function renderCalendarPreservingScroll(){
+  if (typeof renderCalendar !== "function") return;
+  const scrollX = typeof window !== "undefined" ? window.scrollX : 0;
+  const scrollY = typeof window !== "undefined" ? window.scrollY : 0;
+  renderCalendar();
+  if (typeof window !== "undefined" && typeof window.scrollTo === "function"){
+    window.scrollTo(scrollX, scrollY);
+  }
+}
+
 function editingCompletedJobsSet(){
   if (typeof getEditingCompletedJobsSet === "function"){
     return getEditingCompletedJobsSet();
@@ -3009,7 +3019,7 @@ function applyConfigurationForm(){
   }
   if (typeof saveCloudDebounced === "function") saveCloudDebounced();
   if (typeof refreshTimeEfficiencyWidgets === "function") refreshTimeEfficiencyWidgets();
-  if (typeof renderCalendar === "function") renderCalendar();
+  renderCalendarPreservingScroll();
   if (typeof renderDashboard === "function") renderDashboard();
   if (typeof renderJobs === "function") renderJobs();
   if (typeof renderCosts === "function") renderCosts();
@@ -5208,7 +5218,7 @@ function renderDashboard(){
       if (location.hash !== "#/"){
         location.hash = "#/";
       }
-      if (typeof renderCalendar === "function") renderCalendar();
+      renderCalendarPreservingScroll();
       const months = document.getElementById("months");
       const cell = dueISO ? months?.querySelector(`[data-date-iso="${dueISO}"]`) : null;
       if (cell){
@@ -6533,6 +6543,7 @@ function renderDashboard(){
     if (typeof refreshDashboardWidgets === "function"){
       refreshDashboardWidgets({ full: true });
     }
+    renderCalendarPreservingScroll();
     const hash = (location.hash || "#").toLowerCase();
     if (hash.startsWith("#/costs")){
       renderCosts();
@@ -6569,6 +6580,7 @@ function renderDashboard(){
     const list = Array.isArray(window.tasksAsReq) ? window.tasksAsReq : (window.tasksAsReq = []);
     list.unshift(task);
     setContextDate(targetISO);
+    renderCalendarPreservingScroll();
     if (typeof saveCloudNow === "function") saveCloudNow();
     else saveCloudDebounced();
     toast("One-time task added to the calendar");
@@ -6576,6 +6588,7 @@ function renderDashboard(){
     if (typeof refreshDashboardWidgets === "function"){
       refreshDashboardWidgets({ full: true });
     }
+    renderCalendarPreservingScroll();
     const hash = (location.hash || "#").toLowerCase();
     if (hash.startsWith("#/costs")){
       renderCosts();
@@ -6636,6 +6649,7 @@ function renderDashboard(){
       message = "As-required task linked from Maintenance Settings";
     }
     setContextDate(targetISO);
+    renderCalendarPreservingScroll();
     if (typeof saveCloudNow === "function") saveCloudNow();
     else saveCloudDebounced();
     toast(message);
@@ -6643,6 +6657,7 @@ function renderDashboard(){
     if (typeof refreshDashboardWidgets === "function"){
       refreshDashboardWidgets({ full: true });
     }
+    renderCalendarPreservingScroll();
     const hash = (location.hash || "#").toLowerCase();
     if (hash.startsWith("#/costs")){
       renderCosts();
@@ -6741,6 +6756,7 @@ function renderDashboard(){
     updateDashJobCategoryHint();
     window.jobCategoryFilter = previousCategoryFilter;
     saveCloudDebounced();
+    renderCalendarPreservingScroll();
     toast("Cutting job added");
     closeModal();
     renderDashboard();
@@ -10086,7 +10102,7 @@ function renderSettings(){
       updateTaskFieldRelevance(holder);
       if (typeof refreshDashboardWidgets === "function") refreshDashboardWidgets({ full: true });
       persist();
-      if (typeof renderCalendar === "function") renderCalendar();
+      renderCalendarPreservingScroll();
       return;
     }
     if (selectKey === "mode"){
@@ -11104,7 +11120,7 @@ function renderCosts(){
     if (typeof hideBubble === "function") hideBubble();
     location.hash = "#/";
     const runFocus = ()=>{
-      if (typeof renderCalendar === "function") renderCalendar();
+      renderCalendarPreservingScroll();
       const months = document.getElementById("months");
       const cell = dueISO ? months?.querySelector(`[data-date-iso="${dueISO}"]`) : null;
       if (!cell) return false;
@@ -11139,7 +11155,7 @@ function renderCosts(){
     if (typeof hideBubble === "function") hideBubble();
     location.hash = "#/";
     const runFocus = ()=>{
-      if (typeof renderCalendar === "function") renderCalendar();
+      renderCalendarPreservingScroll();
       const months = document.getElementById("months");
       const cell = dueISO ? months?.querySelector(`[data-date-iso="${dueISO}"]`) : null;
       if (!cell) return false;
@@ -19856,6 +19872,7 @@ function renderJobs(){
     window.jobAddDraft = {};
     window.jobCategoryFilter = previousCategoryFilter;
     persistJobChanges();
+    renderCalendarPreservingScroll();
     renderJobs();
   });
 
@@ -20185,6 +20202,7 @@ function renderJobs(){
       reorderPriorities(newJob.id, newJob.priority);
       window.cuttingJobs = cuttingJobs;
       saveCloudDebounced();
+      renderCalendarPreservingScroll();
       toast("Active cutting job created");
       renderJobs();
       return;


### PR DESCRIPTION
### Motivation
- Avoid losing the user's scroll position when the calendar is re-rendered after interactions. 
- Make calendar job handling robust against varying job object shapes and different list formats. 
- Prevent accidental cloud writes from read-only Vercel preview deployments.

### Description
- Added `rerenderCalendarKeepScroll` in `js/calendar.js` and `renderCalendarPreservingScroll` in `js/renderers.js` to capture and restore window scroll while re-rendering the calendar, and replaced numerous direct `renderCalendar()` calls with the preserving variants. 
- Added `normalizeJobList` helper and a `resolveJobRange` flow in `js/calendar.js` to accept arrays or objects for job lists and to derive start/end dates from multiple possible job fields, and updated active/completed job mapping to use these helpers. 
- Reworked job iteration to correctly handle start/end ordering and to mark multi-day spans into `jobsMap` with `status` set to `active` or `completed`. 
- Hardened preview-detection in `js/core.js` via `isVercelPreviewRuntime()` to ensure the `previewReadonly` flag is honored only on Vercel preview hosts, and made `saveCloudDebounced()` and `saveCloudNow()` no-op with a console warning when running in that read-only preview mode.

### Testing
- Ran `npm run lint` and `npm run build` locally; both completed without errors. 
- Verified that calendar re-renders no longer jump scroll position via the dev build (smoke checks in browser).
- No new unit tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0487c79530832583b6cb15553f4dfc)