### PR TITLE
Preserve calendar scroll on re-renders; normalize jobs/dates; safer cloud saves/backups

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -3,6 +3,22 @@ let bubbleTimer = null;
 const CALENDAR_DAY_MS = 24 * 60 * 60 * 1000;
 let calendarHoursEditing = false;
 let calendarHoursPending = new Map();
+function rerenderCalendarKeepScroll(){
+  if (typeof renderCalendar !== "function") return;
+  const scrollX = typeof window !== "undefined" ? window.scrollX : 0;
+  const scrollY = typeof window !== "undefined" ? window.scrollY : 0;
+  renderCalendar();
+  if (typeof window !== "undefined" && typeof window.scrollTo === "function"){
+    window.scrollTo(scrollX, scrollY);
+  }
+}
+
+function normalizeJobList(source){
+  if (Array.isArray(source)) return source.filter(Boolean);
+  if (source && typeof source === "object") return Object.values(source).filter(Boolean);
+  return [];
+}
+
 if (typeof window !== "undefined"){
   if (typeof window.__calendarShowAllMonths !== "boolean"){
     window.__calendarShowAllMonths = true;
@@ -79,7 +95,7 @@ function startCalendarHoursEditing(){
   if (calendarHoursEditing) return false;
   calendarHoursEditing = true;
   calendarHoursPending = new Map();
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof updateCalendarHoursControls === "function") updateCalendarHoursControls();
   return true;
 }
@@ -88,7 +104,7 @@ function cancelCalendarHoursEditing(){
   if (!calendarHoursEditing) return false;
   calendarHoursEditing = false;
   calendarHoursPending = new Map();
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof updateCalendarHoursControls === "function") updateCalendarHoursControls();
   return true;
 }
@@ -110,7 +126,7 @@ function commitCalendarHoursEditing(){
   calendarHoursPending = new Map();
   calendarHoursEditing = false;
   if (changed && typeof saveCloudDebounced === "function") saveCloudDebounced();
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof updateCalendarHoursControls === "function") updateCalendarHoursControls();
   if (changed){
     if (typeof refreshDerivedDailyHours === "function") refreshDerivedDailyHours();
@@ -149,7 +165,7 @@ function promptCalendarDayHours(dateISO){
   }
   const updated = setCalendarPendingHours(key, next);
   if (updated){
-    renderCalendar();
+    rerenderCalendarKeepScroll();
   }
   return updated;
 }
@@ -1099,7 +1115,7 @@ function completeTask(taskId){
     if (typeof saveCloudNow === "function") saveCloudNow();
     else saveCloudDebounced();
     toast("Task completed");
-    route();
+    rerenderCalendarKeepScroll();
   }
 }
 
@@ -1221,7 +1237,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast((Number.isFinite(parsed) && parsed > 0) ? "Occurrence time saved" : "Occurrence time removed");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1236,7 +1252,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast((next || "").trim() ? "Occurrence note saved" : "Occurrence note removed");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1247,7 +1263,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast("Task marked complete");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1258,7 +1274,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast("Completion removed");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1281,7 +1297,7 @@ function showTaskBubble(taskId, anchor, options = {}){
           : "Removed from calendar";
       toast(toastMessage);
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   };
   b.querySelector("[data-bbl-remove-single]")?.addEventListener("click", ()=> runRemoveScope("single"));
@@ -1308,7 +1324,7 @@ function showTaskBubble(taskId, anchor, options = {}){
       else saveCloudDebounced();
       toast("Task removed");
       hideBubble();
-      route();
+      rerenderCalendarKeepScroll();
     }
   });
 
@@ -1350,7 +1366,7 @@ function showJobBubble(jobId, anchor){
   };
   try{
     const active = cuttingJobs.find(x => String(x.id) === String(jobId));
-    const completedJobs = Array.isArray(window.completedCuttingJobs) ? window.completedCuttingJobs : [];
+    const completedJobs = normalizeJobList(window.completedCuttingJobs);
     const completed = completedJobs.find(x => String(x?.id) === String(jobId));
     const prioritySchedule = typeof computePrioritySchedule === "function"
       ? computePrioritySchedule(cuttingJobs)
@@ -1534,7 +1550,7 @@ function showJobBubble(jobId, anchor){
       saveCloudDebounced();
       toast("Job marked complete");
       hideBubble();
-      renderCalendar();
+      rerenderCalendarKeepScroll();
       if (typeof window.location === "object" && window.location.hash === "#/jobs" && typeof renderJobs === "function"){
         renderJobs();
       }
@@ -1563,7 +1579,7 @@ function toggleGarnetComplete(id){
   entry.completed = !entry.completed;
   saveCloudDebounced();
   toast(entry.completed ? "Garnet cleaning completed" : "Marked as scheduled");
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof window.__dashRefreshGarnetList === "function") window.__dashRefreshGarnetList();
 }
 
@@ -1579,7 +1595,7 @@ function removeGarnetEntry(id){
   entries.splice(idx,1);
   saveCloudDebounced();
   toast("Garnet cleaning removed");
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   if (typeof window.__dashRefreshGarnetList === "function") window.__dashRefreshGarnetList();
 }
 
@@ -2368,22 +2384,54 @@ function renderCalendar(){
   });
 
   const jobsMap = {};
-  cuttingJobs.forEach(j => {
-    const start = parseDateLocal(j.startISO);
-    const end   = parseDateLocal(j.dueISO);
+  const activeJobs = normalizeJobList(
+    Array.isArray(window.cuttingJobs) || (window.cuttingJobs && typeof window.cuttingJobs === "object")
+      ? window.cuttingJobs
+      : ((typeof cuttingJobs !== "undefined") ? cuttingJobs : [])
+  );
+  const resolveJobRange = (job)=>{
+    if (!job || typeof job !== "object") return { start:null, end:null };
+    const startCandidate = job.startISO ?? job.startDate ?? job.start ?? job.startAtISO ?? job.start_at ?? job.createdAt ?? null;
+    const endCandidate = job.dueISO ?? job.dueDate ?? job.endISO ?? job.endDate ?? job.end ?? job.completedAtISO ?? job.completedAt ?? null;
+    const start = parseDateLocal(startCandidate);
+    const end = parseDateLocal(endCandidate);
+    if (start && end) return { start, end };
+    if (start && !end) return { start, end: new Date(start.getTime()) };
+    if (!start && end) return { start: new Date(end.getTime()), end };
+    return { start:null, end:null };
+  };
+  activeJobs.forEach(j => {
+    const { start, end } = resolveJobRange(j);
     if (!start || !end) return;
-    start.setHours(0,0,0,0); end.setHours(0,0,0,0);
-    const cur = new Date(start.getTime());
-    while (cur <= end){
+    start.setHours(0,0,0,0);
+    end.setHours(0,0,0,0);
+    const from = start.getTime() <= end.getTime() ? start : end;
+    const to = start.getTime() <= end.getTime() ? end : start;
+    const cur = new Date(from.getTime());
+    while (cur <= to){
       const key = ymd(cur);
       (jobsMap[key] ||= []).push({ type:"job", id:String(j.id), name:j.name, status:"active", cat:j.cat });
       cur.setDate(cur.getDate()+1);
     }
   });
 
-  const completedJobs = Array.isArray(window.completedCuttingJobs) ? window.completedCuttingJobs : [];
+  const completedJobs = normalizeJobList(window.completedCuttingJobs);
   completedJobs.forEach(job => {
     if (!job) return;
+    const { start, end } = resolveJobRange(job);
+    if (start && end){
+      start.setHours(0,0,0,0);
+      end.setHours(0,0,0,0);
+      const from = start.getTime() <= end.getTime() ? start : end;
+      const to = start.getTime() <= end.getTime() ? end : start;
+      const cur = new Date(from.getTime());
+      while (cur <= to){
+        const key = ymd(cur);
+        (jobsMap[key] ||= []).push({ type:"job", id:String(job.id), name:job.name, status:"completed", cat:job.cat });
+        cur.setDate(cur.getDate()+1);
+      }
+      return;
+    }
     const completionKey = job.completedAtISO ? ymd(job.completedAtISO) : (job.dueISO ? ymd(job.dueISO) : null);
     if (!completionKey) return;
     (jobsMap[completionKey] ||= []).push({ type:"job", id:String(job.id), name:job.name, status:"completed", cat:job.cat });
@@ -2675,19 +2723,19 @@ function shiftCalendarMonthOffset(delta){
   const next = Math.min(12, Math.max(-12, Math.round(current + delta)));
   if (next === current) return false;
   window.__calendarMonthOffset = next;
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   return true;
 }
 
 function resetCalendarMonthOffset(){
   if ((Number(window.__calendarMonthOffset) || 0) === 0) return false;
   window.__calendarMonthOffset = 0;
-  renderCalendar();
+  rerenderCalendarKeepScroll();
   return true;
 }
 
 function toggleCalendarShowAllMonths(){
   const next = !Boolean(window.__calendarShowAllMonths);
   window.__calendarShowAllMonths = next;
-  renderCalendar();
+  rerenderCalendarKeepScroll();
 }

--- a/js/core.js
+++ b/js/core.js
@@ -28,7 +28,13 @@ const WORKSPACE_ID = (() => {
 function isVercelPreviewRuntime(){
   if (typeof window === "undefined" || !window.location) return false;
   const params = new URLSearchParams(window.location.search || "");
-  return params.get("previewReadonly") === "1";
+  const readonlyFlag = params.get("previewReadonly") === "1";
+  if (!readonlyFlag) return false;
+  const host = String(window.location.hostname || "").toLowerCase();
+  if (!(host.endsWith(".vercel.app") || host === "vercel.app")) return false;
+  const subdomain = host.split(".")[0] || "";
+  const isPreviewHost = subdomain.includes("-git-") || subdomain.includes("---");
+  return isPreviewHost;
 }
 
 if (typeof window !== "undefined") {
@@ -528,12 +534,69 @@ const CLOUD_SYNC_CLIENT_KEY = "cloud_sync_client_id_v1";
 const LOCAL_STATE_BACKUP_KEY = "omax_local_state_backup_v1";
 
 
+const FIRESTORE_WARN_BYTES = 900000;
+const FIRESTORE_BLOCK_BYTES = 1000000;
+const SAVE_LOG_THROTTLE_MS = 30000;
+let lastSaveLogWriteAt = 0;
+
+function estimatePayloadBytes(payload){
+  try {
+    const json = JSON.stringify(payload || {});
+    if (typeof TextEncoder !== "undefined") return new TextEncoder().encode(json).length;
+    return new Blob([json]).size;
+  } catch (_err){
+    return Number.MAX_SAFE_INTEGER;
+  }
+}
+
+function compactStateForStorage(raw, { forBackup = false } = {}){
+  const snap = raw && typeof raw === "object" ? { ...raw } : {};
+  // Safe-to-trim fields: operational/debug/save logs that can grow unbounded.
+  delete snap.syncProcessLog;
+  delete snap.__lastSnapshot;
+  delete snap.__lastSnapshotForFlow;
+  delete snap.__lastDataFlowFingerprint;
+  if (forBackup){
+    delete snap.deletedItems;
+    delete snap.opportunityRollups;
+    delete snap.weeklyCostReports;
+  }
+  return snap;
+}
+
+function buildEmergencyBackup(snapshot){
+  const src = snapshot && typeof snapshot === "object" ? snapshot : {};
+  return {
+    schema: src.schema || APP_SCHEMA,
+    tasksInterval: Array.isArray(src.tasksInterval) ? src.tasksInterval : [],
+    tasksAsReq: Array.isArray(src.tasksAsReq) ? src.tasksAsReq : [],
+    inventory: Array.isArray(src.inventory) ? src.inventory : [],
+    inventoryFolders: Array.isArray(src.inventoryFolders) ? src.inventoryFolders : [],
+    cuttingJobs: Array.isArray(src.cuttingJobs) ? src.cuttingJobs : [],
+    completedCuttingJobs: Array.isArray(src.completedCuttingJobs) ? src.completedCuttingJobs : [],
+    orderRequests: Array.isArray(src.orderRequests) ? src.orderRequests : [],
+    receiptTrackerWeeks: Array.isArray(src.receiptTrackerWeeks) ? src.receiptTrackerWeeks : [],
+    appConfig: src.appConfig || normalizeAppConfig(window.appConfig),
+    settingsFolders: Array.isArray(src.settingsFolders) ? src.settingsFolders : []
+  };
+}
+
 function persistLocalStateBackup(snapshot){
   if (typeof window === "undefined" || !window.localStorage || !snapshot) return;
+  const trimmed = compactStateForStorage(snapshot, { forBackup:true });
   try {
-    window.localStorage.setItem(LOCAL_STATE_BACKUP_KEY, JSON.stringify(snapshot));
+    window.localStorage.setItem(LOCAL_STATE_BACKUP_KEY, JSON.stringify(trimmed));
+    console.info("Local backup saved", { bytes: estimatePayloadBytes(trimmed) });
   } catch (err){
-    console.warn("Failed to persist local state backup", err);
+    console.warn("Local backup primary write failed", err);
+    try {
+      window.localStorage.removeItem(LOCAL_STATE_BACKUP_KEY);
+      const emergency = buildEmergencyBackup(trimmed);
+      window.localStorage.setItem(LOCAL_STATE_BACKUP_KEY, JSON.stringify(emergency));
+      console.warn("Local backup saved in emergency mode", { bytes: estimatePayloadBytes(emergency) });
+    } catch (retryErr){
+      console.error("Failed to persist local backup even in emergency mode", retryErr);
+    }
   }
 }
 
@@ -2158,9 +2221,12 @@ function snapshotState(){
     weeklyCostReports: Array.isArray(window.weeklyCostReports)
       ? window.weeklyCostReports.map(entry => ({ ...entry }))
       : [],
-    syncProcessLog: Array.isArray(window.syncProcessLog)
-      ? window.syncProcessLog.map(entry => ({ ...entry }))
-      : [],
+    saveMeta: {
+      lastSavedAt: new Date().toISOString(),
+      lastSaveStatus: "pending",
+      lastSaveError: "",
+      lastSaveSizeBytes: 0
+    },
     appConfig: normalizeAppConfig(window.appConfig),
     pumpEff: safePumpEff,
     deletedItems: trashSnapshot,
@@ -2852,7 +2918,7 @@ function adoptState(doc){
   opportunityRollups = Array.isArray(data.opportunityRollups) ? data.opportunityRollups : [];
   weeklyCostReports = Array.isArray(data.weeklyCostReports) ? data.weeklyCostReports.map(entry => ({ ...entry })) : [];
   receiptTrackerWeeks = Array.isArray(data.receiptTrackerWeeks) ? data.receiptTrackerWeeks.map(entry => ({ ...entry })) : [];
-  window.syncProcessLog = Array.isArray(data.syncProcessLog) ? data.syncProcessLog.map(entry => ({ ...entry })) : (Array.isArray(window.syncProcessLog) ? window.syncProcessLog : []);
+  window.syncProcessLog = Array.isArray(data.syncProcessLog) ? data.syncProcessLog.slice(0,100).map(entry => ({ ...entry })) : (Array.isArray(window.syncProcessLog) ? window.syncProcessLog.slice(0,100) : []);
 
   window.totalHistory = totalHistory;
   window.tasksInterval = tasksInterval;
@@ -3050,14 +3116,20 @@ function adoptState(doc){
 const saveCloudInternal = debounce(async ()=>{
   if (!FB.ready || !FB.docRef) return;
   try{
-    const snap = snapshotState();
+    const rawSnap = snapshotState();
+    const snap = compactStateForStorage(rawSnap);
+    const sizeBytes = estimatePayloadBytes(snap);
+    if (sizeBytes >= FIRESTORE_WARN_BYTES){
+      console.warn("Cloud state size warning", { sizeBytes, warnAt: FIRESTORE_WARN_BYTES, blockAt: FIRESTORE_BLOCK_BYTES });
+    }
+    if (sizeBytes >= FIRESTORE_BLOCK_BYTES){
+      console.error("Cloud save blocked: state payload too large", { sizeBytes, blockAt: FIRESTORE_BLOCK_BYTES });
+      hasPendingLocalChanges = true;
+      persistLocalStateBackup(snap);
+      return;
+    }
     try {
-      const prevLogLen = Array.isArray(window.syncProcessLog) ? window.syncProcessLog.length : 0;
       recordDataFlowEvent("cloud_save", snap);
-      const nextLogLen = Array.isArray(window.syncProcessLog) ? window.syncProcessLog.length : 0;
-      if (nextLogLen !== prevLogLen){
-        snap.syncProcessLog = window.syncProcessLog.slice();
-      }
     } catch (err) {
       console.warn("Failed to record save flow event", err);
     }
@@ -3071,8 +3143,18 @@ const saveCloudInternal = debounce(async ()=>{
       snap.pumpEff = mergePumpEffForSave(snap.pumpEff, remoteData.pumpEff);
     }
     const writeRev = Number(snap?.syncMeta?.rev || 0);
+    snap.saveMeta = { lastSavedAt: new Date().toISOString(), lastSaveStatus: "saved", lastSaveError: "", lastSaveSizeBytes: sizeBytes };
     await FB.docRef.set(snap, { merge:true });
     if (writeRev > 0) lastAppliedCloudRevision = writeRev;
+    if (FB.workspaceDoc){
+      const nowMs = Date.now();
+      if (nowMs - lastSaveLogWriteAt >= SAVE_LOG_THROTTLE_MS){
+        lastSaveLogWriteAt = nowMs;
+        try {
+          await FB.workspaceDoc.collection("app").doc("saveLogs").collection("entries").add({ atISO: new Date().toISOString(), status: "saved", sizeBytes, workspaceId: WORKSPACE_ID });
+        } catch (logErr){ console.warn("Failed to write save log entry", logErr); }
+      }
+    }
     if (window.DEBUG_MODE){
       const el = document.getElementById("dbgSnap");
       if (el) el.value = JSON.stringify(snap, null, 2);
@@ -3087,7 +3169,7 @@ const saveCloudInternal = debounce(async ()=>{
   }catch(e){
     console.error("Cloud save failed:", e);
   }
-}, 300);
+}, 1800);
 function recordDataFlowEvent(trigger = "save", nextSnapshot = null){
   try {
     if (!Array.isArray(window.syncProcessLog)) window.syncProcessLog = [];
@@ -3263,7 +3345,11 @@ function getTrackedStateSignature(snapshot){
   return stableStringify(normalized);
 }
 function saveCloudDebounced(){
-  if (isVercelPreviewRuntime()) return;
+  if (isVercelPreviewRuntime()){
+    const host = (typeof window !== "undefined" && window.location) ? String(window.location.hostname || "") : "";
+    console.warn(`Cloud save skipped: previewReadonly=1 on preview host (${host}) for workspace ${WORKSPACE_ID}.`);
+    return;
+  }
   hasPendingLocalChanges = true;
   lastLocalMutationAt = Date.now();
   try {
@@ -3279,7 +3365,11 @@ function saveCloudDebounced(){
   saveCloudInternal();
 }
 function saveCloudNow(){
-  if (isVercelPreviewRuntime()) return;
+  if (isVercelPreviewRuntime()){
+    const host = (typeof window !== "undefined" && window.location) ? String(window.location.hostname || "") : "";
+    console.warn(`Cloud save skipped: previewReadonly=1 on preview host (${host}) for workspace ${WORKSPACE_ID}.`);
+    return;
+  }
   hasPendingLocalChanges = true;
   lastLocalMutationAt = Date.now();
   try {

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -898,6 +898,16 @@ if (typeof window !== "undefined"){
   window.recurrenceSummaryLabel = recurrenceSummaryLabel;
 }
 
+function renderCalendarPreservingScroll(){
+  if (typeof renderCalendar !== "function") return;
+  const scrollX = typeof window !== "undefined" ? window.scrollX : 0;
+  const scrollY = typeof window !== "undefined" ? window.scrollY : 0;
+  renderCalendar();
+  if (typeof window !== "undefined" && typeof window.scrollTo === "function"){
+    window.scrollTo(scrollX, scrollY);
+  }
+}
+
 function editingCompletedJobsSet(){
   if (typeof getEditingCompletedJobsSet === "function"){
     return getEditingCompletedJobsSet();
@@ -3009,7 +3019,7 @@ function applyConfigurationForm(){
   }
   if (typeof saveCloudDebounced === "function") saveCloudDebounced();
   if (typeof refreshTimeEfficiencyWidgets === "function") refreshTimeEfficiencyWidgets();
-  if (typeof renderCalendar === "function") renderCalendar();
+  renderCalendarPreservingScroll();
   if (typeof renderDashboard === "function") renderDashboard();
   if (typeof renderJobs === "function") renderJobs();
   if (typeof renderCosts === "function") renderCosts();
@@ -5208,7 +5218,7 @@ function renderDashboard(){
       if (location.hash !== "#/"){
         location.hash = "#/";
       }
-      if (typeof renderCalendar === "function") renderCalendar();
+      renderCalendarPreservingScroll();
       const months = document.getElementById("months");
       const cell = dueISO ? months?.querySelector(`[data-date-iso="${dueISO}"]`) : null;
       if (cell){
@@ -6533,6 +6543,7 @@ function renderDashboard(){
     if (typeof refreshDashboardWidgets === "function"){
       refreshDashboardWidgets({ full: true });
     }
+    renderCalendarPreservingScroll();
     const hash = (location.hash || "#").toLowerCase();
     if (hash.startsWith("#/costs")){
       renderCosts();
@@ -6569,6 +6580,7 @@ function renderDashboard(){
     const list = Array.isArray(window.tasksAsReq) ? window.tasksAsReq : (window.tasksAsReq = []);
     list.unshift(task);
     setContextDate(targetISO);
+    renderCalendarPreservingScroll();
     if (typeof saveCloudNow === "function") saveCloudNow();
     else saveCloudDebounced();
     toast("One-time task added to the calendar");
@@ -6576,6 +6588,7 @@ function renderDashboard(){
     if (typeof refreshDashboardWidgets === "function"){
       refreshDashboardWidgets({ full: true });
     }
+    renderCalendarPreservingScroll();
     const hash = (location.hash || "#").toLowerCase();
     if (hash.startsWith("#/costs")){
       renderCosts();
@@ -6636,6 +6649,7 @@ function renderDashboard(){
       message = "As-required task linked from Maintenance Settings";
     }
     setContextDate(targetISO);
+    renderCalendarPreservingScroll();
     if (typeof saveCloudNow === "function") saveCloudNow();
     else saveCloudDebounced();
     toast(message);
@@ -6643,6 +6657,7 @@ function renderDashboard(){
     if (typeof refreshDashboardWidgets === "function"){
       refreshDashboardWidgets({ full: true });
     }
+    renderCalendarPreservingScroll();
     const hash = (location.hash || "#").toLowerCase();
     if (hash.startsWith("#/costs")){
       renderCosts();
@@ -6741,6 +6756,7 @@ function renderDashboard(){
     updateDashJobCategoryHint();
     window.jobCategoryFilter = previousCategoryFilter;
     saveCloudDebounced();
+    renderCalendarPreservingScroll();
     toast("Cutting job added");
     closeModal();
     renderDashboard();
@@ -10086,7 +10102,7 @@ function renderSettings(){
       updateTaskFieldRelevance(holder);
       if (typeof refreshDashboardWidgets === "function") refreshDashboardWidgets({ full: true });
       persist();
-      if (typeof renderCalendar === "function") renderCalendar();
+      renderCalendarPreservingScroll();
       return;
     }
     if (selectKey === "mode"){
@@ -11104,7 +11120,7 @@ function renderCosts(){
     if (typeof hideBubble === "function") hideBubble();
     location.hash = "#/";
     const runFocus = ()=>{
-      if (typeof renderCalendar === "function") renderCalendar();
+      renderCalendarPreservingScroll();
       const months = document.getElementById("months");
       const cell = dueISO ? months?.querySelector(`[data-date-iso="${dueISO}"]`) : null;
       if (!cell) return false;
@@ -11139,7 +11155,7 @@ function renderCosts(){
     if (typeof hideBubble === "function") hideBubble();
     location.hash = "#/";
     const runFocus = ()=>{
-      if (typeof renderCalendar === "function") renderCalendar();
+      renderCalendarPreservingScroll();
       const months = document.getElementById("months");
       const cell = dueISO ? months?.querySelector(`[data-date-iso="${dueISO}"]`) : null;
       if (!cell) return false;
@@ -19856,6 +19872,7 @@ function renderJobs(){
     window.jobAddDraft = {};
     window.jobCategoryFilter = previousCategoryFilter;
     persistJobChanges();
+    renderCalendarPreservingScroll();
     renderJobs();
   });
 
@@ -20185,6 +20202,7 @@ function renderJobs(){
       reorderPriorities(newJob.id, newJob.priority);
       window.cuttingJobs = cuttingJobs;
       saveCloudDebounced();
+      renderCalendarPreservingScroll();
       toast("Active cutting job created");
       renderJobs();
       return;


### PR DESCRIPTION
### Motivation
- Prevent the calendar view from jumping when many actions call `renderCalendar` and make calendar interactions less jarring.  
- Make calendar job rendering resilient to different job data shapes and date field names.  
- Reduce risk of oversized Firestore writes and improve local backup behavior when saving large state snapshots.

### Description
- Added `rerenderCalendarKeepScroll` (in `js/calendar.js`) and `renderCalendarPreservingScroll` (in `js/renderers.js`) and replaced many direct `renderCalendar()` calls with these helpers to capture and restore `window.scrollX/Y` across re-renders.  
- Introduced `normalizeJobList` and more robust job range resolution in `renderCalendar()` to accept arrays or objects for job lists and multiple possible date field names (`startISO`, `dueISO`, `startDate`, `completedAtISO`, etc.), and ensured active/completed jobs are mapped to calendar days correctly.  
- Enhanced cloud/local persistence in `js/core.js` by adding `estimatePayloadBytes`, `compactStateForStorage`, and `buildEmergencyBackup`, plus constants `FIRESTORE_WARN_BYTES` and `FIRESTORE_BLOCK_BYTES`; snapshot size is estimated before save, large saves are blocked and persisted locally, and backups are written in a trimmed or emergency form.  
- Tightened `persistLocalStateBackup` to store compacted backups and attempt an emergency fallback if primary write fails, and limited `window.syncProcessLog` length when adopting state.  
- Adjusted `saveCloudInternal` to compact payloads, add `saveMeta` with size/status, throttle writing of a save log, and increase debounce interval for cloud saves; `saveCloudDebounced`/`saveCloudNow` now skip saves on preview-readonly Vercel preview hosts with a warning.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0487c79530832583b6cb15553f4dfc)