### PR TITLE
Safeguard cloud sync and backups, strip embedded file content, and improve cost layout sizing/UX

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -534,8 +534,9 @@ const CLOUD_SYNC_CLIENT_KEY = "cloud_sync_client_id_v1";
 const LOCAL_STATE_BACKUP_KEY = "omax_local_state_backup_v1";
 
 
-const FIRESTORE_WARN_BYTES = 900000;
-const FIRESTORE_BLOCK_BYTES = 1000000;
+const FIRESTORE_WARN_BYTES = 850000;
+const FIRESTORE_STRONG_WARN_BYTES = 900000;
+const FIRESTORE_BLOCK_BYTES = 975000;
 const SAVE_LOG_THROTTLE_MS = 30000;
 let lastSaveLogWriteAt = 0;
 
@@ -549,6 +550,86 @@ function estimatePayloadBytes(payload){
   }
 }
 
+
+const LARGE_CONTENT_KEY_PATTERN = /(base64|filedata|dataurl|previewurl|previewdata|filecontent|content|raw|blob|attachment|image|file|dxf|ord|omx)/i;
+const SAFE_FILE_METADATA_KEY_PATTERN = /^(name|type|size|label|path|storagepath|externalurl|downloadurl|onedriveurl|attachedatiso|uploadedatiso|extension)$/i;
+const EMBEDDED_CONTENT_KEY_PATTERN = /^(dataurl|previewurl|previewdata|filedata|filecontent|raw|content|blob|base64)$/i;
+
+function isDataUrl(value){
+  const raw = String(value || "").trim();
+  return /^data:(image|application)\//i.test(raw);
+}
+
+function isLikelyEmbeddedFileContent(key, value){
+  if (typeof value !== "string") return false;
+  const raw = String(value || "");
+  const normalizedKey = String(key || "").toLowerCase();
+  if (isDataUrl(raw)) return true;
+  if (EMBEDDED_CONTENT_KEY_PATTERN.test(normalizedKey)) return true;
+  if (/base64|blob|binary|dxf|ord|omx/i.test(normalizedKey) && raw.length > 256) return true;
+  if (/^https?:\/\//i.test(raw)) return false;
+  return raw.length > 8192 && LARGE_CONTENT_KEY_PATTERN.test(normalizedKey);
+}
+
+function isSafeMetadataString(key, value){
+  const raw = String(value || "").trim();
+  if (!SAFE_FILE_METADATA_KEY_PATTERN.test(String(key || ""))) return false;
+  if (isDataUrl(raw)) return false;
+  if (raw.length > 2048) return false;
+  return true;
+}
+function isProtectedBusinessDataKey(key){
+  const normalized = String(key || "").toLowerCase();
+  return /(tasksinterval|tasksasreq|completeddates|manualhistory|calendardateiso|recurrence|removedoccurrences|occurrenceoverrides|maintenancetasksv2|maintenanceoccurrencesv2|maintenancecalendarinstancesv2|settingsfolders|folders|inventory|inventoryfolders|inventorymaterials|inventorytransactions|orderrequests|receipttrackerweeks|purchase|vendor|tolerance|inspection|quality|layout|dashboardlayout|costlayout|joblayout|tolerancelayout)/i.test(normalized);
+}
+
+function sanitizeValueForStorage(value, { dropHeavyHistory = false } = {}){
+  if (Array.isArray(value)) return value.map(v => sanitizeValueForStorage(v, { dropHeavyHistory }));
+  if (!value || typeof value !== "object"){
+    if (typeof value === "string" && (value.startsWith("data:image") || value.length > 200000)) return "";
+    return value;
+  }
+  const out = {};
+  for (const [k,v] of Object.entries(value)){
+    const key = String(k || "");
+    if (/^(__|debug|cache|preview)/i.test(key)) continue;
+    if (dropHeavyHistory && !isProtectedBusinessDataKey(key) && /(syncprocesslog|logs|deleteditems|reports|rollups|savelogs)/i.test(key)) continue;
+    if (typeof v === "string" && (isLikelyEmbeddedFileContent(key, v) || v.length > 200000)){
+      if (isSafeMetadataString(key, v)) out[key] = v;
+      continue;
+    }
+    out[k] = sanitizeValueForStorage(v, { dropHeavyHistory });
+  }
+  return out;
+}
+
+function estimateTopLevelFieldSizes(state){
+  const src = state && typeof state === "object" ? state : {};
+  return Object.keys(src).map((field)=>({ field, bytes: estimatePayloadBytes(src[field]) })).sort((a,b)=>b.bytes-a.bytes);
+}
+
+function summarizeLargestNested(fieldName, value){
+  if (!Array.isArray(value)) return [];
+  return value.map((item, index)=>{
+    const keys = item && typeof item === "object" ? Object.keys(item).filter((k)=>LARGE_CONTENT_KEY_PATTERN.test(k) || (typeof item[k] === "string" && item[k].length > 5000)).slice(0,8) : [];
+    return { index, id: item?.id || "", name: item?.name || item?.title || "", bytes: estimatePayloadBytes(item), suspiciousKeys: keys.join(",") };
+  }).sort((a,b)=>b.bytes-a.bytes).slice(0,10);
+}
+
+function logStateSizeDiagnostics(state, label = "state"){
+  const ranked = estimateTopLevelFieldSizes(state);
+  console.info(`Field size diagnostics (${label})`);
+  console.table(ranked);
+  ranked.slice(0,3).forEach((entry)=>{
+    const nested = summarizeLargestNested(entry.field, state?.[entry.field]);
+    if (nested.length){
+      console.info(`Nested size diagnostics for ${entry.field}`);
+      console.table(nested);
+    }
+  });
+  return ranked;
+}
+
 function compactStateForStorage(raw, { forBackup = false } = {}){
   const snap = raw && typeof raw === "object" ? { ...raw } : {};
   // Safe-to-trim fields: operational/debug/save logs that can grow unbounded.
@@ -556,12 +637,20 @@ function compactStateForStorage(raw, { forBackup = false } = {}){
   delete snap.__lastSnapshot;
   delete snap.__lastSnapshotForFlow;
   delete snap.__lastDataFlowFingerprint;
+  snap.tasksInterval = sanitizeValueForStorage(snap.tasksInterval);
+  snap.tasksAsReq = sanitizeValueForStorage(snap.tasksAsReq);
+  snap.inventory = sanitizeValueForStorage(snap.inventory);
+  snap.orderRequests = sanitizeValueForStorage(snap.orderRequests);
+  snap.cuttingJobs = sanitizeValueForStorage(snap.cuttingJobs);
+  snap.completedCuttingJobs = sanitizeValueForStorage(snap.completedCuttingJobs);
+  snap.totalHistory = Array.isArray(snap.totalHistory) ? snap.totalHistory.slice(-500) : [];
+  snap.dailyCutHours = Array.isArray(snap.dailyCutHours) ? snap.dailyCutHours.slice(-365) : [];
   if (forBackup){
     delete snap.deletedItems;
     delete snap.opportunityRollups;
     delete snap.weeklyCostReports;
   }
-  return snap;
+  return sanitizeValueForStorage(snap, { dropHeavyHistory: forBackup });
 }
 
 function buildEmergencyBackup(snapshot){
@@ -581,6 +670,96 @@ function buildEmergencyBackup(snapshot){
   };
 }
 
+function buildTinyCriticalBackup(snapshot){
+  const src = snapshot && typeof snapshot === "object" ? snapshot : {};
+  const base = {
+    schema: src.schema || APP_SCHEMA,
+    tasksInterval: src.tasksInterval || [],
+    tasksAsReq: src.tasksAsReq || [],
+    maintenanceTasksV2: src.maintenanceTasksV2 || [],
+    maintenanceOccurrencesV2: src.maintenanceOccurrencesV2 || [],
+    maintenanceCalendarInstancesV2: src.maintenanceCalendarInstancesV2 || [],
+    inventory: src.inventory || [],
+    inventoryFolders: src.inventoryFolders || [],
+    inventoryMaterials: src.inventoryMaterials || [],
+    inventoryTransactions: src.inventoryTransactions || [],
+    orderRequests: src.orderRequests || [],
+    receiptTrackerWeeks: src.receiptTrackerWeeks || [],
+    settingsFolders: src.settingsFolders || [],
+    folders: src.folders || [],
+    jobFolders: src.jobFolders || [],
+    dashboardLayout: src.dashboardLayout || {},
+    costLayout: src.costLayout || {},
+    jobLayout: src.jobLayout || {},
+    toleranceLayout: src.toleranceLayout || {},
+    appConfig: src.appConfig || normalizeAppConfig(window.appConfig)
+  };
+  for (const [k,v] of Object.entries(src)){
+    if (/(tolerance|inspection|quality)/i.test(k) && !(k in base)) base[k] = v;
+  }
+  const tiny = sanitizeValueForStorage(base, { dropHeavyHistory: true });
+  console.info("Tiny backup included keys", Object.keys(tiny).sort());
+  return tiny;
+}
+
+function collectMaintenanceHistoryMetrics(state){
+  const src = state && typeof state === "object" ? state : {};
+  const listA = Array.isArray(src.tasksInterval) ? src.tasksInterval : [];
+  const listB = Array.isArray(src.tasksAsReq) ? src.tasksAsReq : [];
+  const countBy = (list, key)=>list.reduce((acc,t)=>acc + (Array.isArray(t?.[key]) ? t[key].length : 0), 0);
+  return {
+    tasksInterval: listA.length,
+    tasksAsReq: listB.length,
+    completedDatesCount: countBy(listA, "completedDates") + countBy(listB, "completedDates"),
+    manualHistoryCount: countBy(listA, "manualHistory") + countBy(listB, "manualHistory"),
+    maintenanceOccurrencesV2Count: Array.isArray(src.maintenanceOccurrencesV2) ? src.maintenanceOccurrencesV2.length : 0,
+    maintenanceCalendarInstancesV2Count: Array.isArray(src.maintenanceCalendarInstancesV2) ? src.maintenanceCalendarInstancesV2.length : 0
+  };
+}
+function logMaintenanceHistoryDiagnostics(source, state){
+  const m = collectMaintenanceHistoryMetrics(state);
+  console.info("Maintenance history diagnostics", { source, ...m, missingHistory: (m.completedDatesCount + m.manualHistoryCount) === 0 && (m.tasksInterval + m.tasksAsReq) > 0 });
+  return m;
+}
+function shouldPreferLocalBackup(cloudState, localState){
+  const c = collectMaintenanceHistoryMetrics(cloudState);
+  const l = collectMaintenanceHistoryMetrics(localState);
+  if ((l.completedDatesCount + l.manualHistoryCount + l.maintenanceOccurrencesV2Count) + 20 < (c.completedDatesCount + c.manualHistoryCount + c.maintenanceOccurrencesV2Count)) return false;
+  return true;
+}
+function collectCoreBusinessMetrics(state){
+  const src = state && typeof state === "object" ? state : {};
+  const maintenance = collectMaintenanceHistoryMetrics(src);
+  const orderLineItemCount = (Array.isArray(src.orderRequests) ? src.orderRequests : []).reduce((n,r)=>n + (Array.isArray(r?.items) ? r.items.length : 0), 0);
+  const toleranceKeys = Object.keys(src).filter((k)=>/(tolerance|inspection|quality)/i.test(k));
+  return {
+    ...maintenance,
+    inventoryCount: Array.isArray(src.inventory) ? src.inventory.length : 0,
+    inventoryFoldersCount: Array.isArray(src.inventoryFolders) ? src.inventoryFolders.length : 0,
+    inventoryMaterialsCount: Array.isArray(src.inventoryMaterials) ? src.inventoryMaterials.length : 0,
+    inventoryTransactionsCount: Array.isArray(src.inventoryTransactions) ? src.inventoryTransactions.length : 0,
+    orderRequestsCount: Array.isArray(src.orderRequests) ? src.orderRequests.length : 0,
+    orderLineItemCount,
+    receiptTrackerWeeksCount: Array.isArray(src.receiptTrackerWeeks) ? src.receiptTrackerWeeks.length : 0,
+    settingsFoldersCount: Array.isArray(src.settingsFolders) ? src.settingsFolders.length : 0,
+    foldersCount: Array.isArray(src.folders) ? src.folders.length : 0,
+    toleranceFieldCount: toleranceKeys.length,
+    layoutPresent: Boolean(src.dashboardLayout && src.costLayout && src.jobLayout)
+  };
+}
+function logCoreBusinessDiagnostics(source, state){
+  const metrics = collectCoreBusinessMetrics(state);
+  console.info("Core business data diagnostics", { source, ...metrics });
+  return metrics;
+}
+function safeCleanupLoadedState(raw){
+  const src = raw && typeof raw === "object" ? { ...raw } : {};
+  delete src.syncProcessLog; delete src.__lastSnapshot; delete src.__lastSnapshotForFlow; delete src.__lastDataFlowFingerprint;
+  src.cuttingJobs = sanitizeValueForStorage(src.cuttingJobs);
+  src.completedCuttingJobs = sanitizeValueForStorage(src.completedCuttingJobs);
+  return src;
+}
+
 function persistLocalStateBackup(snapshot){
   if (typeof window === "undefined" || !window.localStorage || !snapshot) return;
   const trimmed = compactStateForStorage(snapshot, { forBackup:true });
@@ -588,7 +767,7 @@ function persistLocalStateBackup(snapshot){
     window.localStorage.setItem(LOCAL_STATE_BACKUP_KEY, JSON.stringify(trimmed));
     console.info("Local backup saved", { bytes: estimatePayloadBytes(trimmed) });
   } catch (err){
-    console.warn("Local backup primary write failed", err);
+    console.warn("Local backup primary write failed", err, { bytes: estimatePayloadBytes(trimmed) });
     try {
       window.localStorage.removeItem(LOCAL_STATE_BACKUP_KEY);
       const emergency = buildEmergencyBackup(trimmed);
@@ -596,6 +775,15 @@ function persistLocalStateBackup(snapshot){
       console.warn("Local backup saved in emergency mode", { bytes: estimatePayloadBytes(emergency) });
     } catch (retryErr){
       console.error("Failed to persist local backup even in emergency mode", retryErr);
+      try {
+        window.localStorage.removeItem(LOCAL_STATE_BACKUP_KEY);
+        ["omax_debug_cache","omax_sync_cache","omax_render_cache","omax_local_state_backup_v0"].forEach((k)=>window.localStorage.removeItem(k));
+        const tiny = buildTinyCriticalBackup(trimmed);
+        window.localStorage.setItem(LOCAL_STATE_BACKUP_KEY, JSON.stringify(tiny));
+        console.warn("Local backup saved in tiny mode", { bytes: estimatePayloadBytes(tiny) });
+      } catch (tinyErr){
+        console.error("Failed to persist tiny local backup", tinyErr);
+      }
     }
   }
 }
@@ -2155,14 +2343,18 @@ function applyJobFileCacheToJobs(jobs, cache){
   });
 }
 
-function stripJobFileDataUrls(jobs){
+function stripJobFileDataUrls(jobs, tracker = null){
   if (!Array.isArray(jobs)) return [];
   return jobs.map(job => {
     if (!job || typeof job !== "object") return job;
     const files = Array.isArray(job.files)
       ? job.files.map(file => {
           if (!file || typeof file !== "object") return file;
-          const { dataUrl, ...rest } = file;
+          const rest = {};
+          for (const [k,v] of Object.entries(file)){
+            if (typeof v === "string" && isLikelyEmbeddedFileContent(k, v)){ if (tracker) tracker.count += 1; continue; }
+            rest[k] = v;
+          }
           return rest;
         })
       : [];
@@ -2172,6 +2364,7 @@ function stripJobFileDataUrls(jobs){
 
 function snapshotState(){
   refreshGlobalCollections();
+  const strippedTracker = { count: 0 };
   const jobFileCache = readJobFileCache();
   syncJobFileCacheFromJobs(cuttingJobs, jobFileCache);
   syncJobFileCacheFromJobs(completedCuttingJobs, jobFileCache);
@@ -2195,7 +2388,7 @@ function snapshotState(){
   const jobLayoutSource = window.cloudJobLayoutLoaded
     ? window.cloudJobLayout
     : (window.jobLayoutState && window.jobLayoutState.layoutById);
-  return {
+  const result = {
     schema: window.APP_SCHEMA || APP_SCHEMA,
     totalHistory,
     tasksInterval,
@@ -2204,8 +2397,8 @@ function snapshotState(){
     inventoryFolders: Array.isArray(window.inventoryFolders) ? window.inventoryFolders.map(folder => ({ ...folder })) : [],
     inventoryMaterials: normalizeInventoryMaterials(window.inventoryMaterials),
     inventorySection: String(window.inventorySection || "items") === "material" ? "material" : "items",
-    cuttingJobs: stripJobFileDataUrls(cuttingJobs),
-    completedCuttingJobs: stripJobFileDataUrls(completedCuttingJobs),
+    cuttingJobs: stripJobFileDataUrls(cuttingJobs, strippedTracker),
+    completedCuttingJobs: stripJobFileDataUrls(completedCuttingJobs, strippedTracker),
     orderRequests,
     receiptTrackerWeeks: Array.isArray(window.receiptTrackerWeeks)
       ? window.receiptTrackerWeeks.map(entry => ({ ...entry }))
@@ -2221,6 +2414,9 @@ function snapshotState(){
     weeklyCostReports: Array.isArray(window.weeklyCostReports)
       ? window.weeklyCostReports.map(entry => ({ ...entry }))
       : [],
+    maintenanceTasksV2: Array.isArray(window.maintenanceTasksV2) ? window.maintenanceTasksV2.map(entry => ({ ...entry })) : [],
+    maintenanceOccurrencesV2: Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2.map(entry => ({ ...entry })) : [],
+    maintenanceCalendarInstancesV2: Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2.map(entry => ({ ...entry })) : [],
     saveMeta: {
       lastSavedAt: new Date().toISOString(),
       lastSaveStatus: "pending",
@@ -2242,6 +2438,8 @@ function snapshotState(){
       updatedBy: getCloudSyncClientId()
     }
   };
+  if (typeof window !== "undefined") window.__lastStrippedHeavyFields = strippedTracker.count;
+  return result;
 }
 
 /* ======================== HISTORY ========================= */
@@ -2932,6 +3130,9 @@ function adoptState(doc){
   window.opportunityRollups = opportunityRollups;
   window.weeklyCostReports = weeklyCostReports;
   window.receiptTrackerWeeks = receiptTrackerWeeks;
+  window.maintenanceTasksV2 = Array.isArray(data.maintenanceTasksV2) ? data.maintenanceTasksV2.map(entry => ({ ...entry })) : (Array.isArray(window.maintenanceTasksV2) ? window.maintenanceTasksV2 : []);
+  window.maintenanceOccurrencesV2 = Array.isArray(data.maintenanceOccurrencesV2) ? data.maintenanceOccurrencesV2.map(entry => ({ ...entry })) : (Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : []);
+  window.maintenanceCalendarInstancesV2 = Array.isArray(data.maintenanceCalendarInstancesV2) ? data.maintenanceCalendarInstancesV2.map(entry => ({ ...entry })) : (Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2 : []);
   deletedItems = normalizeDeletedItems(Array.isArray(data.deletedItems) ? data.deletedItems : deletedItems);
   window.deletedItems = deletedItems;
   purgeExpiredDeletedItems();
@@ -3118,12 +3319,27 @@ const saveCloudInternal = debounce(async ()=>{
   try{
     const rawSnap = snapshotState();
     const snap = compactStateForStorage(rawSnap);
+    const pendingMetrics = logMaintenanceHistoryDiagnostics("before-save", snap);
+    const baselineMetrics = collectMaintenanceHistoryMetrics(window.__lastLoadedCloudState || {});
+    const pendingCore = logCoreBusinessDiagnostics("before-save", snap);
+    const baselineCore = collectCoreBusinessMetrics(window.__lastLoadedCloudState || {});
+    if ((pendingMetrics.completedDatesCount + pendingMetrics.manualHistoryCount + pendingMetrics.maintenanceOccurrencesV2Count + 10) < (baselineMetrics.completedDatesCount + baselineMetrics.manualHistoryCount + baselineMetrics.maintenanceOccurrencesV2Count)){
+      console.error("Cloud save blocked: maintenance completion history would be reduced unexpectedly.", { pendingMetrics, baselineMetrics });
+      return;
+    }
+    if (pendingCore.inventoryCount + 5 < baselineCore.inventoryCount || pendingCore.orderRequestsCount + 2 < baselineCore.orderRequestsCount || pendingCore.orderLineItemCount + 5 < baselineCore.orderLineItemCount || pendingCore.settingsFoldersCount + 1 < baselineCore.settingsFoldersCount || pendingCore.toleranceFieldCount + 1 < baselineCore.toleranceFieldCount || (!pendingCore.layoutPresent && baselineCore.layoutPresent)){
+      console.error("Cloud save blocked: core business data would be reduced unexpectedly.", { pendingCore, baselineCore });
+      return;
+    }
     const sizeBytes = estimatePayloadBytes(snap);
     if (sizeBytes >= FIRESTORE_WARN_BYTES){
-      console.warn("Cloud state size warning", { sizeBytes, warnAt: FIRESTORE_WARN_BYTES, blockAt: FIRESTORE_BLOCK_BYTES });
+      console.warn("Cloud state size warning", { sizeBytes, warnAt: FIRESTORE_WARN_BYTES, strongWarnAt: FIRESTORE_STRONG_WARN_BYTES, blockAt: FIRESTORE_BLOCK_BYTES });
+      logStateSizeDiagnostics(snap, "before-save");
+      if (sizeBytes >= FIRESTORE_STRONG_WARN_BYTES) console.error("Cloud state size strong warning", { sizeBytes, strongWarnAt: FIRESTORE_STRONG_WARN_BYTES });
     }
     if (sizeBytes >= FIRESTORE_BLOCK_BYTES){
       console.error("Cloud save blocked: state payload too large", { sizeBytes, blockAt: FIRESTORE_BLOCK_BYTES });
+      logStateSizeDiagnostics(snap, "blocked-save");
       hasPendingLocalChanges = true;
       persistLocalStateBackup(snap);
       return;
@@ -3145,6 +3361,13 @@ const saveCloudInternal = debounce(async ()=>{
     const writeRev = Number(snap?.syncMeta?.rev || 0);
     snap.saveMeta = { lastSavedAt: new Date().toISOString(), lastSaveStatus: "saved", lastSaveError: "", lastSaveSizeBytes: sizeBytes };
     await FB.docRef.set(snap, { merge:true });
+    console.info("Cloud save succeeded", {
+      workspaceId: WORKSPACE_ID,
+      path: FB.docRef?.path || "",
+      sizeBytes,
+      strippedHeavyFields: Number(window.__lastStrippedHeavyFields || 0),
+      layoutsIncluded: Boolean(snap && snap.dashboardLayout && snap.costLayout && snap.jobLayout)
+    });
     if (writeRev > 0) lastAppliedCloudRevision = writeRev;
     if (FB.workspaceDoc){
       const nowMs = Date.now();
@@ -3345,6 +3568,7 @@ function getTrackedStateSignature(snapshot){
   return stableStringify(normalized);
 }
 function saveCloudDebounced(){
+  if (window.__recoveryInspectMode || window.__autosaveDisabled) return;
   if (isVercelPreviewRuntime()){
     const host = (typeof window !== "undefined" && window.location) ? String(window.location.hostname || "") : "";
     console.warn(`Cloud save skipped: previewReadonly=1 on preview host (${host}) for workspace ${WORKSPACE_ID}.`);
@@ -3365,6 +3589,7 @@ function saveCloudDebounced(){
   saveCloudInternal();
 }
 function saveCloudNow(){
+  if (window.__recoveryInspectMode || window.__autosaveDisabled) return;
   if (isVercelPreviewRuntime()){
     const host = (typeof window !== "undefined" && window.location) ? String(window.location.hostname || "") : "";
     console.warn(`Cloud save skipped: previewReadonly=1 on preview host (${host}) for workspace ${WORKSPACE_ID}.`);
@@ -3394,12 +3619,35 @@ function saveCloudNow(){
 
 if (typeof window !== "undefined"){
   window.addEventListener("visibilitychange", ()=>{
+    if (window.__recoveryInspectMode) return;
     if (document.visibilityState === "hidden"){
       saveCloudNow();
     }
   });
-  window.addEventListener("pagehide", ()=>saveCloudNow());
+  window.addEventListener("pagehide", ()=>{ if (!window.__recoveryInspectMode) saveCloudNow(); });
 }
+
+async function runRecoveryInspect(){
+  window.__recoveryInspectMode = true;
+  window.__autosaveDisabled = true;
+  console.warn("Recovery inspect mode enabled: autosave disabled.");
+  let cloudState = null;
+  try {
+    if (FB.ready && FB.docRef){
+      const snap = await FB.docRef.get();
+      cloudState = snap?.exists ? (typeof snap.data === "function" ? snap.data() : snap.data) : null;
+    }
+  } catch (err){ console.warn("Recovery inspect cloud read failed", err); }
+  const localBackup = readLocalStateBackup();
+  const localRaw = (typeof window !== "undefined" && window.localStorage) ? window.localStorage.getItem(LOCAL_STATE_BACKUP_KEY) : null;
+  console.info("Recovery inspect report", {
+    cloudMetrics: collectCoreBusinessMetrics(cloudState || {}),
+    localBackupMetrics: collectCoreBusinessMetrics(localBackup || {}),
+    localBackupBytes: localRaw ? localRaw.length : 0
+  });
+  return { cloudState, localBackup };
+}
+if (typeof window !== "undefined") window.recoveryInspect = runRecoveryInspect;
 async function loadFromCloud(){
   if (!FB.ready || !FB.docRef) return;
   try{
@@ -3419,8 +3667,14 @@ async function loadFromCloud(){
     const backupRev = Number(localBackup?.syncMeta?.rev || 0);
 
     if (stateHasMeaningfulData(data)){
-      const useBackup = stateHasMeaningfulData(localBackup) && backupRev > cloudRev;
-      adoptState((useBackup ? localBackup : data) || {});
+      logMaintenanceHistoryDiagnostics("cloud-before-adopt", data || {});
+      logMaintenanceHistoryDiagnostics("backup-before-adopt", localBackup || {});
+      logCoreBusinessDiagnostics("cloud-before-adopt", data || {});
+      logCoreBusinessDiagnostics("backup-before-adopt", localBackup || {});
+      const useBackup = stateHasMeaningfulData(localBackup) && backupRev > cloudRev && shouldPreferLocalBackup(data || {}, localBackup || {});
+      const incomingState = safeCleanupLoadedState((useBackup ? localBackup : data) || {});
+      adoptState(incomingState);
+      window.__lastLoadedCloudState = cloneStructured(data || {});
       const loadedRev = useBackup ? backupRev : cloudRev;
       if (loadedRev > 0) lastAppliedCloudRevision = loadedRev;
       if (typeof resetHistoryToCurrent === "function") resetHistoryToCurrent();
@@ -3428,7 +3682,11 @@ async function loadFromCloud(){
         try { saveCloudNow(); } catch (err){ console.warn("Failed to push local backup after cloud load", err); }
       }
     }else if (stateHasMeaningfulData(localBackup)){
-      adoptState(localBackup || {});
+      logMaintenanceHistoryDiagnostics("backup-only-before-adopt", localBackup || {});
+      logCoreBusinessDiagnostics("backup-only-before-adopt", localBackup || {});
+      const incomingBackup = safeCleanupLoadedState(localBackup || {});
+      adoptState(incomingBackup);
+      window.__lastLoadedCloudState = cloneStructured(incomingBackup || {});
       const loadedRev = Number(localBackup?.syncMeta?.rev || 0);
       if (loadedRev > 0) lastAppliedCloudRevision = loadedRev;
       if (typeof resetHistoryToCurrent === "function") resetHistoryToCurrent();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1830,8 +1830,8 @@ const DASHBOARD_WINDOW_MIN_WIDTH   = 240;
 const DASHBOARD_WINDOW_MIN_HEIGHT  = 160;
 
 const COST_LAYOUT_STORAGE_KEY = "cost_layout_windows_v1";
-const COST_WINDOW_MIN_WIDTH   = 240;
-const COST_WINDOW_MIN_HEIGHT  = 160;
+const COST_WINDOW_MIN_WIDTH   = 300;
+const COST_WINDOW_MIN_HEIGHT  = 200;
 const COST_HISTORY_SUPPRESS_KEY = "cost_history_suppressed_v1";
 
 const JOB_LAYOUT_STORAGE_KEY = "job_layout_windows_v1";
@@ -2198,6 +2198,7 @@ function persistDashboardLayout(state){
   }
   if (!cloud.loaded) changed = true;
   if (changed && typeof saveCloudDebounced === "function"){
+    console.info("Layout change persisted", { layout: "dashboardLayout", bytes: (typeof estimatePayloadBytes === "function" ? estimatePayloadBytes(layoutClone) : 0), saveTriggered: true });
     try { saveCloudDebounced(); }
     catch (err) { console.warn("Unable to schedule cloud save for dashboard layout", err); }
   }
@@ -3384,6 +3385,19 @@ function getCostLayoutState(){
 function hasSavedCostLayout(state){
   return !!(state && state.layoutStored);
 }
+function getCostDefaultBox(id, index = 0){
+  const defaults = {
+    overview: { width: 500, height: 360 },
+    chart: { width: 500, height: 360 },
+    weeklyReports: { width: 460, height: 320 },
+    purchaseHistory: { width: 460, height: 320 },
+    inventorySummary: { width: 440, height: 300 }
+  };
+  const base = defaults[id] || { width: 440, height: 320 };
+  const col = index % 2;
+  const row = Math.floor(index / 2);
+  return { x: col * (base.width + 20), y: row * (base.height + 20), width: base.width, height: base.height };
+}
 
 function persistCostLayout(state){
   if (!state) return;
@@ -3413,6 +3427,7 @@ function persistCostLayout(state){
   }
   if (!cloud.loaded) changed = true;
   if (changed && typeof saveCloudDebounced === "function"){
+    console.info("Cost layout saved", { bytes: (typeof estimatePayloadBytes === "function" ? estimatePayloadBytes(layoutClone) : 0), windowCount: Object.keys(layoutClone || {}).length, saveTriggered: true });
     try { saveCloudDebounced(); }
     catch (err) { console.warn("Unable to schedule cloud save for cost layout", err); }
   }
@@ -3450,19 +3465,18 @@ function syncCostLayoutEntries(state){
   const rootRect = state.root.getBoundingClientRect();
   const useExisting = state.root.classList.contains("has-custom-layout") && Object.keys(layout).length;
   const seen = new Set();
-  state.windows.forEach(win => {
+  state.windows.forEach((win, index) => {
     if (!win || !win.dataset) return;
     const id = String(win.dataset.costWindow || "");
     if (!id) return;
     seen.add(id);
     if (!layout[id]){
       if (useExisting){
-        const fallbackWidth = Math.max(COST_WINDOW_MIN_WIDTH, Math.round(win.offsetWidth) || COST_WINDOW_MIN_WIDTH);
-        const fallbackHeight = Math.max(COST_WINDOW_MIN_HEIGHT, Math.round(win.offsetHeight) || COST_WINDOW_MIN_HEIGHT);
-        const offsetY = costLayoutMaxBottom(layout) + 24;
-        layout[id] = { x: 0, y: offsetY, width: fallbackWidth, height: fallbackHeight };
+        const preset = getCostDefaultBox(id, index);
+        const offsetY = costLayoutMaxBottom(layout) + 20;
+        layout[id] = { x: preset.x, y: Math.max(preset.y, offsetY), width: preset.width, height: preset.height };
       }else{
-        layout[id] = captureCostWindowRect(win, rootRect);
+        layout[id] = getCostDefaultBox(id, index);
       }
     }
   });
@@ -3521,7 +3535,12 @@ function applyCostLayout(state){
     scheduleCostLayoutRefresh(state);
     return;
   }
-  const responsiveLayout = getResponsiveLayout(state, COST_WINDOW_MIN_WIDTH, COST_WINDOW_MIN_HEIGHT);
+  const responsiveLayout = {};
+  const rootWidth = getLayoutRootWidth(state);
+  Object.entries(state?.layoutById || {}).forEach(([id, box]) => {
+    const adjusted = clampLayoutBox(box, rootWidth, COST_WINDOW_MIN_WIDTH, COST_WINDOW_MIN_HEIGHT);
+    if (adjusted) responsiveLayout[id] = adjusted;
+  });
   state.activeLayoutById = responsiveLayout;
   state.windows.forEach(win => {
     if (!win || !win.dataset) return;
@@ -3811,6 +3830,7 @@ function setupCostLayout(){
   }
   syncCostLayoutEntries(state);
   applyCostLayout(state);
+  console.info("Cost layout restored", { bytes: (typeof estimatePayloadBytes === "function" ? estimatePayloadBytes(state.layoutById || {}) : 0), windowCount: Object.keys(state.layoutById || {}).length });
   updateCostEditUi(state);
   if (state.editing){
     addCostWindowHandles(state);
@@ -3923,6 +3943,7 @@ function persistJobLayout(state){
   }
   if (!cloud.loaded) changed = true;
   if (changed && typeof saveCloudDebounced === "function"){
+    console.info("Layout change persisted", { layout: "jobLayout", bytes: (typeof estimatePayloadBytes === "function" ? estimatePayloadBytes(layoutClone) : 0), saveTriggered: true });
     try { saveCloudDebounced(); }
     catch (err) { console.warn("Unable to schedule cloud save for jobs layout", err); }
   }

--- a/js/views.js
+++ b/js/views.js
@@ -3753,11 +3753,13 @@ function viewJobs(){
           if (f?.source === "onedrive_local_root" && f?.localRelativePath){
             return `<li class="job-file-menu-item"><button type="button" class="link" data-open-local-file data-job-id="${esc(String(job.id || ""))}" data-file-index="${idx}">${safeName}</button></li>`;
           }
-          const hrefRaw = f?.dataUrl || f?.url || "";
+          const hrefRaw = f?.dataUrl || f?.url || f?.externalUrl || f?.downloadUrl || f?.oneDriveUrl || "";
           const href = esc(hrefRaw);
+          const usableLink = !!hrefRaw && !/^data:(image|application)\//i.test(String(hrefRaw || "")) && /^https?:\/\//i.test(String(hrefRaw || ""));
           if (!hrefRaw){
-            return `<li class="job-file-menu-item">${safeName}</li>`;
+            return `<li class="job-file-menu-item">${safeName}<span class="small muted"> — File metadata saved only — original file content is not stored.</span></li>`;
           }
+          if (!usableLink) return `<li class="job-file-menu-item">${safeName}<span class="small muted"> — File metadata saved only — original file content is not stored.</span></li>`;
           return `<li class="job-file-menu-item"><a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a></li>`;
         }).join("")
       : "";
@@ -4055,11 +4057,13 @@ function viewJobs(){
           if (f?.source === "onedrive_local_root" && f?.localRelativePath){
             return `<li class="job-file-menu-item"><button type="button" class="link" data-open-local-file data-job-id="${esc(String(j.id || ""))}" data-file-index="${idx}">${safeName}</button></li>`;
           }
-          const hrefRaw = f?.dataUrl || f?.url || "";
+          const hrefRaw = f?.dataUrl || f?.url || f?.externalUrl || f?.downloadUrl || f?.oneDriveUrl || "";
           const href = esc(hrefRaw);
+          const usableLink = !!hrefRaw && !/^data:(image|application)\//i.test(String(hrefRaw || "")) && /^https?:\/\//i.test(String(hrefRaw || ""));
           if (!hrefRaw){
-            return `<li class="job-file-menu-item">${safeName}</li>`;
+            return `<li class="job-file-menu-item">${safeName}<span class="small muted"> — File metadata saved only — original file content is not stored.</span></li>`;
           }
+          if (!usableLink) return `<li class="job-file-menu-item">${safeName}<span class="small muted"> — File metadata saved only — original file content is not stored.</span></li>`;
           return `<li class="job-file-menu-item"><a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a></li>`;
         }).join("")
       : "";
@@ -4368,8 +4372,9 @@ function viewJobs(){
                 <ul class="job-file-list">
                   ${jobFiles.length ? jobFiles.map((f, idx)=>{
                     const safeName = f.name || `file_${idx+1}`;
-                    const href = f.dataUrl || f.url || "";
-                    const link = href ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : safeName;
+                    const href = f.dataUrl || f.url || f.externalUrl || f.downloadUrl || f.oneDriveUrl || "";
+                    const usableLink = !!href && !/^data:(image|application)\//i.test(String(href || "")) && /^https?:\/\//i.test(String(href || ""));
+                    const link = usableLink ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : `${safeName} <span class="small muted">— File metadata saved only — original file content is not stored.</span>`;
                     const sourceTag = f?.source === "onedrive" ? `<span class="job-file-source-badge">OneDrive</span>` : "";
                     return `<li>${link} ${sourceTag} <button type="button" class="link" data-edit-file-link="${j.id}" data-file-index="${idx}">Link</button> <button type="button" class="link" data-remove-file="${j.id}" data-file-index="${idx}">Remove</button></li>`;
                   }).join("") : `<li class=\"muted\">No files attached</li>`}

--- a/style.css
+++ b/style.css
@@ -1639,6 +1639,10 @@ body.modal-open .auth-bar {
 .dashboard-layout.has-custom-layout .dashboard-window {
   position: absolute;
 }
+.cost-layout.has-custom-layout .dashboard-window{
+  min-width: 300px;
+  min-height: 200px;
+}
 .dashboard-layout:not(.has-custom-layout) .dashboard-window[data-dashboard-window="pumpChart"] {
   grid-column: 1 / -1;
 }
@@ -1656,6 +1660,14 @@ body.modal-open .auth-bar {
 .dashboard-window > .block {
   height: 100%;
   overflow: auto;
+}
+.cost-layout .dashboard-window > .block{
+  display:flex;
+  flex-direction:column;
+  min-height:0;
+}
+.cost-layout .dashboard-window > .block > *{
+  min-height:0;
 }
 .dashboard-layout.has-custom-layout .dashboard-window > .block {
   max-height: 100%;


### PR DESCRIPTION
### Motivation
- Prevent oversized Firestore writes, avoid accidentally losing business-critical history, and provide safer local backups when storage limits are hit.
- Remove/strip embedded file blobs from persisted state to reduce payload size and surface when only metadata is saved.
- Improve cost layout defaults, sizing and persistence behavior so cost dashboard windows restore and behave more robustly.

### Description
- Added size estimation, diagnostics and heuristics (`estimatePayloadBytes`, `logStateSizeDiagnostics`, `estimateTopLevelFieldSizes`) and tightened Firestore thresholds with `FIRESTORE_WARN_BYTES`, `FIRESTORE_STRONG_WARN_BYTES`, and `FIRESTORE_BLOCK_BYTES` to warn or block large saves.  
- Implemented sanitization helpers (`isLikelyEmbeddedFileContent`, `isSafeMetadataString`, `sanitizeValueForStorage`, `compactStateForStorage` changes) to strip large embedded content and drop heavy history for backups, and added `safeCleanupLoadedState`, `buildTinyCriticalBackup`, and progressive fallback backup writes when `localStorage` writes fail.  
- Added business-data integrity checks before cloud saves to block saves that would unexpectedly reduce maintenance history or other core business data (`collectMaintenanceHistoryMetrics`, `collectCoreBusinessMetrics`, blocking logic in `saveCloudInternal`).  
- Enhanced recovery tools: `runRecoveryInspect` (exposed as `window.recoveryInspect`) and flags to disable autosave during inspection (`__recoveryInspectMode`, `__autosaveDisabled`).  
- Strip embedded file data when snapshotting state and track count of stripped fields (`stripJobFileDataUrls` now accepts `tracker` and `window.__lastStrippedHeavyFields`), and updated job file UI/links to prefer safe external URLs and to display a metadata-only notice when original content is not available.  
- Added logging around layout saves and cost layout restoration for observability and rearranged cost layout logic to use `getCostDefaultBox`, responsive/clamping helpers, and enforce larger minimums; updated constants for cost window sizes and CSS to match (`COST_WINDOW_MIN_WIDTH`, `COST_WINDOW_MIN_HEIGHT`, style changes).  

### Testing
- No automated tests were run as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e0d032a08325b1b156676f3666ea)