### PR TITLE
Fix cutting job file persistence with WJ Cuts relative references

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -2345,17 +2345,20 @@ function applyJobFileCacheToJobs(jobs, cache){
 
 function stripJobFileDataUrls(jobs, tracker = null){
   if (!Array.isArray(jobs)) return [];
+  const allowed = new Set(["id","name","type","size","source","rootLabel","relativePath","attachedAtISO","note"]);
   return jobs.map(job => {
     if (!job || typeof job !== "object") return job;
     const files = Array.isArray(job.files)
       ? job.files.map(file => {
           if (!file || typeof file !== "object") return file;
-          const rest = {};
+          const clean = {};
           for (const [k,v] of Object.entries(file)){
-            if (typeof v === "string" && isLikelyEmbeddedFileContent(k, v)){ if (tracker) tracker.count += 1; continue; }
-            rest[k] = v;
+            const key = String(k || "");
+            if (!allowed.has(key)) { if (tracker) tracker.count += 1; continue; }
+            if (typeof v === "string" && isLikelyEmbeddedFileContent(key, v)){ if (tracker) tracker.count += 1; continue; }
+            clean[key] = v;
           }
-          return rest;
+          return clean;
         })
       : [];
     return { ...job, files };
@@ -2365,10 +2368,6 @@ function stripJobFileDataUrls(jobs, tracker = null){
 function snapshotState(){
   refreshGlobalCollections();
   const strippedTracker = { count: 0 };
-  const jobFileCache = readJobFileCache();
-  syncJobFileCacheFromJobs(cuttingJobs, jobFileCache);
-  syncJobFileCacheFromJobs(completedCuttingJobs, jobFileCache);
-  writeJobFileCache(jobFileCache);
   const safePumpEff = (typeof window.pumpEff !== "undefined") ? window.pumpEff : null;
   const foldersSnapshot = snapshotSettingsFolders();
   const trashSnapshot = deletedItems.map(entry => ({

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -981,6 +981,41 @@ async function readLocalRootHandle(){
   });
 }
 
+
+async function saveWJCutsRootFolderHandle(handle){ return saveLocalRootHandle(handle); }
+async function getWJCutsRootFolderHandle(){ return readLocalRootHandle(); }
+async function resolveWJCutsRelativePath(relativePath){ return resolveLocalFileFromRelativePath(relativePath); }
+async function setWJCutsRootFolder(){
+  if (!supportsLocalRootPicker()){ toast("Local file references require Chrome or Edge."); return null; }
+  const handle = await window.showDirectoryPicker({ mode: "read" });
+  const perm = await handle.requestPermission({ mode: "read" });
+  if (perm !== "granted") return null;
+  await saveWJCutsRootFolderHandle(handle);
+  return handle;
+}
+function sanitizeJobFileReferenceForFirestore(fileRef){
+  if (!fileRef || typeof fileRef !== "object") return null;
+  const clean = {
+    id: String(fileRef.id || genId("file")),
+    name: String(fileRef.name || "Attachment"),
+    type: String(fileRef.type || ""),
+    size: Number.isFinite(Number(fileRef.size)) ? Number(fileRef.size) : null,
+    source: "wj_cuts_reference",
+    rootLabel: "WJ Cuts",
+    relativePath: String(fileRef.relativePath || "").replace(/^\/+/, ""),
+    attachedAtISO: String(fileRef.attachedAtISO || fileRef.addedAt || new Date().toISOString())
+  };
+  if (fileRef.note) clean.note = String(fileRef.note);
+  return clean;
+}
+function attachWJCutsFileReference(jobId, fileRef){ return sanitizeJobFileReferenceForFirestore(fileRef); }
+async function openWJCutsReferencedFile(fileRef){
+  const file = await resolveWJCutsRelativePath(fileRef?.relativePath);
+  if (!file) throw new Error("File reference saved, but the file was not found under your selected WJ Cuts folder.");
+  triggerFileDownload(file, fileRef?.name || file.name);
+  return true;
+}
+
 async function computeLocalRootSignature(handle){
   if (!handle || typeof handle.entries !== "function") return "";
   const parts = [];
@@ -1464,26 +1499,21 @@ function readFileAsDataUrl(file){
 async function filesToAttachments(fileList){
   const files = Array.from(fileList || []);
   const attachments = [];
+  const rootHandle = await getWJCutsRootFolderHandle();
+  if (!rootHandle) return attachments;
   for (const file of files){
-    try {
-      const dataUrl = await readFileAsDataUrl(file);
-      const preview = await buildAttachmentPreview(file);
-      attachments.push({
-        id: genId(file.name || "job_file"),
-        name: file.name || "Attachment",
-        type: file.type || "",
-        size: typeof file.size === "number" ? file.size : null,
-        dataUrl,
-        preview,
-        source: "upload",
-        addedAt: new Date().toISOString()
-      });
-    } catch (err){
-      console.error("Unable to read file", err);
-      toast("Failed to read one of the files.");
-    }
+    const rel = String(file.webkitRelativePath || "").trim();
+    if (!rel) continue;
+    attachments.push(sanitizeJobFileReferenceForFirestore({
+      id: genId(file.name || "job_file"),
+      name: file.name || "Attachment",
+      type: file.type || "",
+      size: typeof file.size === "number" ? file.size : null,
+      relativePath: rel.replace(/^\/+/, ""),
+      attachedAtISO: new Date().toISOString()
+    }));
   }
-  return attachments;
+  return attachments.filter(Boolean);
 }
 
 const JOB_ONEDRIVE_PREVIEW_CACHE_KEY = "cutting_job_onedrive_preview_cache_v1";
@@ -1576,9 +1606,9 @@ async function resolveAttachmentPreview(file){
     return resolveOneDriveAttachmentPreview(file);
   }
 
-  if (file.source === "onedrive_local_root" && file.localRelativePath){
+  if (file.source === "wj_cuts_reference" && (file.relativePath || file.localRelativePath)){
     try {
-      const localFile = await resolveLocalFileFromRelativePath(file.localRelativePath);
+      const localFile = await resolveWJCutsRelativePath(file.relativePath || file.localRelativePath);
       if (!localFile){
         file.preview = file.preview || { mode: "message", content: "Preview unavailable. Local root file is missing." };
         return false;
@@ -18963,7 +18993,7 @@ function renderJobs(){
 
   const chooseLocalOneDriveRoot = async ()=>{
     if (!supportsLocalRootPicker()){
-      toast("This browser does not support saved OneDrive root folder access.");
+      toast("Local file references require Chrome or Edge.");
       return false;
     }
     try {
@@ -19002,7 +19032,7 @@ function renderJobs(){
 
   const attachFromLocalOneDriveRoot = async ()=>{
     if (!supportsLocalRootPicker()){
-      toast("This browser does not support local root folder attach.");
+      toast("Local file references require Chrome or Edge.");
       return false;
     }
     const rootHandle = await readLocalRootHandle();
@@ -19063,12 +19093,10 @@ function renderJobs(){
         name: file.name || "Attachment",
         type: file.type || "",
         size: typeof file.size === "number" ? file.size : null,
-        source: "onedrive_local_root",
-        localRelativePath: relPath,
-        localRootName: getSharedConfig().localRootName || rootHandle.name || "",
-        localRootSignature: signature,
-        localDeviceId: getLocalDeviceId(),
-        addedAt: new Date().toISOString()
+        source: "wj_cuts_reference",
+        rootLabel: "WJ Cuts",
+        relativePath: relPath.replace(/^\/+/, ""),
+        attachedAtISO: new Date().toISOString()
       });
       toast("File attached from this computer OneDrive root.");
       window.jobAddFormOpen = true;
@@ -19157,11 +19185,12 @@ function renderJobs(){
     const attachments = await filesToAttachments(files);
     e.target.value = "";
     if (!attachments.length){
+      toast("Use Attach from Reference Folder so this file can be saved as a WJ Cuts relative path.");
       restoreNewJobFormState(formState);
       return;
     }
     pendingNewJobFiles.push(...attachments.map(a=>({ ...a })));
-    toast(`${attachments.length} file${attachments.length===1?"":"s"} added`);
+    toast(`${attachments.length} file${attachments.length===1?"":"s"} reference${attachments.length===1?"":"s"} added`);
     window.jobAddFormOpen = true;
     renderJobs();
     requestAnimationFrame(()=> restoreNewJobFormState(formState));


### PR DESCRIPTION
### Motivation
- Cutting job attachments previously stored transient file payloads that disappeared after refresh and could not be resolved on different computers.
- The goal is to save only a lightweight path reference inside a shared `WJ Cuts` folder so attachments survive refresh and work across machines without saving file contents to Firebase.

### Description
- Added WJ Cuts/local-root helpers in `js/renderers.js` including `setWJCutsRootFolder`, `getWJCutsRootFolderHandle`, `saveWJCutsRootFolderHandle`, `resolveWJCutsRelativePath`, `openWJCutsReferencedFile`, `attachWJCutsFileReference`, and `sanitizeJobFileReferenceForFirestore`, and kept root handles local-only in IndexedDB (`cutting_job_onedrive_local_root_db`, store `handles`, key `root`).
- Updated the attach-from-root flow in `js/renderers.js` to save file references as `{ id, name, type, size, source: "wj_cuts_reference", rootLabel: "WJ Cuts", relativePath, attachedAtISO, note? }` instead of embedded file contents, and updated `filesToAttachments` to produce sanitized relative-path references when possible.
- Hardened snapshot sanitization in `js/core.js` by changing `stripJobFileDataUrls` to allow only approved metadata fields for job files and removing the job-file cache that persisted embedded data.
- UX/message updates: require `showDirectoryPicker`/File System Access API (Chrome/Edge) with the message "Local file references require Chrome or Edge.", and show a clear guidance toast when a regular `Attach File` cannot produce a reusable WJ Cuts reference: "Use Attach from Reference Folder so this file can be saved as a WJ Cuts relative path.".

### Testing
- Ran syntax checks: `node --check js/core.js`, `node --check js/views.js`, and `node --check js/renderers.js`, all succeeded.
- Searched code paths for file-content persistence fields and ensured the save path strips embedded content (`dataUrl`, `base64`, `fileContent`, `previewData`, `blob`, `raw`, `content`) from `cuttingJobs` / `completedCuttingJobs` (verified via repo search).
- Confirmed `vercel.json` remains exactly `{ "cleanUrls": true }`.
- Manual code inspection verifies `WJ Cuts` relative references are written and resolved via the stored local root handle and that no file blobs are written to Firebase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a063752919c83259ac5162e97bb24a4)