### PR TITLE
Add 'Attach from Reference Folder' UI and improve local file preview/error handling

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -894,6 +894,104 @@ function resolveV2OneTimeOccurrenceState(rootOccurrenceId, scheduledEvent){
   return { status, note, hours, displayDateISO };
 }
 
+function runMaintenanceV2SafetyChecks(){
+  const occurrences = Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : [];
+  const instances = Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2 : [];
+  const warnings = [];
+  const errors = [];
+  const info = [];
+  const byRoot = new Map();
+  const lifecycleMap = new Map([
+    ["completed", "completed"],
+    ["uncompleted", "scheduled"],
+    ["scheduled", "scheduled"],
+    ["removed", "removed"],
+    ["skipped", "skipped"]
+  ]);
+  const stableId = (entry, idx)=> String(entry?.eventId || entry?.id || `${entry?.rootOccurrenceId || "root"}:${idx}`);
+  occurrences.forEach((entry, idx)=>{
+    if (!entry || typeof entry !== "object") return;
+    const rootId = String(entry.rootOccurrenceId || "");
+    if (!rootId) return;
+    if (!byRoot.has(rootId)) byRoot.set(rootId, []);
+    byRoot.get(rootId).push({ entry, idx, stable: stableId(entry, idx) });
+    if (String(entry.eventType || "") === "moved"){
+      const toDate = normalizeDateKey(entry?.payload?.toDateISO || entry?.displayDateISO || entry?.effectiveDateISO || null);
+      if (!toDate){
+        warnings.push({ type: "moved_missing_toDateISO", rootOccurrenceId: rootId, eventId: stableId(entry, idx) });
+      }
+    }
+  });
+
+  const finalLifecycleByRoot = new Map();
+  const finalEventByRoot = new Map();
+  const activeCompletedRoots = new Set();
+  byRoot.forEach((events, rootId)=>{
+    const sortable = events.map(item=>{
+      const ts = Date.parse(String(item.entry?.recordedAtISO || ""));
+      return { ...item, ts: Number.isFinite(ts) ? ts : null };
+    });
+    const unknownOrder = sortable.filter(x => x.ts == null).length > 1;
+    sortable.sort((a,b)=>{
+      if (a.ts != null && b.ts != null && a.ts !== b.ts) return a.ts - b.ts;
+      if (a.ts != null && b.ts == null) return -1;
+      if (a.ts == null && b.ts != null) return 1;
+      if (a.idx !== b.idx) return a.idx - b.idx;
+      return a.stable.localeCompare(b.stable);
+    });
+    if (unknownOrder){
+      warnings.push({ type: "undetermined_lifecycle_order", rootOccurrenceId: rootId, events: sortable.map(s=>s.stable) });
+    }
+    let finalLifecycleStatus = "scheduled";
+    let finalEvent = null;
+    sortable.forEach(item=>{
+      const t = String(item.entry?.eventType || "").toLowerCase();
+      if (lifecycleMap.has(t)){
+        finalLifecycleStatus = lifecycleMap.get(t);
+        finalEvent = item.entry;
+      }
+    });
+    finalLifecycleByRoot.set(rootId, finalLifecycleStatus);
+    if (finalEvent) finalEventByRoot.set(rootId, finalEvent);
+    if (finalLifecycleStatus === "completed") activeCompletedRoots.add(rootId);
+  });
+
+  instances.forEach(instance=>{
+    const rule = instance?.repeatRule && typeof instance.repeatRule === "object" ? instance.repeatRule : {};
+    const endTypeRaw = String(rule.endType || rule.endMode || "never").toLowerCase();
+    const endType = ["never", "on_date", "after_count"].includes(endTypeRaw) ? endTypeRaw : "never";
+    if (endType === "after_count" && !Number.isFinite(Number(rule.endCount || 0))){
+      warnings.push({ type: "repeat_after_count_missing_endCount", instanceId: String(instance?.id || "") });
+    }
+  });
+
+  activeCompletedRoots.forEach(rootId=>{
+    const ev = finalEventByRoot.get(rootId) || {};
+    const displayDateISO = normalizeDateKey(ev.displayDateISO || ev.effectiveDateISO || ev.dateISO || null);
+    if (!String(ev.rootOccurrenceId || rootId) || !String(ev.instanceId || "") || !String(ev.taskId || "") || !displayDateISO){
+      errors.push({ type: "completed_root_missing_required_fields", rootOccurrenceId: rootId });
+    }
+  });
+
+  if (!Array.isArray(window.taskEvents)){
+    info.push({ type: "calendar_chip_parity_non_blocking", detail: "window.taskEvents unavailable; parity check skipped." });
+  }
+
+  const report = {
+    checkedAtISO: new Date().toISOString(),
+    byRootCount: byRoot.size,
+    activeCompletedRoots: Array.from(activeCompletedRoots),
+    finalLifecycleByRoot: Object.fromEntries(finalLifecycleByRoot),
+    warnings,
+    errors,
+    info,
+    readOnly: true
+  };
+  if (window.DEBUG_MODE) console.info("[maintenance-v2] safety checks", report);
+  return report;
+}
+window.runMaintenanceV2SafetyChecks = runMaintenanceV2SafetyChecks;
+
 window.completeV2OneTimeOccurrence = (occurrenceId)=>{
   const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};
   const base = lookup[String(occurrenceId)];

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -237,6 +237,19 @@ function hideBubbleSoon(){
   }, 180);
 }
 
+function ensureBubble(){
+  let bubble = document.getElementById("bubble");
+  if (bubble) return bubble;
+  bubble = document.createElement("div");
+  bubble.id = "bubble";
+  bubble.className = "calendar-bubble";
+  bubble.setAttribute("role", "dialog");
+  bubble.setAttribute("aria-live", "polite");
+  bubble.tabIndex = -1;
+  document.body.appendChild(bubble);
+  return bubble;
+}
+
 function showV2OneTimeBubble(occurrenceId, anchorEl){
   const lookup = (typeof window !== "undefined" && window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object")
     ? window.__calendarV2OneTimeLookup

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -20481,7 +20481,10 @@ function renderJobs(){
       e.target.value = "";
       if (!attachments.length) return;
       j.files = Array.isArray(j.files) ? j.files : [];
-      toast("Use Attach from Reference Folder so this file can be saved as a WJ Cuts relative path.");
+      j.files.push(...attachments);
+      saveCloudDebounced();
+      toast("Files added. For durable cross-device links, use Attach from Reference Folder.");
+      renderJobs();
     }
   });
 
@@ -20526,6 +20529,75 @@ function renderJobs(){
       closeActionMenu();
       closeHistoryActionMenu();
       content.querySelector(`input[data-job-file-input="${id}"]`)?.click();
+      return;
+    }
+
+    const linkJobFile = e.target.closest("[data-link-job-file]");
+    if (linkJobFile){
+      const id = linkJobFile.getAttribute("data-link-job-file");
+      const idStr = String(id || "");
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
+      if (!j) return;
+      try {
+        const picked = await window.oneDrivePicker.openOneDriveDxfPicker();
+        if (!picked) return;
+        j.files = Array.isArray(j.files) ? j.files : [];
+        j.files.push({
+          id: genId(picked.fileName || "job_file"),
+          name: picked.fileName || "Linked file",
+          type: "",
+          size: null,
+          source: "onedrive",
+          driveId: picked.driveId || "",
+          itemId: picked.itemId || "",
+          eTag: picked.eTag || "",
+          lastModifiedDateTime: picked.lastModifiedDateTime || "",
+          webUrl: picked.webUrl || "",
+          url: picked.webUrl || "",
+          addedAt: new Date().toISOString()
+        });
+        saveCloudDebounced();
+        toast("OneDrive DXF linked");
+        renderJobs();
+      } catch (err){
+        toast(err?.message || "Unable to link OneDrive DXF.");
+      }
+      return;
+    }
+
+    const editFileLink = e.target.closest("[data-edit-file-link]");
+    if (editFileLink){
+      const id = editFileLink.getAttribute("data-edit-file-link");
+      const idx = Number(editFileLink.getAttribute("data-file-index"));
+      const idStr = String(id || "");
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
+      const file = j && Array.isArray(j.files) && idx >= 0 ? j.files[idx] : null;
+      if (!file) return;
+      const url = promptOneDriveLinkForFile(file.name || "attachment", file.url || "");
+      if (url == null) return;
+      file.url = url;
+      file.source = "onedrive";
+      saveCloudDebounced();
+      toast(url ? "File link updated" : "File link cleared");
+      renderJobs();
+      return;
+    }
+
+    const removeFile = e.target.closest("[data-remove-file]");
+    if (removeFile){
+      const id = removeFile.getAttribute("data-remove-file");
+      const idx = Number(removeFile.getAttribute("data-file-index"));
+      const idStr = String(id || "");
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
+      if (j && Array.isArray(j.files) && idx >= 0 && idx < j.files.length){
+        j.files.splice(idx, 1);
+        saveCloudDebounced();
+        toast("File removed");
+        renderJobs();
+      }
       return;
     }
 

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1600,7 +1600,7 @@ async function resolveOneDriveAttachmentPreview(file){
       const text = window.dxfPreview.arrayBufferToText(bytes);
       const svg = window.dxfPreview.renderCadToSvgDataUrl(text);
       if (!svg){
-        file.preview = { mode: "message", content: "2D preview unavailable for this file." };
+        file.preview = { mode: "message", content: diagnosePreviewFailure(file) };
         return false;
       }
       file.preview = { mode: "image", content: svg };
@@ -1610,7 +1610,7 @@ async function resolveOneDriveAttachmentPreview(file){
       }
       return true;
     } catch (_err){
-      file.preview = file.preview || { mode: "message", content: "Preview unavailable for this OneDrive file." };
+      file.preview = { mode: "message", content: diagnosePreviewFailure(file) };
       return false;
     } finally {
       oneDrivePreviewInFlight.delete(inFlightKey);
@@ -1619,6 +1619,25 @@ async function resolveOneDriveAttachmentPreview(file){
 
   oneDrivePreviewInFlight.set(inFlightKey, task);
   return task;
+}
+
+function diagnosePreviewFailure(file, context = ""){
+  const source = String(file?.source || "");
+  const ext = fileExtFromName(String(file?.name || ""));
+  const href = String(file?.dataUrl || file?.url || "").trim();
+  if (source === "onedrive"){
+    if (!file?.driveId || !file?.itemId) return "Preview unavailable: OneDrive file metadata is incomplete. Relink this file from OneDrive.";
+    return "Preview unavailable: OneDrive content could not be loaded. Check OneDrive sign-in and file permissions, then try again.";
+  }
+  if (source === "wj_cuts_reference"){
+    return "Preview unavailable: unable to read this file from the selected WJ Cuts root. Re-select root folder and verify this exact file path exists.";
+  }
+  if ([".dxf", ".ord", ".omx"].includes(ext)){
+    if (!href) return "Preview unavailable: no file content URL is saved. Re-attach from Reference Folder or add a direct OneDrive URL.";
+    if (/^https?:\/\//i.test(href)) return "Preview unavailable: remote CAD file could not be fetched. Check the link and access permissions.";
+    return "Preview unavailable: CAD data could not be decoded for preview. Re-attach the source file.";
+  }
+  return context || "Preview unavailable: unsupported format or missing data for this attachment.";
 }
 
 async function resolveAttachmentPreview(file){
@@ -1679,10 +1698,10 @@ async function resolveAttachmentPreview(file){
         file.preview = { mode: "image", content: svg };
         return true;
       }
-      file.preview = file.preview || { mode: "message", content: "2D preview unavailable for this file." };
+      file.preview = { mode: "message", content: diagnosePreviewFailure(file) };
       return false;
     } catch (_err){
-      file.preview = file.preview || { mode: "message", content: "2D preview unavailable for this file." };
+      file.preview = { mode: "message", content: diagnosePreviewFailure(file) };
       return false;
     }
   }
@@ -19393,6 +19412,8 @@ function renderJobs(){
   const oneDriveLibraryAddToJobBtn = document.getElementById("jobOneDriveLibraryAddBtn");
   const oneDriveRootPickerBtn = document.getElementById("jobOneDriveRootPickerBtn");
 
+  let pendingAttachJobId = "";
+
 
   const getSharedConfig = ()=>{
     const cfg = (typeof window.getOneDriveJobConfig === "function") ? window.getOneDriveJobConfig() : normalizeOneDriveJobConfig(null);
@@ -19463,7 +19484,8 @@ function renderJobs(){
     }
     const rootHandle = await readLocalRootHandle();
     if (!rootHandle){
-      toast("Set WJ Cuts Folder to open this file.");
+      pendingAttachJobId = String(targetJobId || "");
+      toast("Root folder is not set up yet. Set up WJ Cuts Folder first, then attach the file.");
       openOneDriveModal();
       return false;
     }
@@ -19567,7 +19589,15 @@ function renderJobs(){
     closeFileMenu(); closeActionMenu(); closeHistoryActionMenu(); openOneDriveModal();
   });
   oneDriveRootPickerBtn?.addEventListener("click", async ()=>{
-    await chooseLocalOneDriveRoot();
+    const ok = await chooseLocalOneDriveRoot();
+    if (ok && pendingAttachJobId){
+      const targetId = pendingAttachJobId;
+      pendingAttachJobId = "";
+      const attached = await attachFromLocalOneDriveRoot(targetId);
+      if (attached){
+        closeOneDriveModal();
+      }
+    }
   });
   oneDriveCancelBtns.forEach(btn => btn.addEventListener("click", closeOneDriveModal));
   oneDriveModal?.addEventListener("click", (event)=>{ if (event.target === oneDriveModal) closeOneDriveModal(); });

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1531,32 +1531,10 @@ function readFileAsDataUrl(file){
 
 async function filesToAttachments(fileList){
   const files = Array.from(fileList || []);
-  const attachments = [];
-  for (const file of files){
-    try {
-      const dataUrl = await new Promise((resolve, reject)=>{
-        const reader = new FileReader();
-        reader.onload = ()=> resolve(typeof reader.result === "string" ? reader.result : "");
-        reader.onerror = ()=> reject(reader.error || new Error("Unable to read file"));
-        reader.readAsDataURL(file);
-      });
-      attachments.push({
-        id: genId(file.name || "job_file"),
-        name: file.name || "Attachment",
-        type: file.type || "",
-        size: typeof file.size === "number" ? file.size : null,
-        source: "upload_requires_reference",
-        attachedAtISO: new Date().toISOString(),
-        rootLocationHint: String(cfg.folderHint || cfg.localRootName || ""),
-        dataUrl,
-        previewUrl: /^data:image\//i.test(dataUrl || "") ? dataUrl : ""
-      });
-    } catch (err){
-      console.error("Unable to read file", err);
-      toast("Use Attach from Reference Folder so this file can be saved as a WJ Cuts relative path.");
-    }
+  if (files.length){
+    toast("Local uploads are temporary and not saved as durable cloud file references. Use Attach from Reference Folder.");
   }
-  return attachments;
+  return [];
 }
 
 const JOB_ONEDRIVE_PREVIEW_CACHE_KEY = "cutting_job_onedrive_preview_cache_v1";
@@ -19431,6 +19409,20 @@ function renderJobs(){
     return normalizeOneDriveJobConfig(cfg);
   };
 
+
+  const getWJCutsRootStatus = async ()=>{
+    const config = getSharedConfig();
+    if (!supportsLocalRootPicker()) return { supported:false, handle:null, hasSavedHandle:false, permission:"unsupported", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Unsupported browser" };
+    const handle = await readLocalRootHandle();
+    if (!handle) return { supported:true, handle:null, hasSavedHandle:false, permission:"missing", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Not set" };
+    let permission = "prompt";
+    try { permission = typeof handle.queryPermission === "function" ? await handle.queryPermission({ mode:"read" }) : "granted"; } catch(_e){}
+    if (permission !== "granted") return { supported:true, handle, hasSavedHandle:true, permission, config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Permission needed" };
+    const signature = await computeLocalRootSignature(handle);
+    const expectedSignature = expectedRootSignatureFromJobs();
+    const signatureMatches = !expectedSignature || !signature ? true : signature === expectedSignature;
+    return { supported:true, handle, hasSavedHandle:true, permission:"granted", config, signature, expectedSignature, signatureMatches, message: signatureMatches ? "Verified" : "Mismatch" };
+  };
   const updateSharedConfig = (patch)=>{
     const cfg = getSharedConfig();
     return writeOneDriveJobConfig({ ...cfg, ...patch });
@@ -19438,9 +19430,11 @@ function renderJobs(){
 
   const updateOneDriveWizardStatus = async ()=>{
     const cfg = getSharedConfig();
-    if (oneDriveConnStatus) oneDriveConnStatus.textContent = cfg.localRootSignature ? "Configured" : "Not set";
-    if (oneDriveFolderStatus) oneDriveFolderStatus.textContent = cfg.localRootSignature ? "Verified" : "Not ready";
-    if (oneDriveLibraryStatus) oneDriveLibraryStatus.textContent = cfg.localRootSignature ? "Ready" : "Setup required";
+    const status = await getWJCutsRootStatus();
+    if (window.DEBUG_MODE) console.info("[cutting-job-files] root status", status);
+    if (oneDriveConnStatus) oneDriveConnStatus.textContent = status.message;
+    if (oneDriveFolderStatus) oneDriveFolderStatus.textContent = status.permission === "granted" ? (status.signatureMatches ? "Verified" : "Mismatch") : (status.hasSavedHandle ? "Permission needed" : "Not set");
+    if (oneDriveLibraryStatus) oneDriveLibraryStatus.textContent = status.permission === "granted" ? "Ready" : "Setup required";
     if (oneDriveRootStatus){
       oneDriveRootStatus.textContent = cfg.localRootName || "Not set";
     }
@@ -19475,10 +19469,13 @@ function renderJobs(){
         return false;
       }
       await saveLocalRootHandle(handle);
+      const verifyHandle = await readLocalRootHandle();
+      if (!verifyHandle){ toast("Unable to save root handle on this browser."); return false; }
       const cfg = getSharedConfig();
       updateSharedConfig({
         localRootName: String(handle.name || cfg.localRootName || "Configured"),
-        localRootSignature: signature
+        localRootSignature: signature,
+        enabled: true
       });
       await updateOneDriveWizardStatus();
       toast("This computer OneDrive root folder saved and verified.");
@@ -19499,13 +19496,10 @@ function renderJobs(){
     const rootHandle = await readLocalRootHandle();
     if (!rootHandle){
       pendingAttachJobId = String(targetJobId || "");
-      toast("Root folder is not set up yet. Select your WJ Cuts root folder now.");
-      const configured = await chooseLocalOneDriveRoot();
-      if (!configured){
-        openOneDriveModal();
-        return false;
-      }
-      return attachFromLocalOneDriveRoot(targetJobId);
+      toast("Set this computer’s WJ Cuts root folder before attaching files. The app saves a reference path, not the file itself.");
+      if (window.DEBUG_MODE) console.info("[cutting-job-files] attach blocked root missing", { targetJobId });
+      openOneDriveModal();
+      return false;
     }
 
     try {
@@ -19560,6 +19554,7 @@ function renderJobs(){
         rootPathStart: "WJ Cuts",
         relativePath: relPath,
         localRootSignature: signature,
+        enabled: true,
         localDeviceId: getLocalDeviceId(),
         attachedAtISO: new Date().toISOString(),
         rootLocationHint: String(cfg.folderHint || cfg.localRootName || "")
@@ -19567,7 +19562,8 @@ function renderJobs(){
       if (!reference) return false;
       const targetId = String(targetJobId || "");
       if (targetId){
-        const job = cuttingJobs.find(x => String(x?.id) === targetId);
+        const found = findJobRecord(targetId);
+        const job = found && found.job ? found.job : null;
         if (!job){
           toast("Job not found for OneDrive attachment.");
           return false;
@@ -19575,6 +19571,7 @@ function renderJobs(){
         job.files = Array.isArray(job.files) ? job.files : [];
         job.files.push(reference);
         saveCloudDebounced();
+        if (window.DEBUG_MODE) console.info("[cutting-job-files] attached reference", { targetId, relPath });
         toast("WJ Cuts file reference attached to job.");
         renderJobs();
       } else {
@@ -20490,8 +20487,10 @@ function renderJobs(){
 
   const historyBody = content.querySelector(".past-jobs-table tbody");
   historyBody?.addEventListener("click", async (e)=>{
+    let handled = false;
     const fileMenuAdd = e.target.closest("[data-job-file-add]");
     if (fileMenuAdd){
+      handled = true;
       const id = fileMenuAdd.getAttribute("data-job-file-add");
       if (id){
         e.preventDefault();
@@ -20509,6 +20508,7 @@ function renderJobs(){
 
     const previewPathBtn = e.target.closest("[data-preview-path-btn]");
     if (previewPathBtn){
+      handled = true;
       e.preventDefault();
       const expected = previewPathBtn.getAttribute("data-preview-expected-path") || "";
       if (expected){
@@ -20524,6 +20524,7 @@ function renderJobs(){
 
     const upload = e.target.closest("[data-upload-job]");
     if (upload){
+      handled = true;
       const id = upload.getAttribute("data-upload-job");
       e.preventDefault();
       closeActionMenu();
@@ -20534,6 +20535,7 @@ function renderJobs(){
 
     const linkJobFile = e.target.closest("[data-link-job-file]");
     if (linkJobFile){
+      handled = true;
       const id = linkJobFile.getAttribute("data-link-job-file");
       const idStr = String(id || "");
       const found = findJobRecord(idStr);
@@ -20568,6 +20570,7 @@ function renderJobs(){
 
     const editFileLink = e.target.closest("[data-edit-file-link]");
     if (editFileLink){
+      handled = true;
       const id = editFileLink.getAttribute("data-edit-file-link");
       const idx = Number(editFileLink.getAttribute("data-file-index"));
       const idStr = String(id || "");
@@ -20587,6 +20590,7 @@ function renderJobs(){
 
     const removeFile = e.target.closest("[data-remove-file]");
     if (removeFile){
+      handled = true;
       const id = removeFile.getAttribute("data-remove-file");
       const idx = Number(removeFile.getAttribute("data-file-index"));
       const idStr = String(id || "");
@@ -20601,6 +20605,7 @@ function renderJobs(){
       return;
     }
 
+    if (handled) e.stopImmediatePropagation();
   });
   historyBody?.addEventListener("change", (e)=>{
     const previewSelect = e.target instanceof Element
@@ -20685,6 +20690,7 @@ function renderJobs(){
   };
 
   historyBody?.addEventListener("click", async (e)=>{
+    let handled = false;
     const historyActionTrigger = e.target.closest("[data-history-actions-toggle]");
     if (historyActionTrigger){
       const id = historyActionTrigger.getAttribute("data-history-actions-toggle");
@@ -20711,6 +20717,7 @@ function renderJobs(){
 
     const previewPathBtn = e.target.closest("[data-preview-path-btn]");
     if (previewPathBtn){
+      handled = true;
       e.preventDefault();
       const expected = previewPathBtn.getAttribute("data-preview-expected-path") || "";
       if (expected){
@@ -21102,6 +21109,7 @@ function renderJobs(){
 
     const fileMenuAdd = e.target.closest("[data-job-file-add]");
     if (fileMenuAdd){
+      handled = true;
       const id = fileMenuAdd.getAttribute("data-job-file-add");
       if (id){
         e.preventDefault();
@@ -21166,6 +21174,7 @@ function renderJobs(){
 
     const upload = e.target.closest("[data-upload-job]");
     if (upload){
+      handled = true;
       const id = upload.getAttribute("data-upload-job");
       closeFileMenu();
       closeActionMenu();
@@ -21176,6 +21185,7 @@ function renderJobs(){
 
     const linkJobFile = e.target.closest("[data-link-job-file]");
     if (linkJobFile){
+      handled = true;
       const id = linkJobFile.getAttribute("data-link-job-file");
       const idStr = String(id || "");
       const found = findJobRecord(idStr);
@@ -21210,6 +21220,7 @@ function renderJobs(){
 
     const editFileLink = e.target.closest("[data-edit-file-link]");
     if (editFileLink){
+      handled = true;
       const id = editFileLink.getAttribute("data-edit-file-link");
       const idx = Number(editFileLink.getAttribute("data-file-index"));
       const idStr = String(id || "");
@@ -21229,6 +21240,7 @@ function renderJobs(){
 
     const removeFile = e.target.closest("[data-remove-file]");
     if (removeFile){
+      handled = true;
       const id = removeFile.getAttribute("data-remove-file");
       const idx = Number(removeFile.getAttribute("data-file-index"));
       const idStr = String(id || "");

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1534,6 +1534,12 @@ async function filesToAttachments(fileList){
   const attachments = [];
   for (const file of files){
     try {
+      const dataUrl = await new Promise((resolve, reject)=>{
+        const reader = new FileReader();
+        reader.onload = ()=> resolve(typeof reader.result === "string" ? reader.result : "");
+        reader.onerror = ()=> reject(reader.error || new Error("Unable to read file"));
+        reader.readAsDataURL(file);
+      });
       attachments.push({
         id: genId(file.name || "job_file"),
         name: file.name || "Attachment",
@@ -1541,7 +1547,9 @@ async function filesToAttachments(fileList){
         size: typeof file.size === "number" ? file.size : null,
         source: "upload_requires_reference",
         attachedAtISO: new Date().toISOString(),
-        rootLocationHint: String(cfg.folderHint || cfg.localRootName || "")
+        rootLocationHint: String(cfg.folderHint || cfg.localRootName || ""),
+        dataUrl,
+        previewUrl: /^data:image\//i.test(dataUrl || "") ? dataUrl : ""
       });
     } catch (err){
       console.error("Unable to read file", err);
@@ -20515,9 +20523,12 @@ function renderJobs(){
     if (upload){
       const id = upload.getAttribute("data-upload-job");
       e.preventDefault();
+      closeActionMenu();
+      closeHistoryActionMenu();
       content.querySelector(`input[data-job-file-input="${id}"]`)?.click();
       return;
     }
+
   });
   historyBody?.addEventListener("change", (e)=>{
     const previewSelect = e.target instanceof Element

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -20409,10 +20409,12 @@ function renderJobs(){
       const mode = option.getAttribute("data-preview-mode") || "message";
       const contentValue = option.getAttribute("data-preview-content") || "";
       const href = option.getAttribute("data-preview-href") || "";
+      const expectedPath = option.getAttribute("data-preview-expected-path") || "";
       const nameEl = previewRoot.querySelector("[data-preview-name]");
       const imgEl = previewRoot.querySelector("[data-preview-image]");
       const msgEl = previewRoot.querySelector("[data-preview-message]");
       const openEl = previewRoot.querySelector("[data-preview-open]");
+      const pathBtn = previewRoot.querySelector("[data-preview-path-btn]");
       if (nameEl){
         nameEl.textContent = name;
         nameEl.setAttribute("title", name);
@@ -20429,6 +20431,10 @@ function renderJobs(){
       if (openEl instanceof HTMLAnchorElement){
         openEl.href = href;
         openEl.hidden = !href;
+      }
+      if (pathBtn instanceof HTMLButtonElement){
+        pathBtn.hidden = !(mode === "message" && expectedPath);
+        pathBtn.dataset.previewExpectedPath = expectedPath;
       }
       return;
     }
@@ -20478,6 +20484,19 @@ function renderJobs(){
       return;
     }
 
+    const previewPathBtn = e.target.closest("[data-preview-path-btn]");
+    if (previewPathBtn){
+      e.preventDefault();
+      const expected = previewPathBtn.getAttribute("data-preview-expected-path") || "";
+      if (expected){
+        const msg = `Expected file path:
+${expected}`;
+        if (navigator?.clipboard?.writeText){ navigator.clipboard.writeText(expected).catch(()=>{}); }
+        if (window.alert) window.alert(msg); else toast(msg);
+      }
+      return;
+    }
+
     const upload = e.target.closest("[data-upload-job]");
     if (upload){
       const id = upload.getAttribute("data-upload-job");
@@ -20499,10 +20518,12 @@ function renderJobs(){
     const mode = option.getAttribute("data-preview-mode") || "message";
     const contentValue = option.getAttribute("data-preview-content") || "";
     const href = option.getAttribute("data-preview-href") || "";
+    const expectedPath = option.getAttribute("data-preview-expected-path") || "";
     const nameEl = previewRoot.querySelector("[data-preview-name]");
     const imgEl = previewRoot.querySelector("[data-preview-image]");
     const msgEl = previewRoot.querySelector("[data-preview-message]");
     const openEl = previewRoot.querySelector("[data-preview-open]");
+    const pathBtn = previewRoot.querySelector("[data-preview-path-btn]");
     if (nameEl){
       nameEl.textContent = name;
       nameEl.setAttribute("title", name);
@@ -20519,6 +20540,10 @@ function renderJobs(){
     if (openEl instanceof HTMLAnchorElement){
       openEl.href = href;
       openEl.hidden = !href;
+    }
+    if (pathBtn instanceof HTMLButtonElement){
+      pathBtn.hidden = !(mode === "message" && expectedPath);
+      pathBtn.dataset.previewExpectedPath = expectedPath;
     }
   });
 
@@ -20582,6 +20607,19 @@ function renderJobs(){
         closeHistoryActionMenu();
         closeActionMenu();
         openFileMenu(id, historyFileTrigger);
+      }
+      return;
+    }
+
+    const previewPathBtn = e.target.closest("[data-preview-path-btn]");
+    if (previewPathBtn){
+      e.preventDefault();
+      const expected = previewPathBtn.getAttribute("data-preview-expected-path") || "";
+      if (expected){
+        const msg = `Expected file path:
+${expected}`;
+        if (navigator?.clipboard?.writeText){ navigator.clipboard.writeText(expected).catch(()=>{}); }
+        if (window.alert) window.alert(msg); else toast(msg);
       }
       return;
     }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -987,7 +987,8 @@ function sanitizeJobFileReferenceForFirestore(fileRef){
     attachedAtISO: String(fileRef.attachedAtISO || fileRef.addedAt || new Date().toISOString()),
     localRootSignature: String(fileRef.localRootSignature || ""),
     localDeviceId: String(fileRef.localDeviceId || ""),
-    ...(fileRef.note ? { note: String(fileRef.note) } : {})
+    ...(fileRef.note ? { note: String(fileRef.note) } : {}),
+    ...(fileRef.rootLocationHint ? { rootLocationHint: String(fileRef.rootLocationHint) } : {})
   };
 }
 
@@ -1539,7 +1540,8 @@ async function filesToAttachments(fileList){
         type: file.type || "",
         size: typeof file.size === "number" ? file.size : null,
         source: "upload_requires_reference",
-        attachedAtISO: new Date().toISOString()
+        attachedAtISO: new Date().toISOString(),
+        rootLocationHint: String(cfg.folderHint || cfg.localRootName || "")
       });
     } catch (err){
       console.error("Unable to read file", err);
@@ -19408,6 +19410,7 @@ function renderJobs(){
   const oneDriveFolderStatus = document.querySelector("[data-onedrive-folder-status]");
   const oneDriveLibraryStatus = document.querySelector("[data-onedrive-library-status]");
   const oneDriveRootStatus = document.querySelector("[data-onedrive-root-status]");
+  const oneDriveRootPathStatus = document.querySelector("[data-onedrive-root-path]");
   const oneDriveDeviceStatus = document.querySelector("[data-onedrive-device-status]");
   const oneDriveLibraryAddToJobBtn = document.getElementById("jobOneDriveLibraryAddBtn");
   const oneDriveRootPickerBtn = document.getElementById("jobOneDriveRootPickerBtn");
@@ -19432,6 +19435,9 @@ function renderJobs(){
     if (oneDriveLibraryStatus) oneDriveLibraryStatus.textContent = cfg.localRootSignature ? "Ready" : "Setup required";
     if (oneDriveRootStatus){
       oneDriveRootStatus.textContent = cfg.localRootName || "Not set";
+    }
+    if (oneDriveRootPathStatus){
+      oneDriveRootPathStatus.textContent = cfg.folderHint || cfg.localRootName || "Not set";
     }
     if (oneDriveDeviceStatus){
       oneDriveDeviceStatus.textContent = getLocalDeviceId() ? `${getLocalDeviceNumber()} (${getLocalDeviceId()})` : "Unavailable";
@@ -19485,9 +19491,13 @@ function renderJobs(){
     const rootHandle = await readLocalRootHandle();
     if (!rootHandle){
       pendingAttachJobId = String(targetJobId || "");
-      toast("Root folder is not set up yet. Set up WJ Cuts Folder first, then attach the file.");
-      openOneDriveModal();
-      return false;
+      toast("Root folder is not set up yet. Select your WJ Cuts root folder now.");
+      const configured = await chooseLocalOneDriveRoot();
+      if (!configured){
+        openOneDriveModal();
+        return false;
+      }
+      return attachFromLocalOneDriveRoot(targetJobId);
     }
 
     try {
@@ -19543,7 +19553,8 @@ function renderJobs(){
         relativePath: relPath,
         localRootSignature: signature,
         localDeviceId: getLocalDeviceId(),
-        attachedAtISO: new Date().toISOString()
+        attachedAtISO: new Date().toISOString(),
+        rootLocationHint: String(cfg.folderHint || cfg.localRootName || "")
       });
       if (!reference) return false;
       const targetId = String(targetJobId || "");
@@ -20435,6 +20446,7 @@ function renderJobs(){
       if (pathBtn instanceof HTMLButtonElement){
         pathBtn.hidden = !(mode === "message" && expectedPath);
         pathBtn.dataset.previewExpectedPath = expectedPath;
+        pathBtn.dataset.previewRootLocation = option.getAttribute("data-preview-root-location") || "";
       }
       return;
     }
@@ -20489,8 +20501,10 @@ function renderJobs(){
       e.preventDefault();
       const expected = previewPathBtn.getAttribute("data-preview-expected-path") || "";
       if (expected){
-        const msg = `Expected file path:
-${expected}`;
+        const rootLocation = previewPathBtn.getAttribute("data-preview-root-location") || "";
+        const msg = rootLocation
+          ? `Root folder used: ${rootLocation}\nExpected file path:\n${expected}`
+          : `Expected file path:\n${expected}`;
         if (navigator?.clipboard?.writeText){ navigator.clipboard.writeText(expected).catch(()=>{}); }
         if (window.alert) window.alert(msg); else toast(msg);
       }
@@ -20544,6 +20558,7 @@ ${expected}`;
     if (pathBtn instanceof HTMLButtonElement){
       pathBtn.hidden = !(mode === "message" && expectedPath);
       pathBtn.dataset.previewExpectedPath = expectedPath;
+        pathBtn.dataset.previewRootLocation = option.getAttribute("data-preview-root-location") || "";
     }
   });
 
@@ -20616,8 +20631,10 @@ ${expected}`;
       e.preventDefault();
       const expected = previewPathBtn.getAttribute("data-preview-expected-path") || "";
       if (expected){
-        const msg = `Expected file path:
-${expected}`;
+        const rootLocation = previewPathBtn.getAttribute("data-preview-root-location") || "";
+        const msg = rootLocation
+          ? `Root folder used: ${rootLocation}\nExpected file path:\n${expected}`
+          : `Expected file path:\n${expected}`;
         if (navigator?.clipboard?.writeText){ navigator.clipboard.writeText(expected).catch(()=>{}); }
         if (window.alert) window.alert(msg); else toast(msg);
       }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1075,9 +1075,28 @@ function verifyRootSignatureMatches(signature){
   return { ok: expected === signature, expected };
 }
 
+function describeLocalRootPreviewError(err){
+  const msg = String(err?.message || err || "").toLowerCase();
+  if (msg.includes("notallowederror") || msg.includes("permission") || msg.includes("denied")){
+    return "Preview unavailable: this browser lost access to your WJ Cuts root folder. Re-open OneDrive setup and re-select the root folder.";
+  }
+  if (msg.includes("notfounderror") || msg.includes("not found")){
+    return "Preview unavailable: this file was not found under your selected WJ Cuts root folder. Verify the same shared root folder is selected.";
+  }
+  return "Preview unavailable: unable to read this file from your WJ Cuts root folder. Re-open OneDrive setup and verify root folder access.";
+}
+
 async function resolveLocalFileFromRelativePath(relativePath){
   const rootHandle = await readLocalRootHandle();
-  if (!rootHandle) return null;
+  if (!rootHandle){
+    throw new Error("No saved WJ Cuts root folder on this device.");
+  }
+  const perm = typeof rootHandle.queryPermission === "function"
+    ? await rootHandle.queryPermission({ mode: "read" })
+    : "granted";
+  if (perm !== "granted"){
+    throw new Error("WJ Cuts root folder permission is not granted.");
+  }
   const rel = String(relativePath || "").replace(/^\/+/, "");
   if (!rel) return null;
   const segments = rel.split("/").filter(Boolean);
@@ -1624,7 +1643,7 @@ async function resolveAttachmentPreview(file){
     try {
       const localFile = await resolveWJCutsRelativePath(file.relativePath);
       if (!localFile){
-        file.preview = file.preview || { mode: "message", content: "File reference saved, but the file was not found under your selected WJ Cuts folder." };
+        file.preview = { mode: "message", content: "Preview unavailable: file reference was saved, but the file is missing under your selected WJ Cuts root folder." };
         return false;
       }
       const preview = await buildAttachmentPreview(localFile);
@@ -1632,10 +1651,10 @@ async function resolveAttachmentPreview(file){
         file.preview = preview;
         return preview.mode === "image";
       }
-      file.preview = file.preview || { mode: "message", content: "Preview unavailable for this WJ Cuts referenced file type." };
+      file.preview = { mode: "message", content: "Preview unavailable: this WJ Cuts file type cannot be rendered as a 2D preview." };
       return false;
-    } catch (_err){
-      file.preview = file.preview || { mode: "message", content: "Preview unavailable for this WJ Cuts referenced file." };
+    } catch (err){
+      file.preview = { mode: "message", content: describeLocalRootPreviewError(err) };
       return false;
     }
   }
@@ -20399,7 +20418,8 @@ function renderJobs(){
     if (e.target.matches("input[data-job-file-input]")){
       const id = e.target.getAttribute("data-job-file-input");
       const idStr = String(id || "");
-      const j = cuttingJobs.find(x => String(x?.id) === idStr);
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
       if (!j){ e.target.value = ""; return; }
       const attachments = await filesToAttachments(e.target.files);
       e.target.value = "";
@@ -20410,6 +20430,32 @@ function renderJobs(){
   });
 
   const historyBody = content.querySelector(".past-jobs-table tbody");
+  historyBody?.addEventListener("click", async (e)=>{
+    const fileMenuAdd = e.target.closest("[data-job-file-add]");
+    if (fileMenuAdd){
+      const id = fileMenuAdd.getAttribute("data-job-file-add");
+      if (id){
+        e.preventDefault();
+        closeFileMenu();
+        closeActionMenu();
+        closeHistoryActionMenu();
+        const attached = await attachFromLocalOneDriveRoot(id);
+        if (!attached){
+          window.pendingJobFocus = { type: "jobRow", id };
+          renderJobs();
+        }
+      }
+      return;
+    }
+
+    const upload = e.target.closest("[data-upload-job]");
+    if (upload){
+      const id = upload.getAttribute("data-upload-job");
+      e.preventDefault();
+      content.querySelector(`input[data-job-file-input="${id}"]`)?.click();
+      return;
+    }
+  });
   historyBody?.addEventListener("change", (e)=>{
     const previewSelect = e.target instanceof Element
       ? e.target.closest("select[data-file-preview-select]")
@@ -20964,7 +21010,8 @@ function renderJobs(){
     if (linkJobFile){
       const id = linkJobFile.getAttribute("data-link-job-file");
       const idStr = String(id || "");
-      const j = cuttingJobs.find(x => String(x?.id) === idStr);
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
       if (!j) return;
       try {
         const picked = await window.oneDrivePicker.openOneDriveDxfPicker();
@@ -20998,7 +21045,8 @@ function renderJobs(){
       const id = editFileLink.getAttribute("data-edit-file-link");
       const idx = Number(editFileLink.getAttribute("data-file-index"));
       const idStr = String(id || "");
-      const j = cuttingJobs.find(x => String(x?.id) === idStr);
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
       const file = j && Array.isArray(j.files) && idx >= 0 ? j.files[idx] : null;
       if (!file) return;
       const url = promptOneDriveLinkForFile(file.name || "attachment", file.url || "");
@@ -21016,7 +21064,8 @@ function renderJobs(){
       const id = removeFile.getAttribute("data-remove-file");
       const idx = Number(removeFile.getAttribute("data-file-index"));
       const idStr = String(id || "");
-      const j = cuttingJobs.find(x => String(x?.id) === idStr);
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
       if (j && Array.isArray(j.files) && idx>=0 && idx<j.files.length){
         j.files.splice(idx,1);
         saveCloudDebounced();

--- a/js/views.js
+++ b/js/views.js
@@ -2906,6 +2906,7 @@ function viewJobs(){
     const href = String(file?.dataUrl || file?.url || "");
     const previewUrl = String(file?.previewUrl || "");
     const ext = extractFileExtension(name);
+    const source = String(file?.source || "");
     const savedPreview = file && typeof file === "object" ? file.preview : null;
     if (savedPreview && typeof savedPreview === "object"){
       const mode = savedPreview.mode === "image" ? "image" : "message";
@@ -2913,7 +2914,12 @@ function viewJobs(){
       if (content) return { name, href, mode, content };
     }
     if (/^data:image\//i.test(previewUrl) || /^https?:\/\//i.test(previewUrl)) return { name, href: href || previewUrl, mode: "image", content: previewUrl };
-    if (!href) return { name, href: "", mode: "message", content: "Preview unavailable" };
+    if (!href){
+      if (source === "wj_cuts_reference") return { name, href: "", mode: "message", content: "Preview unavailable: this file is stored as a WJ Cuts reference path only. Select/verify your WJ Cuts root folder on this device, then reopen this job." };
+      if (source === "onedrive") return { name, href: "", mode: "message", content: "Preview unavailable: OneDrive link metadata is incomplete. Relink this file from OneDrive so preview content can load." };
+      if ([".dxf", ".ord", ".omx"].includes(ext)) return { name, href: "", mode: "message", content: "Preview unavailable: no file content URL is saved for this CAD file. Re-attach from Reference Folder or add a direct OneDrive URL." };
+      return { name, href: "", mode: "message", content: "Preview unavailable: no file content was saved for this attachment." };
+    }
     if (ext === ".svg") return { name, href, mode: "image", content: href };
     if (/^data:image\//i.test(href)) return { name, href, mode: "image", content: href };
     if (/^https?:\/\//i.test(href) && [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"].includes(ext)){

--- a/js/views.js
+++ b/js/views.js
@@ -2904,6 +2904,9 @@ function viewJobs(){
   const filePreviewModel = (file)=>{
     const name = String(file?.name || "Attached file");
     const href = String(file?.dataUrl || file?.url || "");
+    const expectedPath = file?.source === "wj_cuts_reference" && file?.relativePath
+      ? `${String(file?.rootPathStart || "WJ Cuts")}\\${String(file.relativePath || "").replace(/\//g, "\\")}`
+      : "";
     const previewUrl = String(file?.previewUrl || "");
     const ext = extractFileExtension(name);
     const source = String(file?.source || "");
@@ -2911,38 +2914,38 @@ function viewJobs(){
     if (savedPreview && typeof savedPreview === "object"){
       const mode = savedPreview.mode === "image" ? "image" : "message";
       const content = String(savedPreview.content || "").trim();
-      if (content) return { name, href, mode, content };
+      if (content) return { name, href, mode, content, expectedPath };
     }
-    if (/^data:image\//i.test(previewUrl) || /^https?:\/\//i.test(previewUrl)) return { name, href: href || previewUrl, mode: "image", content: previewUrl };
+    if (/^data:image\//i.test(previewUrl) || /^https?:\/\//i.test(previewUrl)) return { name, href: href || previewUrl, mode: "image", content: previewUrl, expectedPath };
     if (!href){
-      if (source === "wj_cuts_reference") return { name, href: "", mode: "message", content: "Preview unavailable: this file is stored as a WJ Cuts reference path only. Select/verify your WJ Cuts root folder on this device, then reopen this job." };
-      if (source === "onedrive") return { name, href: "", mode: "message", content: "Preview unavailable: OneDrive link metadata is incomplete. Relink this file from OneDrive so preview content can load." };
-      if ([".dxf", ".ord", ".omx"].includes(ext)) return { name, href: "", mode: "message", content: "Preview unavailable: no file content URL is saved for this CAD file. Re-attach from Reference Folder or add a direct OneDrive URL." };
-      return { name, href: "", mode: "message", content: "Preview unavailable: no file content was saved for this attachment." };
+      if (source === "wj_cuts_reference") return { name, href: "", mode: "message", content: "Preview unavailable: this file is stored as a WJ Cuts reference path only. Select/verify your WJ Cuts root folder on this device, then reopen this job.", expectedPath };
+      if (source === "onedrive") return { name, href: "", mode: "message", content: "Preview unavailable: OneDrive link metadata is incomplete. Relink this file from OneDrive so preview content can load.", expectedPath };
+      if ([".dxf", ".ord", ".omx"].includes(ext)) return { name, href: "", mode: "message", content: "Preview unavailable: no file content URL is saved for this CAD file. Re-attach from Reference Folder or add a direct OneDrive URL.", expectedPath };
+      return { name, href: "", mode: "message", content: "Preview unavailable: no file content was saved for this attachment.", expectedPath };
     }
-    if (ext === ".svg") return { name, href, mode: "image", content: href };
-    if (/^data:image\//i.test(href)) return { name, href, mode: "image", content: href };
+    if (ext === ".svg") return { name, href, mode: "image", content: href, expectedPath };
+    if (/^data:image\//i.test(href)) return { name, href, mode: "image", content: href, expectedPath };
     if (/^https?:\/\//i.test(href) && [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"].includes(ext)){
-      return { name, href, mode: "image", content: href };
+      return { name, href, mode: "image", content: href, expectedPath };
     }
     if ([".dxf", ".ord", ".omx"].includes(ext)) {
       const text = decodeDataUrlText(href);
       const cadSvg = text ? renderCadToSvgDataUrl(text) : "";
       return cadSvg
-        ? { name, href, mode: "image", content: cadSvg }
-        : { name, href, mode: "message", content: "2D preview unavailable. Add a OneDrive direct file URL or re-upload to refresh preview." };
+        ? { name, href, mode: "image", content: cadSvg, expectedPath }
+        : { name, href, mode: "message", content: "2D preview unavailable. Add a OneDrive direct file URL or re-upload to refresh preview.", expectedPath };
     }
-    return { name, href, mode: "message", content: "Preview unavailable for this file type." };
+    return { name, href, mode: "message", content: "Preview unavailable for this file type.", expectedPath };
   };
   const buildFileCellMarkup = (jobId, files)=>{
     const previews = (Array.isArray(files) ? files : []).map(filePreviewModel);
     if (!previews.length) return '<div class="job-file-preview-empty small muted">No files attached</div>';
-    const first = previews[0] || { name: "Attached file", mode: "message", content: "Preview unavailable", href: "" };
+    const first = previews[0] || { name: "Attached file", mode: "message", content: "Preview unavailable", href: "", expectedPath: "" };
     const selectId = `jobFileSelect_${esc(jobId)}`;
     return `
       <div class="job-file-preview" data-file-preview data-file-preview-job="${esc(jobId)}">
         ${previews.length > 1
-          ? `<label class="sr-only" for="${selectId}">Choose file preview</label><select id="${selectId}" class="job-file-preview-select" data-file-preview-select="${esc(jobId)}">${previews.map((f, idx)=>`<option value="${idx}" data-preview-name="${esc(f.name)}" data-preview-mode="${esc(f.mode)}" data-preview-content="${esc(f.content)}" data-preview-href="${esc(f.href || "")}">${esc(f.name)}</option>`).join("")}</select>`
+          ? `<label class="sr-only" for="${selectId}">Choose file preview</label><select id="${selectId}" class="job-file-preview-select" data-file-preview-select="${esc(jobId)}">${previews.map((f, idx)=>`<option value="${idx}" data-preview-name="${esc(f.name)}" data-preview-mode="${esc(f.mode)}" data-preview-content="${esc(f.content)}" data-preview-href="${esc(f.href || "")}" data-preview-expected-path="${esc(f.expectedPath || "")}">${esc(f.name)}</option>`).join("")}</select>`
           : ""}
         <div class="job-file-preview-panes" data-file-preview-panes>
           <div class="job-file-preview-pane" data-file-preview-pane>
@@ -2950,6 +2953,7 @@ function viewJobs(){
             <div class="job-file-preview-frame">
               <img src="${first.mode === "image" ? esc(first.content) : ""}" alt="Preview of ${esc(first.name)}" class="job-file-preview-image" data-preview-image ${first.mode === "image" ? "" : "hidden"}>
               <span class="job-file-preview-message small muted" data-preview-message ${first.mode === "message" ? "" : "hidden"}>${first.mode === "message" ? esc(first.content) : ""}</span>
+              <button type="button" class="small link" data-preview-path-btn data-preview-expected-path="${esc(first.expectedPath || "")}" ${first.mode === "message" && first.expectedPath ? "" : "hidden"}>Show expected path</button>
             </div>
             <a class="job-file-preview-open small" data-preview-open href="${esc(first.href || "")}" target="_blank" rel="noopener" ${first.href ? "" : "hidden"}>Open file</a>
           </div>

--- a/js/views.js
+++ b/js/views.js
@@ -3961,6 +3961,20 @@ function viewJobs(){
               </aside>
             </div>
             <label class="job-edit-note">Notes<textarea data-history-field="notes" data-history-id="${job.id}" rows="3" placeholder="Notes...">${textEsc(job?.notes || "")}</textarea></label>
+            <div class="job-edit-files">
+              <div class="job-edit-files-actions"><button type="button" data-job-file-add="${job.id}">Attach from Reference Folder</button><button type="button" data-upload-job="${job.id}">Add Files</button><button type="button" data-link-job-file="${job.id}">Link OneDrive URL</button></div>
+              <input type="file" data-job-file-input="${job.id}" multiple style="display:none">
+              <ul class="job-file-list">
+                ${jobFiles.length ? jobFiles.map((f, idx)=>{
+                  const safeName = f.name || `file_${idx+1}`;
+                  const href = f.dataUrl || f.url || f.externalUrl || f.downloadUrl || f.oneDriveUrl || "";
+                  const usableLink = !!href && !/^data:(image|application)\//i.test(String(href || "")) && /^https?:\/\//i.test(String(href || ""));
+                  const link = usableLink ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : `${safeName} <span class="small muted">— File metadata saved only — original file content is not stored.</span>`;
+                  const sourceTag = f?.source === "onedrive" ? `<span class="job-file-source-badge">OneDrive</span>` : "";
+                  return `<li>${link} ${sourceTag} <button type="button" class="link" data-edit-file-link="${job.id}" data-file-index="${idx}">Link</button> <button type="button" class="link" data-remove-file="${job.id}" data-file-index="${idx}">Remove</button></li>`;
+                }).join("") : `<li class="muted">No files attached</li>`}
+              </ul>
+            </div>
             <div class="job-edit-actions">
               <button type="button" data-history-save="${job.id}">Save</button>
               <button type="button" class="danger" data-history-cancel="${job.id}">Cancel</button>
@@ -4374,7 +4388,7 @@ function viewJobs(){
             </div>
               <label class="job-edit-note">Notes<textarea data-j="notes" data-id="${j.id}" rows="3" placeholder="Notes...">${j.notes||""}</textarea></label>
               <div class="job-edit-files">
-                <div class="job-edit-files-actions"><button type="button" data-upload-job="${j.id}">Add Files</button><button type="button" data-link-job-file="${j.id}">Link OneDrive URL</button></div>
+                <div class="job-edit-files-actions"><button type="button" data-job-file-add="${j.id}">Attach from Reference Folder</button><button type="button" data-upload-job="${j.id}">Add Files</button><button type="button" data-link-job-file="${j.id}">Link OneDrive URL</button></div>
                 <input type="file" data-job-file-input="${j.id}" multiple style="display:none">
                 <ul class="job-file-list">
                   ${jobFiles.length ? jobFiles.map((f, idx)=>{

--- a/js/views.js
+++ b/js/views.js
@@ -2910,42 +2910,43 @@ function viewJobs(){
     const previewUrl = String(file?.previewUrl || "");
     const ext = extractFileExtension(name);
     const source = String(file?.source || "");
+    const rootLocation = String(file?.rootLocationHint || "");
     const savedPreview = file && typeof file === "object" ? file.preview : null;
     if (savedPreview && typeof savedPreview === "object"){
       const mode = savedPreview.mode === "image" ? "image" : "message";
       const content = String(savedPreview.content || "").trim();
-      if (content) return { name, href, mode, content, expectedPath };
+      if (content) return { name, href, mode, content, expectedPath, rootLocation };
     }
-    if (/^data:image\//i.test(previewUrl) || /^https?:\/\//i.test(previewUrl)) return { name, href: href || previewUrl, mode: "image", content: previewUrl, expectedPath };
+    if (/^data:image\//i.test(previewUrl) || /^https?:\/\//i.test(previewUrl)) return { name, href: href || previewUrl, mode: "image", content: previewUrl, expectedPath, rootLocation };
     if (!href){
-      if (source === "wj_cuts_reference") return { name, href: "", mode: "message", content: "Preview unavailable: this file is stored as a WJ Cuts reference path only. Select/verify your WJ Cuts root folder on this device, then reopen this job.", expectedPath };
-      if (source === "onedrive") return { name, href: "", mode: "message", content: "Preview unavailable: OneDrive link metadata is incomplete. Relink this file from OneDrive so preview content can load.", expectedPath };
-      if ([".dxf", ".ord", ".omx"].includes(ext)) return { name, href: "", mode: "message", content: "Preview unavailable: no file content URL is saved for this CAD file. Re-attach from Reference Folder or add a direct OneDrive URL.", expectedPath };
-      return { name, href: "", mode: "message", content: "Preview unavailable: no file content was saved for this attachment.", expectedPath };
+      if (source === "wj_cuts_reference") return { name, href: "", mode: "message", content: "Preview unavailable: this file is stored as a WJ Cuts reference path only. Select/verify your WJ Cuts root folder on this device, then reopen this job.", expectedPath, rootLocation };
+      if (source === "onedrive") return { name, href: "", mode: "message", content: "Preview unavailable: OneDrive link metadata is incomplete. Relink this file from OneDrive so preview content can load.", expectedPath, rootLocation };
+      if ([".dxf", ".ord", ".omx"].includes(ext)) return { name, href: "", mode: "message", content: "Preview unavailable: no file content URL is saved for this CAD file. Re-attach from Reference Folder or add a direct OneDrive URL.", expectedPath, rootLocation };
+      return { name, href: "", mode: "message", content: "Preview unavailable: no file content was saved for this attachment.", expectedPath, rootLocation };
     }
-    if (ext === ".svg") return { name, href, mode: "image", content: href, expectedPath };
-    if (/^data:image\//i.test(href)) return { name, href, mode: "image", content: href, expectedPath };
+    if (ext === ".svg") return { name, href, mode: "image", content: href, expectedPath, rootLocation };
+    if (/^data:image\//i.test(href)) return { name, href, mode: "image", content: href, expectedPath, rootLocation };
     if (/^https?:\/\//i.test(href) && [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"].includes(ext)){
-      return { name, href, mode: "image", content: href, expectedPath };
+      return { name, href, mode: "image", content: href, expectedPath, rootLocation };
     }
     if ([".dxf", ".ord", ".omx"].includes(ext)) {
       const text = decodeDataUrlText(href);
       const cadSvg = text ? renderCadToSvgDataUrl(text) : "";
       return cadSvg
-        ? { name, href, mode: "image", content: cadSvg, expectedPath }
-        : { name, href, mode: "message", content: "2D preview unavailable. Add a OneDrive direct file URL or re-upload to refresh preview.", expectedPath };
+        ? { name, href, mode: "image", content: cadSvg, expectedPath, rootLocation }
+        : { name, href, mode: "message", content: "2D preview unavailable. Add a OneDrive direct file URL or re-upload to refresh preview.", expectedPath, rootLocation };
     }
-    return { name, href, mode: "message", content: "Preview unavailable for this file type.", expectedPath };
+    return { name, href, mode: "message", content: "Preview unavailable for this file type.", expectedPath, rootLocation };
   };
   const buildFileCellMarkup = (jobId, files)=>{
     const previews = (Array.isArray(files) ? files : []).map(filePreviewModel);
     if (!previews.length) return '<div class="job-file-preview-empty small muted">No files attached</div>';
-    const first = previews[0] || { name: "Attached file", mode: "message", content: "Preview unavailable", href: "", expectedPath: "" };
+    const first = previews[0] || { name: "Attached file", mode: "message", content: "Preview unavailable", href: "", expectedPath: "", rootLocation: "" };
     const selectId = `jobFileSelect_${esc(jobId)}`;
     return `
       <div class="job-file-preview" data-file-preview data-file-preview-job="${esc(jobId)}">
         ${previews.length > 1
-          ? `<label class="sr-only" for="${selectId}">Choose file preview</label><select id="${selectId}" class="job-file-preview-select" data-file-preview-select="${esc(jobId)}">${previews.map((f, idx)=>`<option value="${idx}" data-preview-name="${esc(f.name)}" data-preview-mode="${esc(f.mode)}" data-preview-content="${esc(f.content)}" data-preview-href="${esc(f.href || "")}" data-preview-expected-path="${esc(f.expectedPath || "")}">${esc(f.name)}</option>`).join("")}</select>`
+          ? `<label class="sr-only" for="${selectId}">Choose file preview</label><select id="${selectId}" class="job-file-preview-select" data-file-preview-select="${esc(jobId)}">${previews.map((f, idx)=>`<option value="${idx}" data-preview-name="${esc(f.name)}" data-preview-mode="${esc(f.mode)}" data-preview-content="${esc(f.content)}" data-preview-href="${esc(f.href || "")}" data-preview-expected-path="${esc(f.expectedPath || "")}" data-preview-root-location="${esc(f.rootLocation || "")}">${esc(f.name)}</option>`).join("")}</select>`
           : ""}
         <div class="job-file-preview-panes" data-file-preview-panes>
           <div class="job-file-preview-pane" data-file-preview-pane>
@@ -2953,7 +2954,7 @@ function viewJobs(){
             <div class="job-file-preview-frame">
               <img src="${first.mode === "image" ? esc(first.content) : ""}" alt="Preview of ${esc(first.name)}" class="job-file-preview-image" data-preview-image ${first.mode === "image" ? "" : "hidden"}>
               <span class="job-file-preview-message small muted" data-preview-message ${first.mode === "message" ? "" : "hidden"}>${first.mode === "message" ? esc(first.content) : ""}</span>
-              <button type="button" class="small link" data-preview-path-btn data-preview-expected-path="${esc(first.expectedPath || "")}" ${first.mode === "message" && first.expectedPath ? "" : "hidden"}>Show expected path</button>
+              <button type="button" class="small link" data-preview-path-btn data-preview-expected-path="${esc(first.expectedPath || "")}" data-preview-root-location="${esc(first.rootLocation || "")}" ${first.mode === "message" && first.expectedPath ? "" : "hidden"}>Show expected path</button>
             </div>
             <a class="job-file-preview-open small" data-preview-open href="${esc(first.href || "")}" target="_blank" rel="noopener" ${first.href ? "" : "hidden"}>Open file</a>
           </div>
@@ -4648,6 +4649,7 @@ function viewJobs(){
               <div>Root setup: <span data-onedrive-connection-status>Not set</span></div>
               <div>Folder status: <span data-onedrive-folder-status>Not ready</span></div>
               <div>This computer root: <span data-onedrive-root-status>Not set</span></div>
+              <div>Root path hint: <span data-onedrive-root-path>Not set</span></div>
               <div>This computer ID: <span data-onedrive-device-status>Not set</span></div>
               <div>Indexed files: <span data-onedrive-library-status>0</span></div>
             </div>

--- a/style.css
+++ b/style.css
@@ -3342,9 +3342,15 @@ body.modal-open .auth-bar {
   display: block;
 }
 .job-file-preview-message {
-  text-align: center;
+  text-align: left;
   line-height: 1.35;
   padding: 0 6px;
+  width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  display: block;
+  max-height: 84px;
+  overflow-y: auto;
 }
 .job-file-preview-empty {
   margin: 0;


### PR DESCRIPTION
### Motivation
- Enable attaching files stored under the saved WJ Cuts root folder and provide clearer user feedback when referenced files cannot be previewed or accessed.
- Make job record lookups more robust by consolidating repeated `cuttingJobs.find` usage into `findJobRecord` so history and inline actions work consistently.

### Description
- Added `describeLocalRootPreviewError` to produce clearer, actionable preview error messages for permission, not-found, and generic failures when reading the local OneDrive root.
- Updated `resolveLocalFileFromRelativePath` to throw explicit errors when no saved root handle or when read permission is not granted, and to check `queryPermission` before accessing files.
- Enhanced `resolveAttachmentPreview` for `wj_cuts_reference` attachments to set more specific preview messages and use `describeLocalRootPreviewError` on exceptions, and kept existing 2D preview rendering paths.
- UI changes in `viewJobs` add an `Attach from Reference Folder` button, file upload controls, and file list rendering with OneDrive badges, plus event handlers in `renderers.js` to handle `data-job-file-add` and `data-upload-job` interactions and replace several direct `cuttingJobs.find` calls with `findJobRecord`.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb1aa0ee88325b4d23412651539a5)