### PR TITLE
WJ Cuts / OneDrive: attach-from-root flow, improved preview diagnostics, job-file UI, and V2 safety checks

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -237,6 +237,19 @@ function hideBubbleSoon(){
   }, 180);
 }
 
+function ensureBubble(){
+  let bubble = document.getElementById("bubble");
+  if (bubble) return bubble;
+  bubble = document.createElement("div");
+  bubble.id = "bubble";
+  bubble.className = "calendar-bubble";
+  bubble.setAttribute("role", "dialog");
+  bubble.setAttribute("aria-live", "polite");
+  bubble.tabIndex = -1;
+  document.body.appendChild(bubble);
+  return bubble;
+}
+
 function showV2OneTimeBubble(occurrenceId, anchorEl){
   const lookup = (typeof window !== "undefined" && window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object")
     ? window.__calendarV2OneTimeLookup
@@ -880,6 +893,104 @@ function resolveV2OneTimeOccurrenceState(rootOccurrenceId, scheduledEvent){
   });
   return { status, note, hours, displayDateISO };
 }
+
+function runMaintenanceV2SafetyChecks(){
+  const occurrences = Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : [];
+  const instances = Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2 : [];
+  const warnings = [];
+  const errors = [];
+  const info = [];
+  const byRoot = new Map();
+  const lifecycleMap = new Map([
+    ["completed", "completed"],
+    ["uncompleted", "scheduled"],
+    ["scheduled", "scheduled"],
+    ["removed", "removed"],
+    ["skipped", "skipped"]
+  ]);
+  const stableId = (entry, idx)=> String(entry?.eventId || entry?.id || `${entry?.rootOccurrenceId || "root"}:${idx}`);
+  occurrences.forEach((entry, idx)=>{
+    if (!entry || typeof entry !== "object") return;
+    const rootId = String(entry.rootOccurrenceId || "");
+    if (!rootId) return;
+    if (!byRoot.has(rootId)) byRoot.set(rootId, []);
+    byRoot.get(rootId).push({ entry, idx, stable: stableId(entry, idx) });
+    if (String(entry.eventType || "") === "moved"){
+      const toDate = normalizeDateKey(entry?.payload?.toDateISO || entry?.displayDateISO || entry?.effectiveDateISO || null);
+      if (!toDate){
+        warnings.push({ type: "moved_missing_toDateISO", rootOccurrenceId: rootId, eventId: stableId(entry, idx) });
+      }
+    }
+  });
+
+  const finalLifecycleByRoot = new Map();
+  const finalEventByRoot = new Map();
+  const activeCompletedRoots = new Set();
+  byRoot.forEach((events, rootId)=>{
+    const sortable = events.map(item=>{
+      const ts = Date.parse(String(item.entry?.recordedAtISO || ""));
+      return { ...item, ts: Number.isFinite(ts) ? ts : null };
+    });
+    const unknownOrder = sortable.filter(x => x.ts == null).length > 1;
+    sortable.sort((a,b)=>{
+      if (a.ts != null && b.ts != null && a.ts !== b.ts) return a.ts - b.ts;
+      if (a.ts != null && b.ts == null) return -1;
+      if (a.ts == null && b.ts != null) return 1;
+      if (a.idx !== b.idx) return a.idx - b.idx;
+      return a.stable.localeCompare(b.stable);
+    });
+    if (unknownOrder){
+      warnings.push({ type: "undetermined_lifecycle_order", rootOccurrenceId: rootId, events: sortable.map(s=>s.stable) });
+    }
+    let finalLifecycleStatus = "scheduled";
+    let finalEvent = null;
+    sortable.forEach(item=>{
+      const t = String(item.entry?.eventType || "").toLowerCase();
+      if (lifecycleMap.has(t)){
+        finalLifecycleStatus = lifecycleMap.get(t);
+        finalEvent = item.entry;
+      }
+    });
+    finalLifecycleByRoot.set(rootId, finalLifecycleStatus);
+    if (finalEvent) finalEventByRoot.set(rootId, finalEvent);
+    if (finalLifecycleStatus === "completed") activeCompletedRoots.add(rootId);
+  });
+
+  instances.forEach(instance=>{
+    const rule = instance?.repeatRule && typeof instance.repeatRule === "object" ? instance.repeatRule : {};
+    const endTypeRaw = String(rule.endType || rule.endMode || "never").toLowerCase();
+    const endType = ["never", "on_date", "after_count"].includes(endTypeRaw) ? endTypeRaw : "never";
+    if (endType === "after_count" && !Number.isFinite(Number(rule.endCount || 0))){
+      warnings.push({ type: "repeat_after_count_missing_endCount", instanceId: String(instance?.id || "") });
+    }
+  });
+
+  activeCompletedRoots.forEach(rootId=>{
+    const ev = finalEventByRoot.get(rootId) || {};
+    const displayDateISO = normalizeDateKey(ev.displayDateISO || ev.effectiveDateISO || ev.dateISO || null);
+    if (!String(ev.rootOccurrenceId || rootId) || !String(ev.instanceId || "") || !String(ev.taskId || "") || !displayDateISO){
+      errors.push({ type: "completed_root_missing_required_fields", rootOccurrenceId: rootId });
+    }
+  });
+
+  if (!Array.isArray(window.taskEvents)){
+    info.push({ type: "calendar_chip_parity_non_blocking", detail: "window.taskEvents unavailable; parity check skipped." });
+  }
+
+  const report = {
+    checkedAtISO: new Date().toISOString(),
+    byRootCount: byRoot.size,
+    activeCompletedRoots: Array.from(activeCompletedRoots),
+    finalLifecycleByRoot: Object.fromEntries(finalLifecycleByRoot),
+    warnings,
+    errors,
+    info,
+    readOnly: true
+  };
+  if (window.DEBUG_MODE) console.info("[maintenance-v2] safety checks", report);
+  return report;
+}
+window.runMaintenanceV2SafetyChecks = runMaintenanceV2SafetyChecks;
 
 window.completeV2OneTimeOccurrence = (occurrenceId)=>{
   const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -237,19 +237,6 @@ function hideBubbleSoon(){
   }, 180);
 }
 
-function ensureBubble(){
-  let bubble = document.getElementById("bubble");
-  if (bubble) return bubble;
-  bubble = document.createElement("div");
-  bubble.id = "bubble";
-  bubble.className = "calendar-bubble";
-  bubble.setAttribute("role", "dialog");
-  bubble.setAttribute("aria-live", "polite");
-  bubble.tabIndex = -1;
-  document.body.appendChild(bubble);
-  return bubble;
-}
-
 function showV2OneTimeBubble(occurrenceId, anchorEl){
   const lookup = (typeof window !== "undefined" && window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object")
     ? window.__calendarV2OneTimeLookup
@@ -893,104 +880,6 @@ function resolveV2OneTimeOccurrenceState(rootOccurrenceId, scheduledEvent){
   });
   return { status, note, hours, displayDateISO };
 }
-
-function runMaintenanceV2SafetyChecks(){
-  const occurrences = Array.isArray(window.maintenanceOccurrencesV2) ? window.maintenanceOccurrencesV2 : [];
-  const instances = Array.isArray(window.maintenanceCalendarInstancesV2) ? window.maintenanceCalendarInstancesV2 : [];
-  const warnings = [];
-  const errors = [];
-  const info = [];
-  const byRoot = new Map();
-  const lifecycleMap = new Map([
-    ["completed", "completed"],
-    ["uncompleted", "scheduled"],
-    ["scheduled", "scheduled"],
-    ["removed", "removed"],
-    ["skipped", "skipped"]
-  ]);
-  const stableId = (entry, idx)=> String(entry?.eventId || entry?.id || `${entry?.rootOccurrenceId || "root"}:${idx}`);
-  occurrences.forEach((entry, idx)=>{
-    if (!entry || typeof entry !== "object") return;
-    const rootId = String(entry.rootOccurrenceId || "");
-    if (!rootId) return;
-    if (!byRoot.has(rootId)) byRoot.set(rootId, []);
-    byRoot.get(rootId).push({ entry, idx, stable: stableId(entry, idx) });
-    if (String(entry.eventType || "") === "moved"){
-      const toDate = normalizeDateKey(entry?.payload?.toDateISO || entry?.displayDateISO || entry?.effectiveDateISO || null);
-      if (!toDate){
-        warnings.push({ type: "moved_missing_toDateISO", rootOccurrenceId: rootId, eventId: stableId(entry, idx) });
-      }
-    }
-  });
-
-  const finalLifecycleByRoot = new Map();
-  const finalEventByRoot = new Map();
-  const activeCompletedRoots = new Set();
-  byRoot.forEach((events, rootId)=>{
-    const sortable = events.map(item=>{
-      const ts = Date.parse(String(item.entry?.recordedAtISO || ""));
-      return { ...item, ts: Number.isFinite(ts) ? ts : null };
-    });
-    const unknownOrder = sortable.filter(x => x.ts == null).length > 1;
-    sortable.sort((a,b)=>{
-      if (a.ts != null && b.ts != null && a.ts !== b.ts) return a.ts - b.ts;
-      if (a.ts != null && b.ts == null) return -1;
-      if (a.ts == null && b.ts != null) return 1;
-      if (a.idx !== b.idx) return a.idx - b.idx;
-      return a.stable.localeCompare(b.stable);
-    });
-    if (unknownOrder){
-      warnings.push({ type: "undetermined_lifecycle_order", rootOccurrenceId: rootId, events: sortable.map(s=>s.stable) });
-    }
-    let finalLifecycleStatus = "scheduled";
-    let finalEvent = null;
-    sortable.forEach(item=>{
-      const t = String(item.entry?.eventType || "").toLowerCase();
-      if (lifecycleMap.has(t)){
-        finalLifecycleStatus = lifecycleMap.get(t);
-        finalEvent = item.entry;
-      }
-    });
-    finalLifecycleByRoot.set(rootId, finalLifecycleStatus);
-    if (finalEvent) finalEventByRoot.set(rootId, finalEvent);
-    if (finalLifecycleStatus === "completed") activeCompletedRoots.add(rootId);
-  });
-
-  instances.forEach(instance=>{
-    const rule = instance?.repeatRule && typeof instance.repeatRule === "object" ? instance.repeatRule : {};
-    const endTypeRaw = String(rule.endType || rule.endMode || "never").toLowerCase();
-    const endType = ["never", "on_date", "after_count"].includes(endTypeRaw) ? endTypeRaw : "never";
-    if (endType === "after_count" && !Number.isFinite(Number(rule.endCount || 0))){
-      warnings.push({ type: "repeat_after_count_missing_endCount", instanceId: String(instance?.id || "") });
-    }
-  });
-
-  activeCompletedRoots.forEach(rootId=>{
-    const ev = finalEventByRoot.get(rootId) || {};
-    const displayDateISO = normalizeDateKey(ev.displayDateISO || ev.effectiveDateISO || ev.dateISO || null);
-    if (!String(ev.rootOccurrenceId || rootId) || !String(ev.instanceId || "") || !String(ev.taskId || "") || !displayDateISO){
-      errors.push({ type: "completed_root_missing_required_fields", rootOccurrenceId: rootId });
-    }
-  });
-
-  if (!Array.isArray(window.taskEvents)){
-    info.push({ type: "calendar_chip_parity_non_blocking", detail: "window.taskEvents unavailable; parity check skipped." });
-  }
-
-  const report = {
-    checkedAtISO: new Date().toISOString(),
-    byRootCount: byRoot.size,
-    activeCompletedRoots: Array.from(activeCompletedRoots),
-    finalLifecycleByRoot: Object.fromEntries(finalLifecycleByRoot),
-    warnings,
-    errors,
-    info,
-    readOnly: true
-  };
-  if (window.DEBUG_MODE) console.info("[maintenance-v2] safety checks", report);
-  return report;
-}
-window.runMaintenanceV2SafetyChecks = runMaintenanceV2SafetyChecks;
 
 window.completeV2OneTimeOccurrence = (occurrenceId)=>{
   const lookup = window.__calendarV2OneTimeLookup && typeof window.__calendarV2OneTimeLookup === "object" ? window.__calendarV2OneTimeLookup : {};

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -20570,7 +20570,27 @@ function renderJobs(){
     }
   };
 
+  const handleCuttingJobFileActionClick = async (e)=>{
+    const act = (matched)=>{ if (!matched) return false; e.preventDefault(); e.stopPropagation(); if (typeof e.stopImmediatePropagation === "function") e.stopImmediatePropagation(); return true; };
+    const fileMenuAdd = e.target.closest("[data-job-file-add]");
+    if (fileMenuAdd && act(true)){ closeFileMenu(); closeActionMenu(); closeHistoryActionMenu(); const id = fileMenuAdd.getAttribute("data-job-file-add"); await attachFromLocalOneDriveRoot(id || ""); return true; }
+    const previewPathBtn = e.target.closest("[data-preview-path-btn]");
+    if (previewPathBtn && act(true)){ const expected = previewPathBtn.getAttribute("data-preview-expected-path") || ""; const rootLocation = previewPathBtn.getAttribute("data-preview-root-location") || "WJ Cuts"; if (expected && navigator?.clipboard?.writeText){ navigator.clipboard.writeText(expected).catch(()=>{}); } const msg = `Root folder: ${rootLocation || "WJ Cuts"}\nExpected file path: ${expected || "Unavailable"}`; if (window.alert) window.alert(msg); else toast(msg); return true; }
+    const localFileBtn = e.target.closest("[data-open-local-file]");
+    if (localFileBtn && act(true)){ await openLocalRootAttachment(localFileBtn.getAttribute("data-job-id"), localFileBtn.getAttribute("data-file-index")); return true; }
+    const upload = e.target.closest("[data-upload-job]");
+    if (upload && act(true)){ const id = upload.getAttribute("data-upload-job"); closeActionMenu(); closeHistoryActionMenu(); content.querySelector(`input[data-job-file-input="${id}"]`)?.click(); return true; }
+    const linkJobFile = e.target.closest("[data-link-job-file]");
+    if (linkJobFile && act(true)){ const idStr = String(linkJobFile.getAttribute("data-link-job-file") || ""); const found = findJobRecord(idStr); const j = found && found.job ? found.job : null; if (!j) return true; try { const picked = await window.oneDrivePicker.openOneDriveDxfPicker(); if (!picked) return true; j.files = Array.isArray(j.files) ? j.files : []; j.files.push({ id: genId(picked.fileName || "job_file"), name: picked.fileName || "Linked file", type: "", size: null, source: "onedrive", driveId: picked.driveId || "", itemId: picked.itemId || "", eTag: picked.eTag || "", lastModifiedDateTime: picked.lastModifiedDateTime || "", webUrl: picked.webUrl || "", url: picked.webUrl || "", addedAt: new Date().toISOString() }); saveCloudDebounced(); toast("OneDrive DXF linked"); renderJobs(); } catch (err){ toast(err?.message || "Unable to link OneDrive DXF."); } return true; }
+    const editFileLink = e.target.closest("[data-edit-file-link]");
+    if (editFileLink && act(true)){ const idStr = String(editFileLink.getAttribute("data-edit-file-link") || ""); const idx = Number(editFileLink.getAttribute("data-file-index")); const found = findJobRecord(idStr); const j = found && found.job ? found.job : null; const file = j && Array.isArray(j.files) && idx >= 0 ? j.files[idx] : null; if (!file) return true; const url = promptOneDriveLinkForFile(file.name || "attachment", file.url || ""); if (url == null) return true; file.url = url; file.source = "onedrive"; saveCloudDebounced(); toast(url ? "File link updated" : "File link cleared"); renderJobs(); return true; }
+    const removeFile = e.target.closest("[data-remove-file]");
+    if (removeFile && act(true)){ const idStr = String(removeFile.getAttribute("data-remove-file") || ""); const idx = Number(removeFile.getAttribute("data-file-index")); const found = findJobRecord(idStr); const j = found && found.job ? found.job : null; if (j && Array.isArray(j.files) && idx >= 0 && idx < j.files.length){ j.files.splice(idx, 1); saveCloudDebounced(); toast("File removed"); renderJobs(); } return true; }
+    return false;
+  };
+
   historyBody?.addEventListener("click", async (e)=>{
+    if (await handleCuttingJobFileActionClick(e)) return;
     const historyActionTrigger = e.target.closest("[data-history-actions-toggle]");
     if (historyActionTrigger){
       const id = historyActionTrigger.getAttribute("data-history-actions-toggle");
@@ -21019,6 +21039,7 @@ function renderJobs(){
 
   // 6) Edit/Remove/Save/Cancel + Log panel + Apply spent/remaining
   content.querySelector(".job-table tbody")?.addEventListener("click", async (e)=>{
+    if (await handleCuttingJobFileActionClick(e)) return;
     const overlapTrigger = e.target.closest("[data-job-overlap-info]");
     if (overlapTrigger){
       e.preventDefault();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -987,7 +987,8 @@ function sanitizeJobFileReferenceForFirestore(fileRef){
     attachedAtISO: String(fileRef.attachedAtISO || fileRef.addedAt || new Date().toISOString()),
     localRootSignature: String(fileRef.localRootSignature || ""),
     localDeviceId: String(fileRef.localDeviceId || ""),
-    ...(fileRef.note ? { note: String(fileRef.note) } : {})
+    ...(fileRef.note ? { note: String(fileRef.note) } : {}),
+    ...(fileRef.rootLocationHint ? { rootLocationHint: String(fileRef.rootLocationHint) } : {})
   };
 }
 
@@ -1075,9 +1076,28 @@ function verifyRootSignatureMatches(signature){
   return { ok: expected === signature, expected };
 }
 
+function describeLocalRootPreviewError(err){
+  const msg = String(err?.message || err || "").toLowerCase();
+  if (msg.includes("notallowederror") || msg.includes("permission") || msg.includes("denied")){
+    return "Preview unavailable: this browser lost access to your WJ Cuts root folder. Re-open OneDrive setup and re-select the root folder.";
+  }
+  if (msg.includes("notfounderror") || msg.includes("not found")){
+    return "Preview unavailable: this file was not found under your selected WJ Cuts root folder. Verify the same shared root folder is selected.";
+  }
+  return "Preview unavailable: unable to read this file from your WJ Cuts root folder. Re-open OneDrive setup and verify root folder access.";
+}
+
 async function resolveLocalFileFromRelativePath(relativePath){
   const rootHandle = await readLocalRootHandle();
-  if (!rootHandle) return null;
+  if (!rootHandle){
+    throw new Error("No saved WJ Cuts root folder on this device.");
+  }
+  const perm = typeof rootHandle.queryPermission === "function"
+    ? await rootHandle.queryPermission({ mode: "read" })
+    : "granted";
+  if (perm !== "granted"){
+    throw new Error("WJ Cuts root folder permission is not granted.");
+  }
   const rel = String(relativePath || "").replace(/^\/+/, "");
   if (!rel) return null;
   const segments = rel.split("/").filter(Boolean);
@@ -1511,23 +1531,10 @@ function readFileAsDataUrl(file){
 
 async function filesToAttachments(fileList){
   const files = Array.from(fileList || []);
-  const attachments = [];
-  for (const file of files){
-    try {
-      attachments.push({
-        id: genId(file.name || "job_file"),
-        name: file.name || "Attachment",
-        type: file.type || "",
-        size: typeof file.size === "number" ? file.size : null,
-        source: "upload_requires_reference",
-        attachedAtISO: new Date().toISOString()
-      });
-    } catch (err){
-      console.error("Unable to read file", err);
-      toast("Use Attach from Reference Folder so this file can be saved as a WJ Cuts relative path.");
-    }
+  if (files.length){
+    toast("Local uploads are temporary and not saved as durable cloud file references. Use Attach from Reference Folder.");
   }
-  return attachments;
+  return [];
 }
 
 const JOB_ONEDRIVE_PREVIEW_CACHE_KEY = "cutting_job_onedrive_preview_cache_v1";
@@ -1581,7 +1588,7 @@ async function resolveOneDriveAttachmentPreview(file){
       const text = window.dxfPreview.arrayBufferToText(bytes);
       const svg = window.dxfPreview.renderCadToSvgDataUrl(text);
       if (!svg){
-        file.preview = { mode: "message", content: "2D preview unavailable for this file." };
+        file.preview = { mode: "message", content: diagnosePreviewFailure(file) };
         return false;
       }
       file.preview = { mode: "image", content: svg };
@@ -1591,7 +1598,7 @@ async function resolveOneDriveAttachmentPreview(file){
       }
       return true;
     } catch (_err){
-      file.preview = file.preview || { mode: "message", content: "Preview unavailable for this OneDrive file." };
+      file.preview = { mode: "message", content: diagnosePreviewFailure(file) };
       return false;
     } finally {
       oneDrivePreviewInFlight.delete(inFlightKey);
@@ -1600,6 +1607,25 @@ async function resolveOneDriveAttachmentPreview(file){
 
   oneDrivePreviewInFlight.set(inFlightKey, task);
   return task;
+}
+
+function diagnosePreviewFailure(file, context = ""){
+  const source = String(file?.source || "");
+  const ext = fileExtFromName(String(file?.name || ""));
+  const href = String(file?.dataUrl || file?.url || "").trim();
+  if (source === "onedrive"){
+    if (!file?.driveId || !file?.itemId) return "Preview unavailable: OneDrive file metadata is incomplete. Relink this file from OneDrive.";
+    return "Preview unavailable: OneDrive content could not be loaded. Check OneDrive sign-in and file permissions, then try again.";
+  }
+  if (source === "wj_cuts_reference"){
+    return "Preview unavailable: unable to read this file from the selected WJ Cuts root. Re-select root folder and verify this exact file path exists.";
+  }
+  if ([".dxf", ".ord", ".omx"].includes(ext)){
+    if (!href) return "Preview unavailable: no file content URL is saved. Re-attach from Reference Folder or add a direct OneDrive URL.";
+    if (/^https?:\/\//i.test(href)) return "Preview unavailable: remote CAD file could not be fetched. Check the link and access permissions.";
+    return "Preview unavailable: CAD data could not be decoded for preview. Re-attach the source file.";
+  }
+  return context || "Preview unavailable: unsupported format or missing data for this attachment.";
 }
 
 async function resolveAttachmentPreview(file){
@@ -1624,7 +1650,7 @@ async function resolveAttachmentPreview(file){
     try {
       const localFile = await resolveWJCutsRelativePath(file.relativePath);
       if (!localFile){
-        file.preview = file.preview || { mode: "message", content: "File reference saved, but the file was not found under your selected WJ Cuts folder." };
+        file.preview = { mode: "message", content: "Preview unavailable: file reference was saved, but the file is missing under your selected WJ Cuts root folder." };
         return false;
       }
       const preview = await buildAttachmentPreview(localFile);
@@ -1632,10 +1658,10 @@ async function resolveAttachmentPreview(file){
         file.preview = preview;
         return preview.mode === "image";
       }
-      file.preview = file.preview || { mode: "message", content: "Preview unavailable for this WJ Cuts referenced file type." };
+      file.preview = { mode: "message", content: "Preview unavailable: this WJ Cuts file type cannot be rendered as a 2D preview." };
       return false;
-    } catch (_err){
-      file.preview = file.preview || { mode: "message", content: "Preview unavailable for this WJ Cuts referenced file." };
+    } catch (err){
+      file.preview = { mode: "message", content: describeLocalRootPreviewError(err) };
       return false;
     }
   }
@@ -1660,10 +1686,10 @@ async function resolveAttachmentPreview(file){
         file.preview = { mode: "image", content: svg };
         return true;
       }
-      file.preview = file.preview || { mode: "message", content: "2D preview unavailable for this file." };
+      file.preview = { mode: "message", content: diagnosePreviewFailure(file) };
       return false;
     } catch (_err){
-      file.preview = file.preview || { mode: "message", content: "2D preview unavailable for this file." };
+      file.preview = { mode: "message", content: diagnosePreviewFailure(file) };
       return false;
     }
   }
@@ -19370,9 +19396,12 @@ function renderJobs(){
   const oneDriveFolderStatus = document.querySelector("[data-onedrive-folder-status]");
   const oneDriveLibraryStatus = document.querySelector("[data-onedrive-library-status]");
   const oneDriveRootStatus = document.querySelector("[data-onedrive-root-status]");
+  const oneDriveRootPathStatus = document.querySelector("[data-onedrive-root-path]");
   const oneDriveDeviceStatus = document.querySelector("[data-onedrive-device-status]");
   const oneDriveLibraryAddToJobBtn = document.getElementById("jobOneDriveLibraryAddBtn");
   const oneDriveRootPickerBtn = document.getElementById("jobOneDriveRootPickerBtn");
+
+  let pendingAttachTarget = null;
 
 
   const getSharedConfig = ()=>{
@@ -19380,6 +19409,20 @@ function renderJobs(){
     return normalizeOneDriveJobConfig(cfg);
   };
 
+
+  const getWJCutsRootStatus = async ()=>{
+    const config = getSharedConfig();
+    if (!supportsLocalRootPicker()) return { supported:false, handle:null, hasSavedHandle:false, permission:"unsupported", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Unsupported browser" };
+    const handle = await readLocalRootHandle();
+    if (!handle) return { supported:true, handle:null, hasSavedHandle:false, permission:"missing", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Not set" };
+    let permission = "prompt";
+    try { permission = typeof handle.queryPermission === "function" ? await handle.queryPermission({ mode:"read" }) : "granted"; } catch(_e){}
+    if (permission !== "granted") return { supported:true, handle, hasSavedHandle:true, permission, config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Permission needed" };
+    const signature = await computeLocalRootSignature(handle);
+    const expectedSignature = expectedRootSignatureFromJobs();
+    const signatureMatches = !expectedSignature || !signature ? true : signature === expectedSignature;
+    return { supported:true, handle, hasSavedHandle:true, permission:"granted", config, signature, expectedSignature, signatureMatches, message: signatureMatches ? "Verified" : "Mismatch" };
+  };
   const updateSharedConfig = (patch)=>{
     const cfg = getSharedConfig();
     return writeOneDriveJobConfig({ ...cfg, ...patch });
@@ -19387,11 +19430,16 @@ function renderJobs(){
 
   const updateOneDriveWizardStatus = async ()=>{
     const cfg = getSharedConfig();
-    if (oneDriveConnStatus) oneDriveConnStatus.textContent = cfg.localRootSignature ? "Configured" : "Not set";
-    if (oneDriveFolderStatus) oneDriveFolderStatus.textContent = cfg.localRootSignature ? "Verified" : "Not ready";
-    if (oneDriveLibraryStatus) oneDriveLibraryStatus.textContent = cfg.localRootSignature ? "Ready" : "Setup required";
+    const status = await getWJCutsRootStatus();
+    if (window.DEBUG_MODE) console.info("[cutting-job-files] root status", status);
+    if (oneDriveConnStatus) oneDriveConnStatus.textContent = status.message;
+    if (oneDriveFolderStatus) oneDriveFolderStatus.textContent = status.permission === "granted" ? (status.signatureMatches ? "Verified" : "Mismatch") : (status.hasSavedHandle ? "Permission needed" : "Not set");
+    if (oneDriveLibraryStatus) oneDriveLibraryStatus.textContent = status.permission === "granted" ? "Ready" : "Setup required";
     if (oneDriveRootStatus){
       oneDriveRootStatus.textContent = cfg.localRootName || "Not set";
+    }
+    if (oneDriveRootPathStatus){
+      oneDriveRootPathStatus.textContent = cfg.folderHint || cfg.localRootName || "Not set";
     }
     if (oneDriveDeviceStatus){
       oneDriveDeviceStatus.textContent = getLocalDeviceId() ? `${getLocalDeviceNumber()} (${getLocalDeviceId()})` : "Unavailable";
@@ -19421,10 +19469,13 @@ function renderJobs(){
         return false;
       }
       await saveLocalRootHandle(handle);
+      const verifyHandle = await readLocalRootHandle();
+      if (!verifyHandle){ toast("Unable to save root handle on this browser."); return false; }
       const cfg = getSharedConfig();
       updateSharedConfig({
         localRootName: String(handle.name || cfg.localRootName || "Configured"),
-        localRootSignature: signature
+        localRootSignature: signature,
+        enabled: true
       });
       await updateOneDriveWizardStatus();
       toast("This computer OneDrive root folder saved and verified.");
@@ -19444,14 +19495,16 @@ function renderJobs(){
     }
     const rootHandle = await readLocalRootHandle();
     if (!rootHandle){
-      toast("Set WJ Cuts Folder to open this file.");
+      pendingAttachTarget = targetJobId ? { mode: "job", jobId: String(targetJobId) } : { mode: "new" };
+      toast("Set this computer’s WJ Cuts root folder before attaching files. The app saves a reference path, not the file itself.");
+      if (window.DEBUG_MODE) console.info("[cutting-job-files] attach blocked root missing", { targetJobId });
       openOneDriveModal();
       return false;
     }
 
     try {
       const cfg = getSharedConfig();
-      const signature = cfg.localRootSignature || await computeLocalRootSignature(rootHandle);
+      const signature = await computeLocalRootSignature(rootHandle);
       if (!signature){
         toast("Unable to verify local OneDrive root folder.");
         return false;
@@ -19501,13 +19554,16 @@ function renderJobs(){
         rootPathStart: "WJ Cuts",
         relativePath: relPath,
         localRootSignature: signature,
+        enabled: true,
         localDeviceId: getLocalDeviceId(),
-        attachedAtISO: new Date().toISOString()
+        attachedAtISO: new Date().toISOString(),
+        rootLocationHint: String(cfg.folderHint || cfg.localRootName || "")
       });
       if (!reference) return false;
       const targetId = String(targetJobId || "");
       if (targetId){
-        const job = cuttingJobs.find(x => String(x?.id) === targetId);
+        const found = findJobRecord(targetId);
+        const job = found && found.job ? found.job : null;
         if (!job){
           toast("Job not found for OneDrive attachment.");
           return false;
@@ -19515,6 +19571,7 @@ function renderJobs(){
         job.files = Array.isArray(job.files) ? job.files : [];
         job.files.push(reference);
         saveCloudDebounced();
+        if (window.DEBUG_MODE) console.info("[cutting-job-files] attached reference", { targetId, relPath });
         toast("WJ Cuts file reference attached to job.");
         renderJobs();
       } else {
@@ -19548,7 +19605,15 @@ function renderJobs(){
     closeFileMenu(); closeActionMenu(); closeHistoryActionMenu(); openOneDriveModal();
   });
   oneDriveRootPickerBtn?.addEventListener("click", async ()=>{
-    await chooseLocalOneDriveRoot();
+    const ok = await chooseLocalOneDriveRoot();
+    if (ok && pendingAttachTarget){
+      const target = pendingAttachTarget;
+      pendingAttachTarget = null;
+      const attached = await attachFromLocalOneDriveRoot(target.mode === "job" ? target.jobId : "");
+      if (attached){
+        closeOneDriveModal();
+      }
+    }
   });
   oneDriveCancelBtns.forEach(btn => btn.addEventListener("click", closeOneDriveModal));
   oneDriveModal?.addEventListener("click", (event)=>{ if (event.target === oneDriveModal) closeOneDriveModal(); });
@@ -20360,10 +20425,12 @@ function renderJobs(){
       const mode = option.getAttribute("data-preview-mode") || "message";
       const contentValue = option.getAttribute("data-preview-content") || "";
       const href = option.getAttribute("data-preview-href") || "";
+      const expectedPath = option.getAttribute("data-preview-expected-path") || "";
       const nameEl = previewRoot.querySelector("[data-preview-name]");
       const imgEl = previewRoot.querySelector("[data-preview-image]");
       const msgEl = previewRoot.querySelector("[data-preview-message]");
       const openEl = previewRoot.querySelector("[data-preview-open]");
+      const pathBtn = previewRoot.querySelector("[data-preview-path-btn]");
       if (nameEl){
         nameEl.textContent = name;
         nameEl.setAttribute("title", name);
@@ -20380,6 +20447,11 @@ function renderJobs(){
       if (openEl instanceof HTMLAnchorElement){
         openEl.href = href;
         openEl.hidden = !href;
+      }
+      if (pathBtn instanceof HTMLButtonElement){
+        pathBtn.hidden = !(mode === "message" && expectedPath);
+        pathBtn.dataset.previewExpectedPath = expectedPath;
+        pathBtn.dataset.previewRootLocation = option.getAttribute("data-preview-root-location") || "";
       }
       return;
     }
@@ -20399,17 +20471,22 @@ function renderJobs(){
     if (e.target.matches("input[data-job-file-input]")){
       const id = e.target.getAttribute("data-job-file-input");
       const idStr = String(id || "");
-      const j = cuttingJobs.find(x => String(x?.id) === idStr);
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
       if (!j){ e.target.value = ""; return; }
       const attachments = await filesToAttachments(e.target.files);
       e.target.value = "";
       if (!attachments.length) return;
       j.files = Array.isArray(j.files) ? j.files : [];
-      toast("Use Attach from Reference Folder so this file can be saved as a WJ Cuts relative path.");
+      j.files.push(...attachments);
+      saveCloudDebounced();
+      toast("Files added. For durable cross-device links, use Attach from Reference Folder.");
+      renderJobs();
     }
   });
 
   const historyBody = content.querySelector(".past-jobs-table tbody");
+  
   historyBody?.addEventListener("change", (e)=>{
     const previewSelect = e.target instanceof Element
       ? e.target.closest("select[data-file-preview-select]")
@@ -20423,10 +20500,12 @@ function renderJobs(){
     const mode = option.getAttribute("data-preview-mode") || "message";
     const contentValue = option.getAttribute("data-preview-content") || "";
     const href = option.getAttribute("data-preview-href") || "";
+    const expectedPath = option.getAttribute("data-preview-expected-path") || "";
     const nameEl = previewRoot.querySelector("[data-preview-name]");
     const imgEl = previewRoot.querySelector("[data-preview-image]");
     const msgEl = previewRoot.querySelector("[data-preview-message]");
     const openEl = previewRoot.querySelector("[data-preview-open]");
+    const pathBtn = previewRoot.querySelector("[data-preview-path-btn]");
     if (nameEl){
       nameEl.textContent = name;
       nameEl.setAttribute("title", name);
@@ -20443,6 +20522,11 @@ function renderJobs(){
     if (openEl instanceof HTMLAnchorElement){
       openEl.href = href;
       openEl.hidden = !href;
+    }
+    if (pathBtn instanceof HTMLButtonElement){
+      pathBtn.hidden = !(mode === "message" && expectedPath);
+      pathBtn.dataset.previewExpectedPath = expectedPath;
+        pathBtn.dataset.previewRootLocation = option.getAttribute("data-preview-root-location") || "";
     }
   });
 
@@ -20465,7 +20549,8 @@ function renderJobs(){
     }
     try {
       const cfg = getSharedConfig();
-      const currentSignature = cfg.localRootSignature;
+      const rootStatus = await getWJCutsRootStatus();
+      const currentSignature = rootStatus.signature || "";
       if (file.localRootSignature && currentSignature && file.localRootSignature !== currentSignature){
         toast("This computer is linked to a different root folder. Reconfigure this computer root folder.");
         openOneDriveModal();
@@ -20506,6 +20591,90 @@ function renderJobs(){
         closeHistoryActionMenu();
         closeActionMenu();
         openFileMenu(id, historyFileTrigger);
+      }
+      return;
+    }
+
+    const fileMenuAdd = e.target.closest("[data-job-file-add]");
+    if (fileMenuAdd){
+      const id = fileMenuAdd.getAttribute("data-job-file-add");
+      if (id){
+        e.preventDefault();
+        if (typeof e.stopImmediatePropagation === "function") e.stopImmediatePropagation();
+        closeFileMenu(); closeActionMenu(); closeHistoryActionMenu();
+        const attached = await attachFromLocalOneDriveRoot(id);
+        if (!attached){ window.pendingJobFocus = { type: "jobRow", id }; renderJobs(); }
+      }
+      return;
+    }
+
+    const upload = e.target.closest("[data-upload-job]");
+    if (upload){
+      const id = upload.getAttribute("data-upload-job");
+      e.preventDefault();
+      if (typeof e.stopImmediatePropagation === "function") e.stopImmediatePropagation();
+      closeActionMenu(); closeHistoryActionMenu();
+      content.querySelector(`input[data-job-file-input="${id}"]`)?.click();
+      return;
+    }
+
+    const linkJobFile = e.target.closest("[data-link-job-file]");
+    if (linkJobFile){
+      const id = linkJobFile.getAttribute("data-link-job-file");
+      const idStr = String(id || "");
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
+      if (!j) return;
+      try {
+        const picked = await window.oneDrivePicker.openOneDriveDxfPicker();
+        if (!picked) return;
+        j.files = Array.isArray(j.files) ? j.files : [];
+        j.files.push({ id: genId(picked.fileName || "job_file"), name: picked.fileName || "Linked file", type: "", size: null, source: "onedrive", driveId: picked.driveId || "", itemId: picked.itemId || "", eTag: picked.eTag || "", lastModifiedDateTime: picked.lastModifiedDateTime || "", webUrl: picked.webUrl || "", url: picked.webUrl || "", addedAt: new Date().toISOString() });
+        saveCloudDebounced(); toast("OneDrive DXF linked"); renderJobs();
+      } catch (err){ toast(err?.message || "Unable to link OneDrive DXF."); }
+      return;
+    }
+
+    const editFileLink = e.target.closest("[data-edit-file-link]");
+    if (editFileLink){
+      const id = editFileLink.getAttribute("data-edit-file-link");
+      const idx = Number(editFileLink.getAttribute("data-file-index"));
+      const idStr = String(id || "");
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
+      const file = j && Array.isArray(j.files) && idx >= 0 ? j.files[idx] : null;
+      if (!file) return;
+      const url = promptOneDriveLinkForFile(file.name || "attachment", file.url || "");
+      if (url == null) return;
+      file.url = url; file.source = "onedrive";
+      saveCloudDebounced(); toast(url ? "File link updated" : "File link cleared"); renderJobs();
+      return;
+    }
+
+    const removeFile = e.target.closest("[data-remove-file]");
+    if (removeFile){
+      const id = removeFile.getAttribute("data-remove-file");
+      const idx = Number(removeFile.getAttribute("data-file-index"));
+      const idStr = String(id || "");
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
+      if (j && Array.isArray(j.files) && idx >= 0 && idx < j.files.length){
+        j.files.splice(idx, 1); saveCloudDebounced(); toast("File removed"); renderJobs();
+      }
+      return;
+    }
+
+    const previewPathBtn = e.target.closest("[data-preview-path-btn]");
+    if (previewPathBtn){
+      e.preventDefault();
+      const expected = previewPathBtn.getAttribute("data-preview-expected-path") || "";
+      if (expected){
+        const rootLocation = previewPathBtn.getAttribute("data-preview-root-location") || "";
+        const msg = rootLocation
+          ? `Root folder used: ${rootLocation}\nExpected file path:\n${expected}`
+          : `Expected file path:\n${expected}`;
+        if (navigator?.clipboard?.writeText){ navigator.clipboard.writeText(expected).catch(()=>{}); }
+        if (window.alert) window.alert(msg); else toast(msg);
       }
       return;
     }
@@ -20964,7 +21133,8 @@ function renderJobs(){
     if (linkJobFile){
       const id = linkJobFile.getAttribute("data-link-job-file");
       const idStr = String(id || "");
-      const j = cuttingJobs.find(x => String(x?.id) === idStr);
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
       if (!j) return;
       try {
         const picked = await window.oneDrivePicker.openOneDriveDxfPicker();
@@ -20998,7 +21168,8 @@ function renderJobs(){
       const id = editFileLink.getAttribute("data-edit-file-link");
       const idx = Number(editFileLink.getAttribute("data-file-index"));
       const idStr = String(id || "");
-      const j = cuttingJobs.find(x => String(x?.id) === idStr);
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
       const file = j && Array.isArray(j.files) && idx >= 0 ? j.files[idx] : null;
       if (!file) return;
       const url = promptOneDriveLinkForFile(file.name || "attachment", file.url || "");
@@ -21016,7 +21187,8 @@ function renderJobs(){
       const id = removeFile.getAttribute("data-remove-file");
       const idx = Number(removeFile.getAttribute("data-file-index"));
       const idStr = String(id || "");
-      const j = cuttingJobs.find(x => String(x?.id) === idStr);
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
       if (j && Array.isArray(j.files) && idx>=0 && idx<j.files.length){
         j.files.splice(idx,1);
         saveCloudDebounced();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -20449,7 +20449,7 @@ function renderJobs(){
         openEl.hidden = !href;
       }
       if (pathBtn instanceof HTMLButtonElement){
-        pathBtn.hidden = !(mode === "message" && expectedPath);
+        pathBtn.hidden = !expectedPath;
         pathBtn.dataset.previewExpectedPath = expectedPath;
         pathBtn.dataset.previewRootLocation = option.getAttribute("data-preview-root-location") || "";
       }
@@ -20524,7 +20524,7 @@ function renderJobs(){
       openEl.hidden = !href;
     }
     if (pathBtn instanceof HTMLButtonElement){
-      pathBtn.hidden = !(mode === "message" && expectedPath);
+      pathBtn.hidden = !expectedPath;
       pathBtn.dataset.previewExpectedPath = expectedPath;
         pathBtn.dataset.previewRootLocation = option.getAttribute("data-preview-root-location") || "";
     }
@@ -20534,15 +20534,10 @@ function renderJobs(){
     const id = String(jobId || "");
     const idx = Number(fileIndex);
     if (!id || !Number.isInteger(idx) || idx < 0) return false;
-    const sources = [Array.isArray(cuttingJobs) ? cuttingJobs : [], Array.isArray(completedJobs) ? completedJobs : []];
-    let file = null;
-    for (const list of sources){
-      const job = list.find(item => String(item?.id || "") === id);
-      if (!job) continue;
-      const files = Array.isArray(job.files) ? job.files : [];
-      file = files[idx] || null;
-      if (file) break;
-    }
+    const found = findJobRecord(id);
+    const job = found && found.job ? found.job : null;
+    const files = Array.isArray(job?.files) ? job.files : [];
+    const file = files[idx] || null;
     if (!file || file.source !== "wj_cuts_reference" || !file.relativePath){
       toast("File metadata saved only — original file content is not stored.");
       return false;
@@ -20615,96 +20610,6 @@ function renderJobs(){
       return;
     }
 
-    const fileMenuAdd = e.target.closest("[data-job-file-add]");
-    if (fileMenuAdd){
-      const id = fileMenuAdd.getAttribute("data-job-file-add");
-      if (id){
-        e.preventDefault();
-        if (typeof e.stopImmediatePropagation === "function") e.stopImmediatePropagation();
-        closeFileMenu(); closeActionMenu(); closeHistoryActionMenu();
-        const attached = await attachFromLocalOneDriveRoot(id);
-        if (!attached){ window.pendingJobFocus = { type: "jobRow", id }; renderJobs(); }
-      }
-      return;
-    }
-
-    const upload = e.target.closest("[data-upload-job]");
-    if (upload){
-      const id = upload.getAttribute("data-upload-job");
-      e.preventDefault();
-      if (typeof e.stopImmediatePropagation === "function") e.stopImmediatePropagation();
-      closeActionMenu(); closeHistoryActionMenu();
-      content.querySelector(`input[data-job-file-input="${id}"]`)?.click();
-      return;
-    }
-
-    const linkJobFile = e.target.closest("[data-link-job-file]");
-    if (linkJobFile){
-      const id = linkJobFile.getAttribute("data-link-job-file");
-      const idStr = String(id || "");
-      const found = findJobRecord(idStr);
-      const j = found && found.job ? found.job : null;
-      if (!j) return;
-      try {
-        const picked = await window.oneDrivePicker.openOneDriveDxfPicker();
-        if (!picked) return;
-        j.files = Array.isArray(j.files) ? j.files : [];
-        j.files.push({ id: genId(picked.fileName || "job_file"), name: picked.fileName || "Linked file", type: "", size: null, source: "onedrive", driveId: picked.driveId || "", itemId: picked.itemId || "", eTag: picked.eTag || "", lastModifiedDateTime: picked.lastModifiedDateTime || "", webUrl: picked.webUrl || "", url: picked.webUrl || "", addedAt: new Date().toISOString() });
-        saveCloudDebounced(); toast("OneDrive DXF linked"); renderJobs();
-      } catch (err){ toast(err?.message || "Unable to link OneDrive DXF."); }
-      return;
-    }
-
-    const editFileLink = e.target.closest("[data-edit-file-link]");
-    if (editFileLink){
-      const id = editFileLink.getAttribute("data-edit-file-link");
-      const idx = Number(editFileLink.getAttribute("data-file-index"));
-      const idStr = String(id || "");
-      const found = findJobRecord(idStr);
-      const j = found && found.job ? found.job : null;
-      const file = j && Array.isArray(j.files) && idx >= 0 ? j.files[idx] : null;
-      if (!file) return;
-      const url = promptOneDriveLinkForFile(file.name || "attachment", file.url || "");
-      if (url == null) return;
-      file.url = url; file.source = "onedrive";
-      saveCloudDebounced(); toast(url ? "File link updated" : "File link cleared"); renderJobs();
-      return;
-    }
-
-    const removeFile = e.target.closest("[data-remove-file]");
-    if (removeFile){
-      const id = removeFile.getAttribute("data-remove-file");
-      const idx = Number(removeFile.getAttribute("data-file-index"));
-      const idStr = String(id || "");
-      const found = findJobRecord(idStr);
-      const j = found && found.job ? found.job : null;
-      if (j && Array.isArray(j.files) && idx >= 0 && idx < j.files.length){
-        j.files.splice(idx, 1); saveCloudDebounced(); toast("File removed"); renderJobs();
-      }
-      return;
-    }
-
-    const previewPathBtn = e.target.closest("[data-preview-path-btn]");
-    if (previewPathBtn){
-      e.preventDefault();
-      const expected = previewPathBtn.getAttribute("data-preview-expected-path") || "";
-      if (expected){
-        const rootLocation = previewPathBtn.getAttribute("data-preview-root-location") || "";
-        const msg = rootLocation
-          ? `Root folder used: ${rootLocation}\nExpected file path:\n${expected}`
-          : `Expected file path:\n${expected}`;
-        if (navigator?.clipboard?.writeText){ navigator.clipboard.writeText(expected).catch(()=>{}); }
-        if (window.alert) window.alert(msg); else toast(msg);
-      }
-      return;
-    }
-
-    const localFileBtn = e.target.closest("[data-open-local-file]");
-    if (localFileBtn){
-      e.preventDefault();
-      await openLocalRootAttachment(localFileBtn.getAttribute("data-job-id"), localFileBtn.getAttribute("data-file-index"));
-      return;
-    }
 
     const noteTrigger = e.target.closest("[data-job-note]");
     if (noteTrigger && (!noteBackdrop || !noteBackdrop.contains(noteTrigger))){
@@ -21076,29 +20981,6 @@ function renderJobs(){
       return;
     }
 
-    const fileMenuAdd = e.target.closest("[data-job-file-add]");
-    if (fileMenuAdd){
-      const id = fileMenuAdd.getAttribute("data-job-file-add");
-      if (id){
-        e.preventDefault();
-        closeFileMenu();
-        closeActionMenu();
-        const attached = await attachFromLocalOneDriveRoot(id);
-        if (!attached){
-          window.pendingJobFocus = { type: "jobAddFiles", id };
-          editingJobs.add(id);
-          renderJobs();
-        }
-      }
-      return;
-    }
-
-    const localFileBtn = e.target.closest("[data-open-local-file]");
-    if (localFileBtn){
-      e.preventDefault();
-      await openLocalRootAttachment(localFileBtn.getAttribute("data-job-id"), localFileBtn.getAttribute("data-file-index"));
-      return;
-    }
 
     if (openFileMenuId){
       const activeMenu = content.querySelector(`[data-job-file-menu="${openFileMenuId}"]`);
@@ -21140,84 +21022,6 @@ function renderJobs(){
       return;
     }
 
-    const upload = e.target.closest("[data-upload-job]");
-    if (upload){
-      const id = upload.getAttribute("data-upload-job");
-      closeFileMenu();
-      closeActionMenu();
-      closeHistoryActionMenu();
-      content.querySelector(`input[data-job-file-input="${id}"]`)?.click();
-      return;
-    }
-
-    const linkJobFile = e.target.closest("[data-link-job-file]");
-    if (linkJobFile){
-      const id = linkJobFile.getAttribute("data-link-job-file");
-      const idStr = String(id || "");
-      const found = findJobRecord(idStr);
-      const j = found && found.job ? found.job : null;
-      if (!j) return;
-      try {
-        const picked = await window.oneDrivePicker.openOneDriveDxfPicker();
-        if (!picked) return;
-        j.files = Array.isArray(j.files) ? j.files : [];
-        j.files.push({
-          id: genId(picked.fileName || "job_file"),
-          name: picked.fileName || "Linked file",
-          type: "",
-          size: null,
-          source: "onedrive",
-          driveId: picked.driveId || "",
-          itemId: picked.itemId || "",
-          eTag: picked.eTag || "",
-          lastModifiedDateTime: picked.lastModifiedDateTime || "",
-          webUrl: picked.webUrl || "",
-          url: picked.webUrl || "",
-          addedAt: new Date().toISOString()
-        });
-        saveCloudDebounced();
-        toast("OneDrive DXF linked");
-        renderJobs();
-      } catch (err){
-        toast(err?.message || "Unable to link OneDrive DXF.");
-      }
-      return;
-    }
-
-    const editFileLink = e.target.closest("[data-edit-file-link]");
-    if (editFileLink){
-      const id = editFileLink.getAttribute("data-edit-file-link");
-      const idx = Number(editFileLink.getAttribute("data-file-index"));
-      const idStr = String(id || "");
-      const found = findJobRecord(idStr);
-      const j = found && found.job ? found.job : null;
-      const file = j && Array.isArray(j.files) && idx >= 0 ? j.files[idx] : null;
-      if (!file) return;
-      const url = promptOneDriveLinkForFile(file.name || "attachment", file.url || "");
-      if (url == null) return;
-      file.url = url;
-      file.source = "onedrive";
-      saveCloudDebounced();
-      toast(url ? "File link updated" : "File link cleared");
-      renderJobs();
-      return;
-    }
-
-    const removeFile = e.target.closest("[data-remove-file]");
-    if (removeFile){
-      const id = removeFile.getAttribute("data-remove-file");
-      const idx = Number(removeFile.getAttribute("data-file-index"));
-      const idStr = String(id || "");
-      const found = findJobRecord(idStr);
-      const j = found && found.job ? found.job : null;
-      if (j && Array.isArray(j.files) && idx>=0 && idx<j.files.length){
-        j.files.splice(idx,1);
-        saveCloudDebounced();
-        toast("File removed");
-        renderJobs();
-      }
-      return;
-    }
 
     const ed = e.target.closest("[data-edit-job]");
     const rm = e.target.closest("[data-remove-job]");

--- a/js/views.js
+++ b/js/views.js
@@ -3985,16 +3985,16 @@ function viewJobs(){
                   const href = f.dataUrl || f.url || f.externalUrl || f.downloadUrl || f.oneDriveUrl || "";
                   const usableLink = !!href && !/^data:(image|application)\//i.test(String(href || "")) && /^https?:\/\//i.test(String(href || ""));
                   const isRef = f?.source === "wj_cuts_reference" && !!f?.relativePath;
-                  const expectedPath = isRef ? `WJ Cuts\${String(f.relativePath || "").replace(/^\+/, "")}` : "";
+                  const expectedPath = isRef ? `WJ Cuts\\${String(f.relativePath || "").replace(/^\\+/, "")}` : "";
                   const link = isRef
-                    ? `<button type="button" class="link" data-open-local-file data-job-id="${j.id}" data-file-index="${idx}">${safeName}</button>`
+                    ? `<button type="button" class="link" data-open-local-file data-job-id="${job.id}" data-file-index="${idx}">${safeName}</button>`
                     : (usableLink ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : `${safeName} <span class="small muted">— File metadata saved only — original file content is not stored.</span>`);
                   const sourceTag = isRef
                     ? `<span class="job-file-source-badge">Reference folder</span>`
                     : (f?.source === "onedrive" ? `<span class="job-file-source-badge">OneDrive</span>` : "");
                   const pathAction = expectedPath ? `<button type="button" class="link" data-preview-path-btn data-preview-expected-path="${esc(expectedPath)}" data-preview-root-location="${esc(f?.rootLocationHint || 'WJ Cuts')}">Show path</button>` : "";
-                  const linkAction = !isRef ? `<button type="button" class="link" data-edit-file-link="${j.id}" data-file-index="${idx}">Link</button>` : "";
-                  return `<li>${link} ${sourceTag} ${expectedPath ? `<span class="small muted">— ${esc(expectedPath)}</span>` : ""} ${pathAction} ${linkAction} <button type="button" class="link" data-remove-file="${j.id}" data-file-index="${idx}">Remove</button></li>`;
+                  const linkAction = !isRef ? `<button type="button" class="link" data-edit-file-link="${job.id}" data-file-index="${idx}">Link</button>` : "";
+                  return `<li>${link} ${sourceTag} ${expectedPath ? `<span class="small muted">— ${esc(expectedPath)}</span>` : ""} ${pathAction} ${linkAction} <button type="button" class="link" data-remove-file="${job.id}" data-file-index="${idx}">Remove</button></li>`;
                 }).join("") : `<li class="muted">No files attached</li>`}
               </ul>
             </div>
@@ -4418,9 +4418,17 @@ function viewJobs(){
                     const safeName = f.name || `file_${idx+1}`;
                     const href = f.dataUrl || f.url || f.externalUrl || f.downloadUrl || f.oneDriveUrl || "";
                     const usableLink = !!href && !/^data:(image|application)\//i.test(String(href || "")) && /^https?:\/\//i.test(String(href || ""));
-                    const link = usableLink ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : `${safeName} <span class="small muted">— File metadata saved only — original file content is not stored.</span>`;
-                    const sourceTag = f?.source === "onedrive" ? `<span class="job-file-source-badge">OneDrive</span>` : "";
-                    return `<li>${link} ${sourceTag} <button type="button" class="link" data-edit-file-link="${j.id}" data-file-index="${idx}">Link</button> <button type="button" class="link" data-remove-file="${j.id}" data-file-index="${idx}">Remove</button></li>`;
+                    const isRef = f?.source === "wj_cuts_reference" && !!f?.relativePath;
+                    const expectedPath = isRef ? `WJ Cuts\\${String(f.relativePath || "").replace(/^\\+/, "")}` : "";
+                    const link = isRef
+                      ? `<button type="button" class="link" data-open-local-file data-job-id="${j.id}" data-file-index="${idx}">${safeName}</button>`
+                      : (usableLink ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : `${safeName} <span class="small muted">— File metadata saved only — original file content is not stored.</span>`);
+                    const sourceTag = isRef
+                      ? `<span class="job-file-source-badge">Reference folder</span>`
+                      : (f?.source === "onedrive" ? `<span class="job-file-source-badge">OneDrive</span>` : "");
+                    const pathAction = expectedPath ? `<button type="button" class="link" data-preview-path-btn data-preview-expected-path="${esc(expectedPath)}" data-preview-root-location="${esc(f?.rootLocationHint || 'WJ Cuts')}">Show path</button>` : "";
+                    const linkAction = !isRef ? `<button type="button" class="link" data-edit-file-link="${j.id}" data-file-index="${idx}">Link</button>` : "";
+                    return `<li>${link} ${sourceTag} ${expectedPath ? `<span class="small muted">— ${esc(expectedPath)}</span>` : ""} ${pathAction} ${linkAction} <button type="button" class="link" data-remove-file="${j.id}" data-file-index="${idx}">Remove</button></li>`;
                   }).join("") : `<li class=\"muted\">No files attached</li>`}
                 </ul>
               </div>

--- a/js/views.js
+++ b/js/views.js
@@ -2915,28 +2915,28 @@ function viewJobs(){
     if (savedPreview && typeof savedPreview === "object"){
       const mode = savedPreview.mode === "image" ? "image" : "message";
       const content = String(savedPreview.content || "").trim();
-      if (content) return { name, href, mode, content, expectedPath, rootLocation };
+      if (content) return { name, href, mode, content, expectedPath, rootLocation, source };
     }
-    if (/^data:image\//i.test(previewUrl) || /^https?:\/\//i.test(previewUrl)) return { name, href: href || previewUrl, mode: "image", content: previewUrl, expectedPath, rootLocation };
+    if (/^data:image\//i.test(previewUrl) || /^https?:\/\//i.test(previewUrl)) return { name, href: href || previewUrl, mode: "image", content: previewUrl, expectedPath, rootLocation, source };
     if (!href){
-      if (source === "wj_cuts_reference") return { name, href: "", mode: "message", content: "Preview unavailable: this file is stored as a WJ Cuts reference path only. Select/verify your WJ Cuts root folder on this device, then reopen this job.", expectedPath, rootLocation };
-      if (source === "onedrive") return { name, href: "", mode: "message", content: "Preview unavailable: OneDrive link metadata is incomplete. Relink this file from OneDrive so preview content can load.", expectedPath, rootLocation };
-      if ([".dxf", ".ord", ".omx"].includes(ext)) return { name, href: "", mode: "message", content: "Preview unavailable: no file content URL is saved for this CAD file. Re-attach from Reference Folder or add a direct OneDrive URL.", expectedPath, rootLocation };
-      return { name, href: "", mode: "message", content: "Preview unavailable: no file content was saved for this attachment.", expectedPath, rootLocation };
+      if (source === "wj_cuts_reference") return { name, href: "", mode: "message", content: "Preview unavailable: this file is stored as a WJ Cuts reference path only. Select/verify your WJ Cuts root folder on this device, then reopen this job.", expectedPath, rootLocation, source };
+      if (source === "onedrive") return { name, href: "", mode: "message", content: "Preview unavailable: OneDrive link metadata is incomplete. Relink this file from OneDrive so preview content can load.", expectedPath, rootLocation, source };
+      if ([".dxf", ".ord", ".omx"].includes(ext)) return { name, href: "", mode: "message", content: "Preview unavailable: no file content URL is saved for this CAD file. Re-attach from Reference Folder or add a direct OneDrive URL.", expectedPath, rootLocation, source };
+      return { name, href: "", mode: "message", content: "Preview unavailable: no file content was saved for this attachment.", expectedPath, rootLocation, source };
     }
-    if (ext === ".svg") return { name, href, mode: "image", content: href, expectedPath, rootLocation };
-    if (/^data:image\//i.test(href)) return { name, href, mode: "image", content: href, expectedPath, rootLocation };
+    if (ext === ".svg") return { name, href, mode: "image", content: href, expectedPath, rootLocation, source };
+    if (/^data:image\//i.test(href)) return { name, href, mode: "image", content: href, expectedPath, rootLocation, source };
     if (/^https?:\/\//i.test(href) && [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"].includes(ext)){
-      return { name, href, mode: "image", content: href, expectedPath, rootLocation };
+      return { name, href, mode: "image", content: href, expectedPath, rootLocation, source };
     }
     if ([".dxf", ".ord", ".omx"].includes(ext)) {
       const text = decodeDataUrlText(href);
       const cadSvg = text ? renderCadToSvgDataUrl(text) : "";
       return cadSvg
-        ? { name, href, mode: "image", content: cadSvg, expectedPath, rootLocation }
-        : { name, href, mode: "message", content: "2D preview unavailable. Add a OneDrive direct file URL or re-upload to refresh preview.", expectedPath, rootLocation };
+        ? { name, href, mode: "image", content: cadSvg, expectedPath, rootLocation, source }
+        : { name, href, mode: "message", content: "2D preview unavailable. Add a OneDrive direct file URL or re-upload to refresh preview.", expectedPath, rootLocation, source };
     }
-    return { name, href, mode: "message", content: "Preview unavailable for this file type.", expectedPath, rootLocation };
+    return { name, href, mode: "message", content: "Preview unavailable for this file type.", expectedPath, rootLocation, source };
   };
   const buildFileCellMarkup = (jobId, files)=>{
     const previews = (Array.isArray(files) ? files : []).map(filePreviewModel);
@@ -2954,9 +2954,13 @@ function viewJobs(){
             <div class="job-file-preview-frame">
               <img src="${first.mode === "image" ? esc(first.content) : ""}" alt="Preview of ${esc(first.name)}" class="job-file-preview-image" data-preview-image ${first.mode === "image" ? "" : "hidden"}>
               <span class="job-file-preview-message small muted" data-preview-message ${first.mode === "message" ? "" : "hidden"}>${first.mode === "message" ? esc(first.content) : ""}</span>
-              <button type="button" class="small link" data-preview-path-btn data-preview-expected-path="${esc(first.expectedPath || "")}" data-preview-root-location="${esc(first.rootLocation || "")}" ${first.mode === "message" && first.expectedPath ? "" : "hidden"}>Show expected path</button>
             </div>
-            <a class="job-file-preview-open small" data-preview-open href="${esc(first.href || "")}" target="_blank" rel="noopener" ${first.href ? "" : "hidden"}>Open file</a>
+            <div class="job-file-preview-actions">
+              <button type="button" class="job-file-preview-link" data-preview-path-btn data-preview-expected-path="${esc(first.expectedPath || "")}" data-preview-root-location="${esc(first.rootLocation || "")}" ${first.expectedPath ? "" : "hidden"}>Show path</button>
+              ${first.source === "wj_cuts_reference"
+                ? `<button type="button" class="job-file-preview-link" data-open-local-file data-job-id="${esc(jobId)}" data-file-index="0">Open</button>`
+                : `<a class="job-file-preview-link" data-preview-open href="${esc(first.href || "")}" target="_blank" rel="noopener" ${first.href ? "" : "hidden"}>Open</a>`}
+            </div>
           </div>
         </div>
       </div>
@@ -3980,9 +3984,17 @@ function viewJobs(){
                   const safeName = f.name || `file_${idx+1}`;
                   const href = f.dataUrl || f.url || f.externalUrl || f.downloadUrl || f.oneDriveUrl || "";
                   const usableLink = !!href && !/^data:(image|application)\//i.test(String(href || "")) && /^https?:\/\//i.test(String(href || ""));
-                  const link = usableLink ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : `${safeName} <span class="small muted">— File metadata saved only — original file content is not stored.</span>`;
-                  const sourceTag = f?.source === "onedrive" ? `<span class="job-file-source-badge">OneDrive</span>` : "";
-                  return `<li>${link} ${sourceTag} <button type="button" class="link" data-edit-file-link="${job.id}" data-file-index="${idx}">Link</button> <button type="button" class="link" data-remove-file="${job.id}" data-file-index="${idx}">Remove</button></li>`;
+                  const isRef = f?.source === "wj_cuts_reference" && !!f?.relativePath;
+                  const expectedPath = isRef ? `WJ Cuts\${String(f.relativePath || "").replace(/^\+/, "")}` : "";
+                  const link = isRef
+                    ? `<button type="button" class="link" data-open-local-file data-job-id="${j.id}" data-file-index="${idx}">${safeName}</button>`
+                    : (usableLink ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : `${safeName} <span class="small muted">— File metadata saved only — original file content is not stored.</span>`);
+                  const sourceTag = isRef
+                    ? `<span class="job-file-source-badge">Reference folder</span>`
+                    : (f?.source === "onedrive" ? `<span class="job-file-source-badge">OneDrive</span>` : "");
+                  const pathAction = expectedPath ? `<button type="button" class="link" data-preview-path-btn data-preview-expected-path="${esc(expectedPath)}" data-preview-root-location="${esc(f?.rootLocationHint || 'WJ Cuts')}">Show path</button>` : "";
+                  const linkAction = !isRef ? `<button type="button" class="link" data-edit-file-link="${j.id}" data-file-index="${idx}">Link</button>` : "";
+                  return `<li>${link} ${sourceTag} ${expectedPath ? `<span class="small muted">— ${esc(expectedPath)}</span>` : ""} ${pathAction} ${linkAction} <button type="button" class="link" data-remove-file="${j.id}" data-file-index="${idx}">Remove</button></li>`;
                 }).join("") : `<li class="muted">No files attached</li>`}
               </ul>
             </div>

--- a/js/views.js
+++ b/js/views.js
@@ -2904,39 +2904,49 @@ function viewJobs(){
   const filePreviewModel = (file)=>{
     const name = String(file?.name || "Attached file");
     const href = String(file?.dataUrl || file?.url || "");
+    const expectedPath = file?.source === "wj_cuts_reference" && file?.relativePath
+      ? `${String(file?.rootPathStart || "WJ Cuts")}\\${String(file.relativePath || "").replace(/\//g, "\\")}`
+      : "";
     const previewUrl = String(file?.previewUrl || "");
     const ext = extractFileExtension(name);
+    const source = String(file?.source || "");
+    const rootLocation = String(file?.rootLocationHint || "");
     const savedPreview = file && typeof file === "object" ? file.preview : null;
     if (savedPreview && typeof savedPreview === "object"){
       const mode = savedPreview.mode === "image" ? "image" : "message";
       const content = String(savedPreview.content || "").trim();
-      if (content) return { name, href, mode, content };
+      if (content) return { name, href, mode, content, expectedPath, rootLocation };
     }
-    if (/^data:image\//i.test(previewUrl) || /^https?:\/\//i.test(previewUrl)) return { name, href: href || previewUrl, mode: "image", content: previewUrl };
-    if (!href) return { name, href: "", mode: "message", content: "Preview unavailable" };
-    if (ext === ".svg") return { name, href, mode: "image", content: href };
-    if (/^data:image\//i.test(href)) return { name, href, mode: "image", content: href };
+    if (/^data:image\//i.test(previewUrl) || /^https?:\/\//i.test(previewUrl)) return { name, href: href || previewUrl, mode: "image", content: previewUrl, expectedPath, rootLocation };
+    if (!href){
+      if (source === "wj_cuts_reference") return { name, href: "", mode: "message", content: "Preview unavailable: this file is stored as a WJ Cuts reference path only. Select/verify your WJ Cuts root folder on this device, then reopen this job.", expectedPath, rootLocation };
+      if (source === "onedrive") return { name, href: "", mode: "message", content: "Preview unavailable: OneDrive link metadata is incomplete. Relink this file from OneDrive so preview content can load.", expectedPath, rootLocation };
+      if ([".dxf", ".ord", ".omx"].includes(ext)) return { name, href: "", mode: "message", content: "Preview unavailable: no file content URL is saved for this CAD file. Re-attach from Reference Folder or add a direct OneDrive URL.", expectedPath, rootLocation };
+      return { name, href: "", mode: "message", content: "Preview unavailable: no file content was saved for this attachment.", expectedPath, rootLocation };
+    }
+    if (ext === ".svg") return { name, href, mode: "image", content: href, expectedPath, rootLocation };
+    if (/^data:image\//i.test(href)) return { name, href, mode: "image", content: href, expectedPath, rootLocation };
     if (/^https?:\/\//i.test(href) && [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"].includes(ext)){
-      return { name, href, mode: "image", content: href };
+      return { name, href, mode: "image", content: href, expectedPath, rootLocation };
     }
     if ([".dxf", ".ord", ".omx"].includes(ext)) {
       const text = decodeDataUrlText(href);
       const cadSvg = text ? renderCadToSvgDataUrl(text) : "";
       return cadSvg
-        ? { name, href, mode: "image", content: cadSvg }
-        : { name, href, mode: "message", content: "2D preview unavailable. Add a OneDrive direct file URL or re-upload to refresh preview." };
+        ? { name, href, mode: "image", content: cadSvg, expectedPath, rootLocation }
+        : { name, href, mode: "message", content: "2D preview unavailable. Add a OneDrive direct file URL or re-upload to refresh preview.", expectedPath, rootLocation };
     }
-    return { name, href, mode: "message", content: "Preview unavailable for this file type." };
+    return { name, href, mode: "message", content: "Preview unavailable for this file type.", expectedPath, rootLocation };
   };
   const buildFileCellMarkup = (jobId, files)=>{
     const previews = (Array.isArray(files) ? files : []).map(filePreviewModel);
     if (!previews.length) return '<div class="job-file-preview-empty small muted">No files attached</div>';
-    const first = previews[0] || { name: "Attached file", mode: "message", content: "Preview unavailable", href: "" };
+    const first = previews[0] || { name: "Attached file", mode: "message", content: "Preview unavailable", href: "", expectedPath: "", rootLocation: "" };
     const selectId = `jobFileSelect_${esc(jobId)}`;
     return `
       <div class="job-file-preview" data-file-preview data-file-preview-job="${esc(jobId)}">
         ${previews.length > 1
-          ? `<label class="sr-only" for="${selectId}">Choose file preview</label><select id="${selectId}" class="job-file-preview-select" data-file-preview-select="${esc(jobId)}">${previews.map((f, idx)=>`<option value="${idx}" data-preview-name="${esc(f.name)}" data-preview-mode="${esc(f.mode)}" data-preview-content="${esc(f.content)}" data-preview-href="${esc(f.href || "")}">${esc(f.name)}</option>`).join("")}</select>`
+          ? `<label class="sr-only" for="${selectId}">Choose file preview</label><select id="${selectId}" class="job-file-preview-select" data-file-preview-select="${esc(jobId)}">${previews.map((f, idx)=>`<option value="${idx}" data-preview-name="${esc(f.name)}" data-preview-mode="${esc(f.mode)}" data-preview-content="${esc(f.content)}" data-preview-href="${esc(f.href || "")}" data-preview-expected-path="${esc(f.expectedPath || "")}" data-preview-root-location="${esc(f.rootLocation || "")}">${esc(f.name)}</option>`).join("")}</select>`
           : ""}
         <div class="job-file-preview-panes" data-file-preview-panes>
           <div class="job-file-preview-pane" data-file-preview-pane>
@@ -2944,6 +2954,7 @@ function viewJobs(){
             <div class="job-file-preview-frame">
               <img src="${first.mode === "image" ? esc(first.content) : ""}" alt="Preview of ${esc(first.name)}" class="job-file-preview-image" data-preview-image ${first.mode === "image" ? "" : "hidden"}>
               <span class="job-file-preview-message small muted" data-preview-message ${first.mode === "message" ? "" : "hidden"}>${first.mode === "message" ? esc(first.content) : ""}</span>
+              <button type="button" class="small link" data-preview-path-btn data-preview-expected-path="${esc(first.expectedPath || "")}" data-preview-root-location="${esc(first.rootLocation || "")}" ${first.mode === "message" && first.expectedPath ? "" : "hidden"}>Show expected path</button>
             </div>
             <a class="job-file-preview-open small" data-preview-open href="${esc(first.href || "")}" target="_blank" rel="noopener" ${first.href ? "" : "hidden"}>Open file</a>
           </div>
@@ -3961,6 +3972,20 @@ function viewJobs(){
               </aside>
             </div>
             <label class="job-edit-note">Notes<textarea data-history-field="notes" data-history-id="${job.id}" rows="3" placeholder="Notes...">${textEsc(job?.notes || "")}</textarea></label>
+            <div class="job-edit-files">
+              <div class="job-edit-files-actions"><button type="button" data-job-file-add="${job.id}">Attach from Reference Folder</button><button type="button" data-upload-job="${job.id}">Temporary local upload — not saved</button><button type="button" data-link-job-file="${job.id}">Link OneDrive URL</button></div>
+              <input type="file" data-job-file-input="${job.id}" multiple style="display:none">
+              <ul class="job-file-list">
+                ${jobFiles.length ? jobFiles.map((f, idx)=>{
+                  const safeName = f.name || `file_${idx+1}`;
+                  const href = f.dataUrl || f.url || f.externalUrl || f.downloadUrl || f.oneDriveUrl || "";
+                  const usableLink = !!href && !/^data:(image|application)\//i.test(String(href || "")) && /^https?:\/\//i.test(String(href || ""));
+                  const link = usableLink ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : `${safeName} <span class="small muted">— File metadata saved only — original file content is not stored.</span>`;
+                  const sourceTag = f?.source === "onedrive" ? `<span class="job-file-source-badge">OneDrive</span>` : "";
+                  return `<li>${link} ${sourceTag} <button type="button" class="link" data-edit-file-link="${job.id}" data-file-index="${idx}">Link</button> <button type="button" class="link" data-remove-file="${job.id}" data-file-index="${idx}">Remove</button></li>`;
+                }).join("") : `<li class="muted">No files attached</li>`}
+              </ul>
+            </div>
             <div class="job-edit-actions">
               <button type="button" data-history-save="${job.id}">Save</button>
               <button type="button" class="danger" data-history-cancel="${job.id}">Cancel</button>
@@ -4374,7 +4399,7 @@ function viewJobs(){
             </div>
               <label class="job-edit-note">Notes<textarea data-j="notes" data-id="${j.id}" rows="3" placeholder="Notes...">${j.notes||""}</textarea></label>
               <div class="job-edit-files">
-                <div class="job-edit-files-actions"><button type="button" data-upload-job="${j.id}">Add Files</button><button type="button" data-link-job-file="${j.id}">Link OneDrive URL</button></div>
+                <div class="job-edit-files-actions"><button type="button" data-job-file-add="${j.id}">Attach from Reference Folder</button><button type="button" data-upload-job="${j.id}">Temporary local upload — not saved</button><button type="button" data-link-job-file="${j.id}">Link OneDrive URL</button></div>
                 <input type="file" data-job-file-input="${j.id}" multiple style="display:none">
                 <ul class="job-file-list">
                   ${jobFiles.length ? jobFiles.map((f, idx)=>{
@@ -4624,6 +4649,7 @@ function viewJobs(){
               <div>Root setup: <span data-onedrive-connection-status>Not set</span></div>
               <div>Folder status: <span data-onedrive-folder-status>Not ready</span></div>
               <div>This computer root: <span data-onedrive-root-status>Not set</span></div>
+              <div>Root path hint: <span data-onedrive-root-path>Not set</span></div>
               <div>This computer ID: <span data-onedrive-device-status>Not set</span></div>
               <div>Indexed files: <span data-onedrive-library-status>0</span></div>
             </div>

--- a/style.css
+++ b/style.css
@@ -3325,14 +3325,15 @@ body.modal-open .auth-bar {
 }
 .job-file-preview-frame {
   width: 100%;
-  height: 94px;
+  min-height: 64px;
+  height: auto;
   border-radius: 10px;
   border: 1px solid #d6e0f3;
   background: #fff;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
+  align-items: flex-start;
+  justify-content: flex-start;
+  overflow: visible;
   padding: 4px;
 }
 .job-file-preview-image {
@@ -3342,6 +3343,7 @@ body.modal-open .auth-bar {
   display: block;
 }
 .job-file-preview-message {
+  font-size: 13px;
   text-align: left;
   line-height: 1.35;
   padding: 0 6px;
@@ -3349,21 +3351,14 @@ body.modal-open .auth-bar {
   white-space: normal;
   overflow-wrap: anywhere;
   display: block;
-  max-height: 84px;
-  overflow-y: auto;
+  max-height: none;
+  overflow: visible;
 }
 .job-file-preview-empty {
   margin: 0;
 }
-.job-file-preview-open {
-  color: #1f3b67;
-  text-decoration: none;
-  font-weight: 600;
-}
-.job-file-preview-open:hover,
-.job-file-preview-open:focus-visible {
-  text-decoration: underline;
-}
+.job-file-preview-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 4px; }
+.job-file-preview-link { background: transparent; border: 0; padding: 0; color: #1f3b67; text-decoration: underline; font-size: 12px; font-weight: 600; cursor: pointer; }
 .job-edit-files-actions {
   display: flex;
   gap: 8px;

--- a/style.css
+++ b/style.css
@@ -3342,9 +3342,15 @@ body.modal-open .auth-bar {
   display: block;
 }
 .job-file-preview-message {
-  text-align: center;
+  text-align: left;
   line-height: 1.35;
   padding: 0 6px;
+  width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  display: block;
+  max-height: 84px;
+  overflow-y: auto;
 }
 .job-file-preview-empty {
   margin: 0;


### PR DESCRIPTION
### Motivation
- Provide a robust workflow to attach files by referencing a local synced OneDrive/WJ Cuts root folder rather than uploading files into the cloud.
- Improve user feedback for why file previews fail (OneDrive, reference root, CAD decoding, permissions) and surface expected reference paths.
- Add safety and diagnostic tooling for maintenance V2 occurrence data to detect missing/invalid lifecycle or required fields.
- Improve job file editing UX (attach/link/remove), preserve stable IDs and root verification across devices.

### Description
- Added `ensureBubble()` helper and `runMaintenanceV2SafetyChecks()` in `js/calendar.js`, and exposed `window.runMaintenanceV2SafetyChecks` for runtime diagnostics of maintenance V2 occurrences.
- Extended `sanitizeJobFileReferenceForFirestore()` to include `rootLocationHint`, and changed `filesToAttachments()` to warn that local uploads are temporary and return an empty list to encourage reference-based attachments (`js/renderers.js`).
- Implemented local root handling flows: `resolveLocalFileFromRelativePath` now enforces saved handle and permissions, `describeLocalRootPreviewError()` produces clearer error messages, and `diagnosePreviewFailure()` centralizes preview-failure explanations for OneDrive, WJ Cuts reference, and CAD files (`js/renderers.js`).
- Added `getWJCutsRootStatus`, `pendingAttachTarget` handling, and improved OneDrive root picker/attach flows to save `localRootSignature`, `rootLocationHint`, and `enabled` status, plus automatic continuation of pending attach after setup (`js/renderers.js`).
- Enhanced preview/cache behavior so OneDrive/CAD preview failures show actionable text and use `diagnosePreviewFailure()`; catching local root errors now surfaces descriptive messages (`js/renderers.js`).
- Added numerous UI event handlers and data attributes to support: attach-from-reference, temporary local upload, link OneDrive DXF, edit link, remove file, show expected reference path, and copy expected path to clipboard (`js/renderers.js`, `js/views.js`).
- Reworked file preview model to include `expectedPath` and `rootLocation` and updated markup to show an explicit "Show expected path" button and job-edit file list with attach/link/remove actions (`js/views.js`).
- Minor DOM/text/CSS improvements for file preview messaging and layout changes to make long messages wrap and scroll (`style.css`).
- Replaced ad-hoc job lookups with `findJobRecord` where applicable and added debug logging (`window.DEBUG_MODE`) around critical flows.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb1aa0ee88325b4d23412651539a5)