### PR TITLE
Enhance WJ Cuts OneDrive/local-reference handling, preview diagnostics, and UI

### DIFF
--- a/js/renderers.js
+++ b/js/renderers.js
@@ -19807,10 +19807,11 @@ function renderJobs(){
         const allowSwitch = window.confirm("This is a different WJ Cuts root. Existing files from the old root will show as mismatched until reattached. Continue?");
         if (!allowSwitch) return false;
       }
-      await saveLocalRootHandleForProfile(profileId, handle);
       await saveLocalRootHandle(handle);
-      const verifyHandle = await readLocalRootHandleForProfile(profileId);
-      if (!verifyHandle){ toast("Unable to save root handle on this browser."); return false; }
+      if (profileId) await saveLocalRootHandleForProfile(profileId, handle);
+      const verifyGlobalHandle = await readLocalRootHandle();
+      const verifyProfileHandle = profileId ? await readLocalRootHandleForProfile(profileId) : true;
+      if (!verifyGlobalHandle || !verifyProfileHandle){ toast("Unable to save root handle on this browser."); return false; }
       const rootDevices = { ...(cfg.rootDevices || {}) };
       if (profileId){
         rootDevices[profileId] = { ...(rootDevices[profileId] || {}), deviceId: profileId, computerProfileId: profileId, deviceNumber: currentDeviceNumber, label: rootDevices[profileId]?.label || `Computer ${currentDeviceNumber}`, folderName: String(handle.name || ""), folderHint: rootHint, rootSignature: signature, rootId: String(marker?.rootId || ""), lastVerifiedAtISO: new Date().toISOString(), lastSeenBrowserDeviceId: currentDeviceId, lastSeenBrowserDeviceNumber: currentDeviceNumber };
@@ -19825,7 +19826,16 @@ function renderJobs(){
         currentComputerProfileByBrowserDeviceId: { ...(cfg.currentComputerProfileByBrowserDeviceId || {}), ...(currentDeviceId ? { [currentDeviceId]: profileId } : {}) }
       });
       if (typeof saveCloudDebounced === "function") saveCloudDebounced();
-      await updateOneDriveWizardStatus();
+      const refreshed = await refreshWJCutsRootStateAfterChange({ closeModal:false });
+      const guard = "wjCutsRootJustSelectedReload";
+      const statusText = String(oneDriveConnStatus?.textContent || "").toLowerCase();
+      const didReload = typeof window !== "undefined" && window.sessionStorage ? window.sessionStorage.getItem(guard) === "1" : false;
+      if (refreshed.ok && statusText.includes("not linked") && !didReload){
+        try { window.sessionStorage.setItem(guard, "1"); } catch(_){}
+        window.location.reload();
+        return true;
+      }
+      try { window.sessionStorage.removeItem(guard); } catch(_){}
       toast("This computer OneDrive root folder saved and verified.");
       return true;
     } catch (err){
@@ -19939,6 +19949,17 @@ function renderJobs(){
     document.body.classList.add("modal-open");
     updateOneDriveWizardStatus();
   };
+  const refreshWJCutsRootStateAfterChange = async (options = {})=>{
+    const active = await getActiveWJCutsRoot();
+    await updateOneDriveWizardStatus();
+    await updatePermissionBanner();
+    if (active.ok){
+      setSetupReason("");
+      if (options.closeModal !== false) closeOneDriveModal();
+    }
+    renderJobs();
+    return active;
+  };
 
   oneDriveSetupBtn?.addEventListener("click", ()=>{
     closeFileMenu(); closeActionMenu(); closeHistoryActionMenu(); openOneDriveModal();
@@ -20008,15 +20029,14 @@ function renderJobs(){
     requestAnimationFrame(()=> restoreNewJobFormState(formState));
   });
 
-  updateOneDriveWizardStatus();
-  updatePermissionBanner();
+  refreshWJCutsRootStateAfterChange({ closeModal:false });
   permissionSetupBtn?.addEventListener("click", ()=> openOneDriveModal());
   permissionGrantBtn?.addEventListener("click", async ()=>{
     const profileId = getCurrentComputerProfileId(getSharedConfig());
-    let handle = await readLocalRootHandleForProfile(profileId);
+    let handle = await readLocalRootHandle();
     if (!handle){
-      handle = await readLocalRootHandle();
-      if (handle && profileId) await saveLocalRootHandleForProfile(profileId, handle);
+      handle = await readLocalRootHandleForProfile(profileId);
+      if (handle) await saveLocalRootHandle(handle);
     }
     if (handle){
       try {
@@ -20025,8 +20045,7 @@ function renderJobs(){
       } catch (_err){
         toast("Permission is required for referenced files to preview or open.");
       }
-      await updateOneDriveWizardStatus();
-      await updatePermissionBanner();
+      await refreshWJCutsRootStateAfterChange({ closeModal:false });
       return;
     }
     openOneDriveModal();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -19549,9 +19549,6 @@ function renderJobs(){
         toast("This folder does not match files already attached by other computers. Select the same shared root folder.");
         return false;
       }
-      await saveLocalRootHandle(handle);
-      const verifyHandle = await readLocalRootHandle();
-      if (!verifyHandle){ toast("Unable to save root handle on this browser."); return false; }
       const cfg = getSharedConfig();
       const currentDeviceId = String(getLocalDeviceId() || "");
       const currentDeviceNumber = getLocalDeviceNumber();
@@ -19562,6 +19559,9 @@ function renderJobs(){
         toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile.");
         return false;
       }
+      await saveLocalRootHandle(handle);
+      const verifyHandle = await readLocalRootHandle();
+      if (!verifyHandle){ toast("Unable to save root handle on this browser."); return false; }
       const rootDevices = { ...(cfg.rootDevices || {}) };
       if (profileId){
         rootDevices[profileId] = { ...(rootDevices[profileId] || {}), deviceId: profileId, computerProfileId: profileId, deviceNumber: currentDeviceNumber, label: rootDevices[profileId]?.label || `Computer ${currentDeviceNumber}`, folderName: String(handle.name || ""), folderHint: rootHint, rootSignature: signature, lastVerifiedAtISO: new Date().toISOString(), lastSeenBrowserDeviceId: currentDeviceId, lastSeenBrowserDeviceNumber: currentDeviceNumber };
@@ -19572,7 +19572,7 @@ function renderJobs(){
         folderHint: rootHint,
         enabled: true,
         rootDevices,
-        currentComputerProfileId: profileId,
+        currentComputerProfileId: cfg.currentComputerProfileId || profileId,
         currentComputerProfileByBrowserDeviceId: { ...(cfg.currentComputerProfileByBrowserDeviceId || {}), ...(currentDeviceId ? { [currentDeviceId]: profileId } : {}) }
       });
       if (typeof saveCloudDebounced === "function") saveCloudDebounced();
@@ -19713,8 +19713,7 @@ function renderJobs(){
       pendingAttachTarget = null;
       const attached = await attachFromLocalOneDriveRoot(target.mode === "job" ? target.jobId : "");
       if (attached){
-        if (typeof saveCloudDebounced === "function") saveCloudDebounced();
-    closeOneDriveModal();
+        closeOneDriveModal();
       }
     }
   });
@@ -19760,8 +19759,9 @@ function renderJobs(){
     const label = String(oneDriveProfileLabelInput?.value || "").trim() || `Computer ${getLocalDeviceNumber()}`;
     const rootDevices = { ...(cfg.rootDevices || {}) };
     rootDevices[profileId] = { ...(rootDevices[profileId] || {}), deviceId: profileId, computerProfileId: profileId, label, lastSeenBrowserDeviceId: currentDeviceId, lastSeenBrowserDeviceNumber: getLocalDeviceNumber() };
-    updateSharedConfig({ rootDevices, currentComputerProfileId: profileId,
+    updateSharedConfig({ rootDevices, currentComputerProfileId: cfg.currentComputerProfileId || profileId,
         currentComputerProfileByBrowserDeviceId: { ...(cfg.currentComputerProfileByBrowserDeviceId || {}), ...(currentDeviceId ? { [currentDeviceId]: profileId } : {}) } });
+    if (typeof saveCloudDebounced === "function") saveCloudDebounced();
     updateOneDriveWizardStatus();
   });
 
@@ -19786,7 +19786,6 @@ function renderJobs(){
       } catch (_err){
         toast("Permission is required for referenced files to preview or open.");
       }
-      if (typeof saveCloudDebounced === "function") saveCloudDebounced();
       await updateOneDriveWizardStatus();
       await updatePermissionBanner();
       return;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -19431,6 +19431,7 @@ function renderJobs(){
   const oneDriveProfileLabelInput = document.getElementById("jobOneDriveProfileLabel");
   const oneDriveProfileUseBtn = document.getElementById("jobOneDriveProfileUseBtn");
   const oneDriveProfileSaveBtn = document.getElementById("jobOneDriveProfileSaveBtn");
+  const oneDriveStatusInline = content.querySelector(".job-onedrive-status");
 
   let pendingAttachTarget = null;
   const ensureCurrentProfile = (cfg)=>{
@@ -19506,15 +19507,35 @@ function renderJobs(){
     if (oneDriveCurrentComputer){
       const selectedProfile = (cfg.rootDevices || {})[getCurrentComputerProfileId(cfg) || ""] || null;
       const signature = status.signature || selectedProfile?.rootSignature || "Not verified";
-      oneDriveCurrentComputer.innerHTML = `Browser/device ID: ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected computer profile: ${escapeHtml(selectedProfile?.label || "Not selected")}<br>Selected root folder: ${status.handleName || "Not selected on this computer"}<br>Root location hint: ${selectedProfile?.folderHint || cfg.folderHint || "Not set"}<br>Root signature: ${signature}<br>Status: ${status.message}<br><span class="small muted">Root metadata is saved to the shared app state. Actual folder permission is saved in this browser profile and may need to be re-authorized after browser/site storage is cleared or when using a different browser.</span>`;
+      const authState = status.permission === "granted" && status.signatureMatches ? "Authorized" : (status.hasSavedHandle ? "Needs permission" : "Not authorized");
+      oneDriveCurrentComputer.innerHTML = `Browser/device ID: ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected computer profile: ${escapeHtml(selectedProfile?.label || "Not selected")}<br>Local root authorization: ${authState}<br>Selected root folder: ${status.handleName || "Not selected in this browser"}<br>Root location hint: ${selectedProfile?.folderHint || cfg.folderHint || "Not set"}<br>Root signature: ${signature}<br>Status: ${status.message}`;
+    }
+    if (oneDriveStatusInline){
+      const hint = (status.currentDeviceMeta?.folderHint || cfg.folderHint || status.handleName || "").trim();
+      oneDriveStatusInline.textContent = status.permission === "granted" && status.signature && status.signatureMatches
+        ? `WJ Cuts root authorized${hint ? ` · ${hint}` : ""}`
+        : ((status.currentDeviceMeta || cfg.folderHint || cfg.localRootName)
+          ? `WJ Cuts root needs permission${hint ? ` · ${hint}` : ""}`
+          : "WJ Cuts root not set");
     }
     if (oneDriveKnownDevices){
       const rows = Object.values(cfg.rootDevices || {});
       oneDriveKnownDevices.innerHTML = rows.length
-        ? rows.map(row=>`<tr><td>${escapeHtml(row.label || "Unnamed")}<br><span class="small muted">${escapeHtml(String(row.deviceId || ""))}</span>${(row.computerProfileId || row.deviceId)===getCurrentComputerProfileId(cfg)?" <strong>(Selected)</strong>":""}</td><td>${escapeHtml(row.folderName || "—")}</td><td>${escapeHtml(row.folderHint || "—")}</td><td>${escapeHtml(row.rootSignature || "—")}</td><td>${escapeHtml(row.lastVerifiedAtISO || "—")}<br><span class="small muted">${escapeHtml(String(row.lastSeenBrowserDeviceNumber || "?"))} (${escapeHtml(String(row.lastSeenBrowserDeviceId || ""))})</span></td></tr>`).join("")
-        : `<tr><td colspan="5" class="small muted">No computer roots recorded yet.</td></tr>`;
+        ? rows.map(row=>{ const sig=String(row.rootSignature||""); const shortSig=sig?`${sig.slice(0,16)}${sig.length>16?"…":""}`:"Not verified"; const last=row.lastVerifiedAtISO?new Date(row.lastVerifiedAtISO).toLocaleString():"Never"; return `<tr><td>${escapeHtml(row.label || "Unnamed")}<br><span class="small muted">${escapeHtml(String(row.deviceId || ""))}</span>${(row.computerProfileId || row.deviceId)===getCurrentComputerProfileId(cfg)?" <strong>(Selected)</strong>":""}</td><td>${escapeHtml(row.folderName || "Not selected yet")}</td><td>${escapeHtml(row.folderHint || "—")}</td><td>${escapeHtml(shortSig)}</td><td>${escapeHtml(last)}</td><td>${escapeHtml(String(row.lastSeenBrowserDeviceNumber || "?"))} (${escapeHtml(String(row.lastSeenBrowserDeviceId || ""))})</td></tr>`; }).join("")
+        : `<tr><td colspan="6" class="small muted">No computer roots recorded yet.</td></tr>`;
     }
   };
+  async function ensureLocalRootAuthorizedForAttach(targetJobId = ""){
+    const cfg = getSharedConfig(); const profileId = getCurrentComputerProfileId(cfg); const profile = cfg.rootDevices?.[profileId] || null;
+    const handle = await readLocalRootHandle();
+    if (!handle){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; openOneDriveModal(); toast(profile ? "This computer profile has saved root metadata, but this browser is not authorized. Select/Re-authorize the WJ Cuts root folder shown in the hint, then the file picker will open." : "Create/select a computer profile and choose this computer’s WJ Cuts root folder first."); return { ok:false }; }
+    let perm = "prompt"; try { perm = await handle.requestPermission({ mode:"read" }); } catch(_){}
+    if (perm !== "granted"){ toast("Permission is required before WJ Cuts files can be added or previewed."); return { ok:false }; }
+    const signature = await computeLocalRootSignature(handle); if (!signature) return { ok:false };
+    if (profile?.rootSignature && profile.rootSignature !== signature){ toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile."); return { ok:false }; }
+    const match = verifyRootSignatureMatches(signature); if (!match.ok){ toast("This folder does not match files already attached by other computers. Select the same shared root folder."); return { ok:false }; }
+    return { ok:true, handle, signature, profileId, profile };
+  }
   const updatePermissionBanner = async ()=>{
     if (!permissionBanner) return;
     const hasRefs = [...(Array.isArray(cuttingJobs)?cuttingJobs:[]), ...(Array.isArray(completedCuttingJobs)?completedCuttingJobs:[])].some(j => Array.isArray(j?.files) && j.files.some(f=>f?.source==="wj_cuts_reference"));
@@ -19592,35 +19613,15 @@ function renderJobs(){
       toast("Local file references require Chrome or Edge.");
       return false;
     }
-    const rootHandle = await readLocalRootHandle();
-    if (!rootHandle){
-      pendingAttachTarget = targetJobId ? { mode: "job", jobId: String(targetJobId) } : { mode: "new" };
-      toast("Set this computer’s WJ Cuts root folder before attaching files. The app saves a reference path, not the file itself.");
-      if (window.DEBUG_MODE) console.info("[cutting-job-files] attach blocked root missing", { targetJobId });
-      openOneDriveModal();
-      return false;
-    }
+    const ensured = await ensureLocalRootAuthorizedForAttach(targetJobId);
+    if (!ensured.ok) return false;
+    const rootHandle = ensured.handle;
 
     try {
       const cfg = getSharedConfig();
-      const profileId = getCurrentComputerProfileId(cfg);
-      const currentProfile = cfg.rootDevices?.[profileId];
-      const signature = await computeLocalRootSignature(rootHandle);
-      if (!signature){
-        toast("Unable to verify local OneDrive root folder.");
-        return false;
-      }
-      const match = verifyRootSignatureMatches(signature);
-      if (!match.ok){
-        toast("Local root folder mismatch. Please pick the same shared root as other computers.");
-        return false;
-      }
-
-      const perm = await rootHandle.requestPermission({ mode: "read" });
-      if (perm !== "granted"){
-        toast("Root folder permission is required to attach from this computer.");
-        return false;
-      }
+      const profileId = ensured.profileId;
+      const currentProfile = ensured.profile;
+      const signature = ensured.signature;
       const pickedHandles = await window.showOpenFilePicker({
         multiple: false,
         startIn: rootHandle,

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1042,6 +1042,32 @@ async function saveLocalRootHandle(handle){
     tx.onerror = ()=>{ db.close(); reject(tx.error || new Error("Failed saving local root handle")); };
   });
 }
+function localRootHandleKeyForProfile(profileId){
+  const clean = String(profileId || "").trim();
+  return clean ? `profile:${clean}` : JOB_ONEDRIVE_LOCAL_ROOT_KEY;
+}
+async function saveLocalRootHandleForProfile(profileId, handle){
+  if (!supportsLocalRootPicker()) return false;
+  const db = await openOneDriveRootDb();
+  const key = localRootHandleKeyForProfile(profileId);
+  return new Promise((resolve, reject)=>{
+    const tx = db.transaction(JOB_ONEDRIVE_LOCAL_ROOT_STORE, "readwrite");
+    tx.objectStore(JOB_ONEDRIVE_LOCAL_ROOT_STORE).put(handle, key);
+    tx.oncomplete = ()=>{ db.close(); resolve(true); };
+    tx.onerror = ()=>{ db.close(); reject(tx.error || new Error("Failed saving profile local root handle")); };
+  });
+}
+async function readLocalRootHandleForProfile(profileId){
+  if (!supportsLocalRootPicker()) return null;
+  const db = await openOneDriveRootDb();
+  const key = localRootHandleKeyForProfile(profileId);
+  return new Promise((resolve, reject)=>{
+    const tx = db.transaction(JOB_ONEDRIVE_LOCAL_ROOT_STORE, "readonly");
+    const req = tx.objectStore(JOB_ONEDRIVE_LOCAL_ROOT_STORE).get(key);
+    req.onsuccess = ()=>{ db.close(); resolve(req.result || null); };
+    req.onerror = ()=>{ db.close(); reject(req.error || new Error("Failed reading profile local root handle")); };
+  });
+}
 
 async function readLocalRootHandle(){
   if (!supportsLocalRootPicker()) return null;
@@ -19538,7 +19564,14 @@ function renderJobs(){
     const profileId = getCurrentComputerProfileId(config);
     const currentDeviceMeta = (config.rootDevices && profileId) ? config.rootDevices[profileId] : null;
     if (!supportsLocalRootPicker()) return { supported:false, handle:null, hasSavedHandle:false, permission:"unsupported", config, signature:"", profileSignature:"", profileMatches:true, expectedSignature: expectedRootSignatureFromJobs(), expectedMatches:true, signatureMatches:true, message:"Unsupported browser" };
-    const handle = await readLocalRootHandle();
+    let handle = await readLocalRootHandleForProfile(profileId);
+    if (!handle){
+      const legacyHandle = await readLocalRootHandle();
+      if (legacyHandle){
+        handle = legacyHandle;
+        if (profileId) await saveLocalRootHandleForProfile(profileId, legacyHandle);
+      }
+    }
     if (!handle) return { supported:true, handle:null, hasSavedHandle:false, permission:"missing", config, signature:"", profileSignature:String(currentDeviceMeta?.rootSignature || "").trim(), profileMatches:true, expectedSignature: expectedRootSignatureFromJobs(), expectedMatches:true, signatureMatches:true, message: currentDeviceMeta ? "Root metadata exists for this computer profile, but this browser is not authorized yet. Re-authorize the folder shown in the hint." : "Not set", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:"", profileId };
     let permission = "prompt";
     try { permission = typeof handle.queryPermission === "function" ? await handle.queryPermission({ mode:"read" }) : "granted"; } catch(_e){}
@@ -19548,12 +19581,9 @@ function renderJobs(){
     const profileRootId = String(currentDeviceMeta?.rootId || "").trim();
     const marker = await readWJCutsRootMarker(handle);
     const markerRootId = String(marker?.rootId || "").trim();
-    const expectedRootId = expectedRootIdFromJobs();
     const expectedSignature = expectedRootSignatureFromJobs();
     const profileMatches = !profileSignature || !signature || profileSignature === signature;
-    const expectedMatches = expectedRootId
-      ? (!markerRootId || expectedRootId === markerRootId)
-      : (!expectedSignature || !signature || expectedSignature === signature);
+    const expectedMatches = !expectedSignature || !signature || expectedSignature === signature;
     const markerMatchesProfile = !profileRootId || !markerRootId || profileRootId === markerRootId;
     const signatureMatches = profileMatches && expectedMatches && markerMatchesProfile;
     return { supported:true, handle, hasSavedHandle:true, permission:"granted", config, signature, profileSignature, profileMatches, expectedSignature, expectedMatches, signatureMatches, message: signatureMatches ? "Verified" : "Mismatch", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || ""), profileId, markerRootId, markerMatchesProfile };
@@ -19635,7 +19665,14 @@ function renderJobs(){
       toast("This browser does not support local root folder access.");
       return { ok:false };
     }
-    const handle = await readLocalRootHandle();
+    let handle = await readLocalRootHandleForProfile(profileId);
+    if (!handle){
+      const legacyHandle = await readLocalRootHandle();
+      if (legacyHandle){
+        handle = legacyHandle;
+        await saveLocalRootHandleForProfile(profileId, legacyHandle);
+      }
+    }
     if (!handle){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; setSetupReason("missing_local_root_folder"); logSetupReason("missing_local_handle", { handle:null }); openOneDriveModal(); toast(profile ? "This computer profile has saved root metadata, but this browser is not authorized. Select/Re-authorize the WJ Cuts root folder shown in the hint, then the file picker will open." : "Create/select a computer profile and choose this computer’s WJ Cuts root folder first."); return { ok:false }; }
     let perm = "prompt"; try { perm = await handle.requestPermission({ mode:"read" }); } catch(_){}
     if (perm !== "granted"){ setSetupReason("folder_permission_needed"); logSetupReason("permission_denied", { handle, permission:perm }); openOneDriveModal(); toast("Permission is required before WJ Cuts files can be added or previewed."); return { ok:false }; }
@@ -19650,21 +19687,8 @@ function renderJobs(){
       return { ok:false };
     }
     const marker = markerResult.marker;
-    const expectedRootId = expectedRootIdFromJobs();
-    if (expectedRootId){
-      if (String(marker?.rootId || "") !== expectedRootId){
-        pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" };
-        setSetupReason("existing_reference_root_mismatch");
-        logSetupReason("existing_reference_root_mismatch", { handle, permission:perm, signature, expectedMatches:false });
-        openOneDriveModal();
-        toast("This folder does not match files already attached by other computers. Select the same shared root folder.");
-        return { ok:false };
-      }
-    } else {
-      const match = verifyRootSignatureMatches(signature); if (!match.ok){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; setSetupReason("existing_reference_root_mismatch"); logSetupReason("existing_reference_signature_mismatch", { handle, permission:perm, signature, profileMatches: !(profile?.rootSignature) || profile.rootSignature===signature, expectedMatches:false }); openOneDriveModal(); toast("This folder does not match files already attached by other computers. Select the same shared root folder."); return { ok:false }; }
-    }
     if (profile?.rootId && marker?.rootId && profile.rootId !== marker.rootId){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; setSetupReason("profile_root_mismatch"); logSetupReason("selected root does not match this profile", { handle, permission:perm, signature }); openOneDriveModal(); toast("This file was attached under a different WJ Cuts root. Select the matching root folder or reattach the file."); return { ok:false }; }
-    if (!expectedRootId && profile?.rootSignature && profile.rootSignature !== signature){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; setSetupReason("profile_root_mismatch"); logSetupReason("profile_signature_mismatch", { handle, permission:perm, signature, profileMatches:false, expectedMatches:true }); openOneDriveModal(); toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile."); return { ok:false }; }
+    if (!profile?.rootId && profile?.rootSignature && profile.rootSignature !== signature){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; setSetupReason("profile_root_mismatch"); logSetupReason("profile_signature_mismatch", { handle, permission:perm, signature, profileMatches:false, expectedMatches:true }); openOneDriveModal(); toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile."); return { ok:false }; }
     return { ok:true, handle, signature, profileId, profile, rootId: String(marker?.rootId || ""), marker };
   }
   const updatePermissionBanner = async ()=>{
@@ -19708,28 +19732,16 @@ function renderJobs(){
         return false;
       }
       const marker = markerResult.marker;
-      const expectedRootId = expectedRootIdFromJobs();
-      if (expectedRootId){
-        if (String(marker?.rootId || "") !== expectedRootId){
-          toast("This folder does not match files already attached by other computers. Select the same shared root folder.");
-          return false;
-        }
-      } else {
-        const match = verifyRootSignatureMatches(signature);
-        if (!match.ok){
-          toast("This folder does not match files already attached by other computers. Select the same shared root folder.");
-          return false;
-        }
-      }
       if (selectedProfile?.rootId && marker?.rootId && selectedProfile.rootId !== marker.rootId){
-        const allowSwitch = window.confirm("This is a different WJ Cuts root. Existing attached files from the old root will show as mismatched until reattached. Continue?");
+        const allowSwitch = window.confirm("This is a different WJ Cuts root. Existing files from the old root will show as mismatched until reattached. Continue?");
         if (!allowSwitch) return false;
-      } else if (!expectedRootId && selectedProfile?.rootSignature && selectedProfile.rootSignature !== signature){
-        const allowSwitch = window.confirm("This is a different WJ Cuts root. Existing attached files from the old root will show as mismatched until reattached. Continue?");
+      } else if (!selectedProfile?.rootId && selectedProfile?.rootSignature && selectedProfile.rootSignature !== signature){
+        const allowSwitch = window.confirm("This is a different WJ Cuts root. Existing files from the old root will show as mismatched until reattached. Continue?");
         if (!allowSwitch) return false;
       }
+      await saveLocalRootHandleForProfile(profileId, handle);
       await saveLocalRootHandle(handle);
-      const verifyHandle = await readLocalRootHandle();
+      const verifyHandle = await readLocalRootHandleForProfile(profileId);
       if (!verifyHandle){ toast("Unable to save root handle on this browser."); return false; }
       const rootDevices = { ...(cfg.rootDevices || {}) };
       if (profileId){
@@ -19918,18 +19930,20 @@ function renderJobs(){
 
   oneDriveLibraryAddToJobBtn?.addEventListener("click", async ()=>{
     const formState = captureNewJobFormState();
-    const attached = await attachFromLocalOneDriveRoot();
+    await attachFromLocalOneDriveRoot();
     requestAnimationFrame(()=> restoreNewJobFormState(formState));
-    if (!attached){
-      openOneDriveModal();
-    }
   });
 
   updateOneDriveWizardStatus();
   updatePermissionBanner();
   permissionSetupBtn?.addEventListener("click", ()=> openOneDriveModal());
   permissionGrantBtn?.addEventListener("click", async ()=>{
-    const handle = await readLocalRootHandle();
+    const profileId = getCurrentComputerProfileId(getSharedConfig());
+    let handle = await readLocalRootHandleForProfile(profileId);
+    if (!handle){
+      handle = await readLocalRootHandle();
+      if (handle && profileId) await saveLocalRootHandleForProfile(profileId, handle);
+    }
     if (handle){
       try {
         const perm = await handle.requestPermission({ mode: "read" });

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -987,6 +987,7 @@ function sanitizeJobFileReferenceForFirestore(fileRef){
     attachedAtISO: String(fileRef.attachedAtISO || fileRef.addedAt || new Date().toISOString()),
     localRootSignature: String(fileRef.localRootSignature || ""),
     localDeviceId: String(fileRef.localDeviceId || ""),
+    ...(fileRef.computerProfileId ? { computerProfileId: String(fileRef.computerProfileId) } : {}),
     ...(fileRef.note ? { note: String(fileRef.note) } : {}),
     ...(fileRef.rootLocationHint ? { rootLocationHint: String(fileRef.rootLocationHint) } : {})
   };
@@ -1127,15 +1128,18 @@ function normalizeOneDriveJobConfig(config){
   const rawDevices = source.rootDevices && typeof source.rootDevices === "object" ? source.rootDevices : {};
   const rootDevices = Object.fromEntries(Object.entries(rawDevices).map(([key, value])=>{
     const row = value && typeof value === "object" ? value : {};
-    const id = String(row.deviceId || key || "");
+    const id = String(row.computerProfileId || row.deviceId || key || "");
     return [id, {
-      deviceId: id,
+      deviceId: String(row.deviceId || id),
+      computerProfileId: id,
       deviceNumber: Number.isFinite(Number(row.deviceNumber)) ? Number(row.deviceNumber) : null,
       label: typeof row.label === "string" ? row.label : "",
       folderName: typeof row.folderName === "string" ? row.folderName : "",
       folderHint: typeof row.folderHint === "string" ? row.folderHint : "",
       rootSignature: typeof row.rootSignature === "string" ? row.rootSignature : "",
-      lastVerifiedAtISO: typeof row.lastVerifiedAtISO === "string" ? row.lastVerifiedAtISO : ""
+      lastVerifiedAtISO: typeof row.lastVerifiedAtISO === "string" ? row.lastVerifiedAtISO : "",
+      lastSeenBrowserDeviceId: typeof row.lastSeenBrowserDeviceId === "string" ? row.lastSeenBrowserDeviceId : "",
+      lastSeenBrowserDeviceNumber: Number.isFinite(Number(row.lastSeenBrowserDeviceNumber)) ? Number(row.lastSeenBrowserDeviceNumber) : null
     }];
   }));
   return {
@@ -1152,6 +1156,7 @@ function normalizeOneDriveJobConfig(config){
     accessToken: typeof source.accessToken === "string" ? source.accessToken : "",
     accessTokenExpiresAt: typeof source.accessTokenExpiresAt === "string" ? source.accessTokenExpiresAt : "",
     lastLinkedAt: typeof source.lastLinkedAt === "string" ? source.lastLinkedAt : "",
+    currentComputerProfileId: typeof source.currentComputerProfileId === "string" ? source.currentComputerProfileId : "",
     rootDevices
   };
 }
@@ -19448,17 +19453,18 @@ function renderJobs(){
     const config = getSharedConfig();
     const currentDeviceId = String(getLocalDeviceId() || "");
     const currentDeviceNumber = getLocalDeviceNumber();
-    const currentDeviceMeta = (config.rootDevices && currentDeviceId) ? config.rootDevices[currentDeviceId] : null;
+    const profileId = String(config.currentComputerProfileId || currentDeviceId || "");
+    const currentDeviceMeta = (config.rootDevices && profileId) ? config.rootDevices[profileId] : null;
     if (!supportsLocalRootPicker()) return { supported:false, handle:null, hasSavedHandle:false, permission:"unsupported", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Unsupported browser" };
     const handle = await readLocalRootHandle();
-    if (!handle) return { supported:true, handle:null, hasSavedHandle:false, permission:"missing", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Not set", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:"" };
+    if (!handle) return { supported:true, handle:null, hasSavedHandle:false, permission:"missing", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message: currentDeviceMeta ? "Root metadata exists for this computer profile, but this browser is not authorized yet. Re-authorize the folder shown in the hint." : "Not set", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:"", profileId };
     let permission = "prompt";
     try { permission = typeof handle.queryPermission === "function" ? await handle.queryPermission({ mode:"read" }) : "granted"; } catch(_e){}
-    if (permission !== "granted") return { supported:true, handle, hasSavedHandle:true, permission, config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Permission needed", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || "") };
+    if (permission !== "granted") return { supported:true, handle, hasSavedHandle:true, permission, config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Folder permission is required for WJ Cuts file previews and Open actions.", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || ""), profileId };
     const signature = await computeLocalRootSignature(handle);
     const expectedSignature = expectedRootSignatureFromJobs();
     const signatureMatches = !expectedSignature || !signature ? true : signature === expectedSignature;
-    return { supported:true, handle, hasSavedHandle:true, permission:"granted", config, signature, expectedSignature, signatureMatches, message: signatureMatches ? "Verified" : "Mismatch", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || "") };
+    return { supported:true, handle, hasSavedHandle:true, permission:"granted", config, signature, expectedSignature, signatureMatches, message: signatureMatches ? "Verified" : "Mismatch", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || ""), profileId };
   };
   const updateSharedConfig = (patch)=>{
     const cfg = getSharedConfig();
@@ -19468,6 +19474,17 @@ function renderJobs(){
   const updateOneDriveWizardStatus = async ()=>{
     const cfg = getSharedConfig();
     const status = await getWJCutsRootStatus();
+    if (oneDriveProfileSelect){
+      const selected = cfg.currentComputerProfileId || "";
+      const rows = Object.values(cfg.rootDevices || {});
+      oneDriveProfileSelect.innerHTML = rows.length
+        ? rows.map(row=>`<option value="${escapeHtml(row.computerProfileId || row.deviceId || "")}" ${(row.computerProfileId || row.deviceId)===selected?"selected":""}>${escapeHtml(row.label || row.computerProfileId || row.deviceId || "Unnamed profile")}</option>`).join("")
+        : `<option value="">Create/select a computer profile</option>`;
+      if (oneDriveProfileLabelInput){
+        const selectedProfile = (cfg.rootDevices || {})[selected] || null;
+        oneDriveProfileLabelInput.value = selectedProfile?.label || "";
+      }
+    }
     if (window.DEBUG_MODE) console.info("[cutting-job-files] root status", status);
     if (oneDriveConnStatus) oneDriveConnStatus.textContent = status.message;
     if (oneDriveFolderStatus) oneDriveFolderStatus.textContent = status.permission === "granted" ? (status.signatureMatches ? "Verified" : "Mismatch") : (status.hasSavedHandle ? "Permission needed" : "Not set");
@@ -19574,7 +19591,8 @@ function renderJobs(){
 
     try {
       const cfg = getSharedConfig();
-      const currentDeviceMeta = cfg.rootDevices?.[String(getLocalDeviceId() || "")];
+      const profileId = String(cfg.currentComputerProfileId || getLocalDeviceId() || "");
+      const currentProfile = cfg.rootDevices?.[profileId];
       const signature = await computeLocalRootSignature(rootHandle);
       if (!signature){
         toast("Unable to verify local OneDrive root folder.");
@@ -19627,8 +19645,9 @@ function renderJobs(){
         localRootSignature: signature,
         enabled: true,
         localDeviceId: getLocalDeviceId(),
+        computerProfileId: profileId,
         attachedAtISO: new Date().toISOString(),
-        rootLocationHint: String(currentDeviceMeta?.folderHint || cfg.folderHint || cfg.localRootName || "")
+        rootLocationHint: String(currentProfile?.folderHint || cfg.folderHint || cfg.localRootName || "")
       });
       if (!reference) return false;
       const targetId = String(targetJobId || "");
@@ -23321,8 +23340,3 @@ function renderDeletedItems(options){
 }
 
 window.debugPurchaseInventoryLinks = function(){ const scan = scanPurchaseInventoryLinks(); return { totalOrderRequests: Array.isArray(orderRequests)?orderRequests.length:0, totalPurchaseLines: scan.lines.length, linkedCount: scan.linked.length, unlinkedCount: scan.unlinked.length, invalidLinkCount: scan.invalid.length, unlinkedGroupsByPartNumber: scan.groups.filter(g=>g.pn).length, noPartNumberIndividualRecords: scan.groups.filter(g=>!g.pn).length, syncProcessLogCount: Array.isArray(window.syncProcessLog)?window.syncProcessLog.length:0, inventoryTransactionsCount: Array.isArray(window.inventoryTransactions)?window.inventoryTransactions.length:0, sampleUnlinkedRecords: scan.unlinked.slice(0,5), sampleInvalidRecords: scan.invalid.slice(0,5) }; };
-    if (oneDriveProfileSelect){
-      const selected = cfg.currentComputerProfileId || "";
-      const rows = Object.values(cfg.rootDevices || {});
-      oneDriveProfileSelect.innerHTML = rows.map(row=>`<option value="${escapeHtml(row.deviceId || "")}" ${row.deviceId===selected?"selected":""}>${escapeHtml(row.label || row.deviceId || "Unnamed profile")}</option>`).join("");
-    }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1157,6 +1157,7 @@ function normalizeOneDriveJobConfig(config){
     accessTokenExpiresAt: typeof source.accessTokenExpiresAt === "string" ? source.accessTokenExpiresAt : "",
     lastLinkedAt: typeof source.lastLinkedAt === "string" ? source.lastLinkedAt : "",
     currentComputerProfileId: typeof source.currentComputerProfileId === "string" ? source.currentComputerProfileId : "",
+    currentComputerProfileByBrowserDeviceId: source.currentComputerProfileByBrowserDeviceId && typeof source.currentComputerProfileByBrowserDeviceId === "object" ? Object.fromEntries(Object.entries(source.currentComputerProfileByBrowserDeviceId).map(([k,v])=>[String(k), String(v||"")])) : {},
     rootDevices
   };
 }
@@ -19435,12 +19436,16 @@ function renderJobs(){
   const ensureCurrentProfile = (cfg)=>{
     const deviceId = String(getLocalDeviceId() || "");
     const nextCfg = { ...cfg };
-    if (!nextCfg.currentComputerProfileId){
-      nextCfg.currentComputerProfileId = deviceId || "";
-    }
     nextCfg.rootDevices = nextCfg.rootDevices || {};
+    nextCfg.currentComputerProfileByBrowserDeviceId = nextCfg.currentComputerProfileByBrowserDeviceId || {};
+    if (nextCfg.currentComputerProfileId && deviceId && !nextCfg.currentComputerProfileByBrowserDeviceId[deviceId]) nextCfg.currentComputerProfileByBrowserDeviceId[deviceId] = nextCfg.currentComputerProfileId;
     return nextCfg;
   };
+  function getCurrentComputerProfileId(cfg){
+    const browserDeviceId = String(getLocalDeviceId() || "");
+    const localFallback = (typeof window !== "undefined" && window.localStorage) ? String(window.localStorage.getItem("cutting_job_current_profile_local") || "") : "";
+    return String((cfg.currentComputerProfileByBrowserDeviceId || {})[browserDeviceId] || localFallback || cfg.currentComputerProfileId || browserDeviceId || "");
+  }
 
 
   const getSharedConfig = ()=>{
@@ -19453,7 +19458,7 @@ function renderJobs(){
     const config = getSharedConfig();
     const currentDeviceId = String(getLocalDeviceId() || "");
     const currentDeviceNumber = getLocalDeviceNumber();
-    const profileId = String(config.currentComputerProfileId || currentDeviceId || "");
+    const profileId = getCurrentComputerProfileId(config);
     const currentDeviceMeta = (config.rootDevices && profileId) ? config.rootDevices[profileId] : null;
     if (!supportsLocalRootPicker()) return { supported:false, handle:null, hasSavedHandle:false, permission:"unsupported", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Unsupported browser" };
     const handle = await readLocalRootHandle();
@@ -19475,7 +19480,7 @@ function renderJobs(){
     const cfg = getSharedConfig();
     const status = await getWJCutsRootStatus();
     if (oneDriveProfileSelect){
-      const selected = cfg.currentComputerProfileId || "";
+      const selected = getCurrentComputerProfileId(cfg);
       const rows = Object.values(cfg.rootDevices || {});
       oneDriveProfileSelect.innerHTML = rows.length
         ? rows.map(row=>`<option value="${escapeHtml(row.computerProfileId || row.deviceId || "")}" ${(row.computerProfileId || row.deviceId)===selected?"selected":""}>${escapeHtml(row.label || row.computerProfileId || row.deviceId || "Unnamed profile")}</option>`).join("")
@@ -19499,14 +19504,14 @@ function renderJobs(){
       oneDriveDeviceStatus.textContent = getLocalDeviceId() ? `${getLocalDeviceNumber()} (${getLocalDeviceId()})` : "Unavailable";
     }
     if (oneDriveCurrentComputer){
-      const selectedProfile = (cfg.rootDevices || {})[cfg.currentComputerProfileId || ""] || null;
+      const selectedProfile = (cfg.rootDevices || {})[getCurrentComputerProfileId(cfg) || ""] || null;
       const signature = status.signature || selectedProfile?.rootSignature || "Not verified";
       oneDriveCurrentComputer.innerHTML = `Browser/device ID: ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected computer profile: ${escapeHtml(selectedProfile?.label || "Not selected")}<br>Selected root folder: ${status.handleName || "Not selected on this computer"}<br>Root location hint: ${selectedProfile?.folderHint || cfg.folderHint || "Not set"}<br>Root signature: ${signature}<br>Status: ${status.message}<br><span class="small muted">Root metadata is saved to the shared app state. Actual folder permission is saved in this browser profile and may need to be re-authorized after browser/site storage is cleared or when using a different browser.</span>`;
     }
     if (oneDriveKnownDevices){
       const rows = Object.values(cfg.rootDevices || {});
       oneDriveKnownDevices.innerHTML = rows.length
-        ? rows.map(row=>`<tr><td>${escapeHtml(row.label || "Unnamed")}<br><span class="small muted">${escapeHtml(String(row.deviceId || ""))}</span>${row.deviceId===cfg.currentComputerProfileId?" <strong>(Selected)</strong>":""}</td><td>${escapeHtml(row.folderName || "—")}</td><td>${escapeHtml(row.folderHint || "—")}</td><td>${escapeHtml(row.rootSignature || "—")}</td><td>${escapeHtml(row.lastVerifiedAtISO || "—")}<br><span class="small muted">${escapeHtml(String(row.lastSeenBrowserDeviceNumber || "?"))} (${escapeHtml(String(row.lastSeenBrowserDeviceId || ""))})</span></td></tr>`).join("")
+        ? rows.map(row=>`<tr><td>${escapeHtml(row.label || "Unnamed")}<br><span class="small muted">${escapeHtml(String(row.deviceId || ""))}</span>${(row.computerProfileId || row.deviceId)===getCurrentComputerProfileId(cfg)?" <strong>(Selected)</strong>":""}</td><td>${escapeHtml(row.folderName || "—")}</td><td>${escapeHtml(row.folderHint || "—")}</td><td>${escapeHtml(row.rootSignature || "—")}</td><td>${escapeHtml(row.lastVerifiedAtISO || "—")}<br><span class="small muted">${escapeHtml(String(row.lastSeenBrowserDeviceNumber || "?"))} (${escapeHtml(String(row.lastSeenBrowserDeviceId || ""))})</span></td></tr>`).join("")
         : `<tr><td colspan="5" class="small muted">No computer roots recorded yet.</td></tr>`;
     }
   };
@@ -19551,7 +19556,12 @@ function renderJobs(){
       const currentDeviceId = String(getLocalDeviceId() || "");
       const currentDeviceNumber = getLocalDeviceNumber();
       const rootHint = String(oneDriveFolderHintInput?.value || cfg.folderHint || "");
-      const profileId = String(cfg.currentComputerProfileId || currentDeviceId || "");
+      const profileId = getCurrentComputerProfileId(cfg);
+      const selectedProfile = (cfg.rootDevices || {})[profileId] || null;
+      if (selectedProfile?.rootSignature && selectedProfile.rootSignature !== signature){
+        toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile.");
+        return false;
+      }
       const rootDevices = { ...(cfg.rootDevices || {}) };
       if (profileId){
         rootDevices[profileId] = { ...(rootDevices[profileId] || {}), deviceId: profileId, computerProfileId: profileId, deviceNumber: currentDeviceNumber, label: rootDevices[profileId]?.label || `Computer ${currentDeviceNumber}`, folderName: String(handle.name || ""), folderHint: rootHint, rootSignature: signature, lastVerifiedAtISO: new Date().toISOString(), lastSeenBrowserDeviceId: currentDeviceId, lastSeenBrowserDeviceNumber: currentDeviceNumber };
@@ -19562,8 +19572,10 @@ function renderJobs(){
         folderHint: rootHint,
         enabled: true,
         rootDevices,
-        currentComputerProfileId: profileId
+        currentComputerProfileId: profileId,
+        currentComputerProfileByBrowserDeviceId: { ...(cfg.currentComputerProfileByBrowserDeviceId || {}), ...(currentDeviceId ? { [currentDeviceId]: profileId } : {}) }
       });
+      if (typeof saveCloudDebounced === "function") saveCloudDebounced();
       await updateOneDriveWizardStatus();
       toast("This computer OneDrive root folder saved and verified.");
       return true;
@@ -19591,7 +19603,7 @@ function renderJobs(){
 
     try {
       const cfg = getSharedConfig();
-      const profileId = String(cfg.currentComputerProfileId || getLocalDeviceId() || "");
+      const profileId = getCurrentComputerProfileId(cfg);
       const currentProfile = cfg.rootDevices?.[profileId];
       const signature = await computeLocalRootSignature(rootHandle);
       if (!signature){
@@ -19701,7 +19713,8 @@ function renderJobs(){
       pendingAttachTarget = null;
       const attached = await attachFromLocalOneDriveRoot(target.mode === "job" ? target.jobId : "");
       if (attached){
-        closeOneDriveModal();
+        if (typeof saveCloudDebounced === "function") saveCloudDebounced();
+    closeOneDriveModal();
       }
     }
   });
@@ -19715,7 +19728,7 @@ function renderJobs(){
     const nextHint = String(oneDriveFolderHintInput?.value || cfg.folderHint || "");
     const existing = cfg.rootDevices || {};
     const rootStatus = await getWJCutsRootStatus();
-    const profileId = String(cfg.currentComputerProfileId || currentDeviceId || "");
+    const profileId = getCurrentComputerProfileId(cfg);
     const row = existing[profileId] || { deviceId: profileId, computerProfileId: profileId, deviceNumber: currentDeviceNumber, label: `Computer ${currentDeviceNumber}` };
     const next = updateSharedConfig({
       enabled: !!oneDriveEnabledInput?.checked,
@@ -19725,6 +19738,7 @@ function renderJobs(){
         ...(profileId ? { [profileId]: { ...row, folderHint: nextHint, folderName: row.folderName || rootStatus.handleName || "", rootSignature: row.rootSignature || rootStatus.signature || "", lastSeenBrowserDeviceId: currentDeviceId, lastSeenBrowserDeviceNumber: currentDeviceNumber, lastVerifiedAtISO: rootStatus.message === "Verified" ? new Date().toISOString() : (row.lastVerifiedAtISO || "") } } : {})
       }
     });
+    if (typeof saveCloudDebounced === "function") saveCloudDebounced();
     closeOneDriveModal();
     toast(next.enabled ? "OneDrive root setup saved for this computer" : "OneDrive setup saved (disabled)");
     renderJobs();
@@ -19733,17 +19747,21 @@ function renderJobs(){
     const cfg = getSharedConfig();
     const selected = String(oneDriveProfileSelect?.value || "");
     if (!selected) return;
-    updateSharedConfig({ currentComputerProfileId: selected });
+    const browserDeviceId = String(getLocalDeviceId() || "");
+    if (typeof window !== "undefined" && window.localStorage) window.localStorage.setItem("cutting_job_current_profile_local", selected);
+    updateSharedConfig({ currentComputerProfileByBrowserDeviceId: { ...(cfg.currentComputerProfileByBrowserDeviceId || {}), ...(browserDeviceId ? { [browserDeviceId]: selected } : {}) }, currentComputerProfileId: cfg.currentComputerProfileId || selected });
+    if (typeof saveCloudDebounced === "function") saveCloudDebounced();
     updateOneDriveWizardStatus();
   });
   oneDriveProfileSaveBtn?.addEventListener("click", ()=>{
     const cfg = getSharedConfig();
     const currentDeviceId = String(getLocalDeviceId() || "");
-    const profileId = String(oneDriveProfileSelect?.value || cfg.currentComputerProfileId || currentDeviceId || genId("computer_profile"));
+    const profileId = String(oneDriveProfileSelect?.value || getCurrentComputerProfileId(cfg) || currentDeviceId || genId("computer_profile"));
     const label = String(oneDriveProfileLabelInput?.value || "").trim() || `Computer ${getLocalDeviceNumber()}`;
     const rootDevices = { ...(cfg.rootDevices || {}) };
     rootDevices[profileId] = { ...(rootDevices[profileId] || {}), deviceId: profileId, computerProfileId: profileId, label, lastSeenBrowserDeviceId: currentDeviceId, lastSeenBrowserDeviceNumber: getLocalDeviceNumber() };
-    updateSharedConfig({ rootDevices, currentComputerProfileId: profileId });
+    updateSharedConfig({ rootDevices, currentComputerProfileId: profileId,
+        currentComputerProfileByBrowserDeviceId: { ...(cfg.currentComputerProfileByBrowserDeviceId || {}), ...(currentDeviceId ? { [currentDeviceId]: profileId } : {}) } });
     updateOneDriveWizardStatus();
   });
 
@@ -19768,6 +19786,7 @@ function renderJobs(){
       } catch (_err){
         toast("Permission is required for referenced files to preview or open.");
       }
+      if (typeof saveCloudDebounced === "function") saveCloudDebounced();
       await updateOneDriveWizardStatus();
       await updatePermissionBanner();
       return;

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -19571,6 +19571,8 @@ function renderJobs(){
   const oneDriveProfileUseBtn = document.getElementById("jobOneDriveProfileUseBtn");
   const oneDriveProfileSaveBtn = document.getElementById("jobOneDriveProfileSaveBtn");
   const oneDriveStatusInline = content.querySelector(".job-onedrive-status");
+  const oneDriveProfileControls = content.querySelector(".job-onedrive-profile-controls");
+  const oneDriveKnownWrap = content.querySelector(".job-onedrive-known");
 
   let pendingAttachTarget = null;
   const setupReasonLabels = {
@@ -19653,6 +19655,7 @@ function renderJobs(){
   const updateOneDriveWizardStatus = async ()=>{
     const cfg = getSharedConfig();
     const status = await getWJCutsRootStatus();
+    const activeRoot = await getActiveWJCutsRoot();
     if (oneDriveProfileSelect){
       const selected = getCurrentComputerProfileId(cfg);
       const rows = Object.values(cfg.rootDevices || {});
@@ -19665,11 +19668,11 @@ function renderJobs(){
       }
     }
     if (window.DEBUG_MODE) console.info("[cutting-job-files] root status", status);
-    if (oneDriveConnStatus) oneDriveConnStatus.textContent = status.message;
-    if (oneDriveFolderStatus) oneDriveFolderStatus.textContent = status.permission === "granted" ? (status.signatureMatches ? "Verified" : "Mismatch") : (status.hasSavedHandle ? "Permission needed" : "Not set");
+    if (oneDriveConnStatus) oneDriveConnStatus.textContent = activeRoot.ok ? "Linked" : (activeRoot.reason === "permission_needed" ? "Permission needed" : (activeRoot.reason === "missing_root" ? "Not linked" : "Root mismatch"));
+    if (oneDriveFolderStatus) oneDriveFolderStatus.textContent = activeRoot.ok ? "Linked" : (activeRoot.reason === "permission_needed" ? "Permission needed" : "Not linked");
     if (oneDriveLibraryStatus) oneDriveLibraryStatus.textContent = status.permission === "granted" ? "Ready" : "Setup required";
     if (oneDriveRootStatus){
-      oneDriveRootStatus.textContent = status.handleName || "Not selected on this computer";
+      oneDriveRootStatus.textContent = activeRoot.folderName || status.handleName || "Not selected";
     }
     if (oneDriveRootPathStatus){
       oneDriveRootPathStatus.textContent = status.currentDeviceMeta?.folderHint || cfg.folderHint || cfg.localRootName || "Not set";
@@ -19681,8 +19684,10 @@ function renderJobs(){
       const selectedProfile = (cfg.rootDevices || {})[getCurrentComputerProfileId(cfg) || ""] || null;
       const signature = status.signature || selectedProfile?.rootSignature || "Not verified";
       const authState = status.permission === "granted" && status.signatureMatches ? "Authorized" : (status.hasSavedHandle ? "Needs permission" : "Not authorized");
-      oneDriveCurrentComputer.innerHTML = `Browser/device ID (local): ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected PC/profile ID (shared label): ${escapeHtml(getCurrentComputerProfileId(cfg) || "Not selected")}<br>Selected computer profile: ${escapeHtml(selectedProfile?.label || "Not selected")}<br>Local root authorization: ${authState}<br>Selected root folder: ${status.handleName || "Not selected in this browser"}<br>Expected root ID for profile: ${escapeHtml(String(selectedProfile?.rootId || "Not set"))}<br>Selected folder root ID: ${escapeHtml(String(status.markerRootId || "Marker missing"))}<br>Root match: ${selectedProfile?.rootId ? (status.markerRootId ? (selectedProfile.rootId === status.markerRootId ? "Match" : "Mismatch") : "Marker missing") : "No profile root set"}<br>Root location hint: ${selectedProfile?.folderHint || cfg.folderHint || "Not set"}<br>Root signature (compat): ${signature}<br>Status: ${status.message}`;
+      oneDriveCurrentComputer.innerHTML = `Current root status: ${activeRoot.ok ? "Linked" : (activeRoot.reason === "permission_needed" ? "Permission needed" : (activeRoot.reason === "missing_root" ? "Not linked" : "Root mismatch"))}<br>Selected folder: ${activeRoot.folderName || status.handleName || "Not selected"}<br>Root ID: ${escapeHtml(String(activeRoot.rootId || status.markerRootId || "Not verified"))}<br>Browser storage: ${status.hasSavedHandle || activeRoot.handle ? "Saved locally" : "Not saved"}<br>Manual hint: ${escapeHtml(selectedProfile?.folderHint || cfg.folderHint || "Not set")}<br><details><summary>Advanced diagnostics</summary>Local browser/device ID: ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected PC/profile: ${escapeHtml(selectedProfile?.label || "Not selected")} (${escapeHtml(getCurrentComputerProfileId(cfg) || "Not selected")})<br>Last seen browser/device on selected row: ${escapeHtml(String(selectedProfile?.lastSeenBrowserDeviceNumber || "?"))} (${escapeHtml(String(selectedProfile?.lastSeenBrowserDeviceId || ""))})</details>`;
     }
+    if (oneDriveProfileControls) oneDriveProfileControls.hidden = true;
+    if (oneDriveKnownWrap) oneDriveKnownWrap.hidden = true;
     if (oneDriveStatusInline){
       const hint = (status.currentDeviceMeta?.folderHint || cfg.folderHint || status.handleName || "").trim();
       oneDriveStatusInline.textContent = status.permission === "granted" && status.signature && status.profileMatches && status.expectedMatches
@@ -19836,16 +19841,22 @@ function renderJobs(){
       toast("Local file references require Chrome or Edge.");
       return false;
     }
-    const ensured = await ensureLocalRootAuthorizedForAttach(targetJobId);
-    if (!ensured.ok) return false;
-    const rootHandle = ensured.handle;
+    const active = await getActiveWJCutsRoot();
+    if (!active.ok){
+      pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" };
+      setSetupReason(active.reason || "missing_local_root_folder");
+      openOneDriveModal();
+      toast(active.reason === "permission_needed" ? "Grant folder permission." : "Select your WJ Cuts root folder first.");
+      return false;
+    }
+    const rootHandle = active.handle;
 
     try {
       const cfg = getSharedConfig();
-      const profileId = ensured.profileId;
-      const currentProfile = ensured.profile;
-      const signature = ensured.signature;
-      const rootId = ensured.rootId || "";
+      const profileId = getCurrentComputerProfileId(cfg);
+      const currentProfile = cfg.rootDevices?.[profileId] || null;
+      const signature = active.signature;
+      const rootId = active.rootId || "";
       const pickedHandles = await window.showOpenFilePicker({
         multiple: false,
         startIn: rootHandle,
@@ -23604,3 +23615,21 @@ function renderDeletedItems(options){
 }
 
 window.debugPurchaseInventoryLinks = function(){ const scan = scanPurchaseInventoryLinks(); return { totalOrderRequests: Array.isArray(orderRequests)?orderRequests.length:0, totalPurchaseLines: scan.lines.length, linkedCount: scan.linked.length, unlinkedCount: scan.unlinked.length, invalidLinkCount: scan.invalid.length, unlinkedGroupsByPartNumber: scan.groups.filter(g=>g.pn).length, noPartNumberIndividualRecords: scan.groups.filter(g=>!g.pn).length, syncProcessLogCount: Array.isArray(window.syncProcessLog)?window.syncProcessLog.length:0, inventoryTransactionsCount: Array.isArray(window.inventoryTransactions)?window.inventoryTransactions.length:0, sampleUnlinkedRecords: scan.unlinked.slice(0,5), sampleInvalidRecords: scan.invalid.slice(0,5) }; };
+  async function getActiveWJCutsRoot(){
+    const cfg = getSharedConfig();
+    let handle = await readLocalRootHandle();
+    let profileId = getCurrentComputerProfileId(cfg);
+    if (!handle && profileId){
+      handle = await readLocalRootHandleForProfile(profileId);
+      if (handle) await saveLocalRootHandle(handle);
+    }
+    if (!handle) return { ok:false, handle:null, permission:"missing", marker:null, rootId:"", signature:"", folderName:"", reason:"missing_root" };
+    let permission = "prompt";
+    try { permission = typeof handle.queryPermission === "function" ? await handle.queryPermission({ mode:"read" }) : "granted"; } catch(_){}
+    if (permission !== "granted") return { ok:false, handle, permission, marker:null, rootId:"", signature:"", folderName:String(handle?.name || ""), reason:"permission_needed" };
+    const markerResult = await ensureWJCutsRootMarker(handle);
+    if (!markerResult.ok) return { ok:false, handle, permission, marker:null, rootId:"", signature:"", folderName:String(handle?.name || ""), reason:"marker_missing" };
+    const marker = markerResult.marker;
+    const signature = await computeLocalRootSignature(handle);
+    return { ok:true, handle, permission:"granted", marker, rootId:String(marker?.rootId || ""), signature, folderName:String(handle?.name || ""), reason:"" };
+  }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -19417,13 +19417,30 @@ function renderJobs(){
   const oneDriveKnownDevices = document.querySelector("[data-onedrive-known-devices]");
   const oneDriveLibraryAddToJobBtn = document.getElementById("jobOneDriveLibraryAddBtn");
   const oneDriveRootPickerBtn = document.getElementById("jobOneDriveRootPickerBtn");
+  const permissionBanner = content.querySelector("[data-wjcuts-permission-banner]");
+  const permissionBannerText = content.querySelector("[data-wjcuts-permission-text]");
+  const permissionGrantBtn = content.querySelector("[data-wjcuts-grant-permission]");
+  const permissionSetupBtn = content.querySelector("[data-wjcuts-open-setup]");
+  const oneDriveProfileSelect = document.getElementById("jobOneDriveComputerProfile");
+  const oneDriveProfileLabelInput = document.getElementById("jobOneDriveProfileLabel");
+  const oneDriveProfileUseBtn = document.getElementById("jobOneDriveProfileUseBtn");
+  const oneDriveProfileSaveBtn = document.getElementById("jobOneDriveProfileSaveBtn");
 
   let pendingAttachTarget = null;
+  const ensureCurrentProfile = (cfg)=>{
+    const deviceId = String(getLocalDeviceId() || "");
+    const nextCfg = { ...cfg };
+    if (!nextCfg.currentComputerProfileId){
+      nextCfg.currentComputerProfileId = deviceId || "";
+    }
+    nextCfg.rootDevices = nextCfg.rootDevices || {};
+    return nextCfg;
+  };
 
 
   const getSharedConfig = ()=>{
     const cfg = (typeof window.getOneDriveJobConfig === "function") ? window.getOneDriveJobConfig() : normalizeOneDriveJobConfig(null);
-    return normalizeOneDriveJobConfig(cfg);
+    return ensureCurrentProfile(normalizeOneDriveJobConfig(cfg));
   };
 
 
@@ -19465,14 +19482,26 @@ function renderJobs(){
       oneDriveDeviceStatus.textContent = getLocalDeviceId() ? `${getLocalDeviceNumber()} (${getLocalDeviceId()})` : "Unavailable";
     }
     if (oneDriveCurrentComputer){
-      const signature = status.signature || status.currentDeviceMeta?.rootSignature || "Not verified";
-      oneDriveCurrentComputer.innerHTML = `Computer ID: ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected root folder: ${status.handleName || "Not selected on this computer"}<br>Root location hint: ${status.currentDeviceMeta?.folderHint || cfg.folderHint || "Not set"}<br>Root signature: ${signature}<br>Status: ${status.message}<br><span class="small muted">The browser cannot reveal the full local Windows path. Use the root location hint to record where this folder is on this computer.</span>`;
+      const selectedProfile = (cfg.rootDevices || {})[cfg.currentComputerProfileId || ""] || null;
+      const signature = status.signature || selectedProfile?.rootSignature || "Not verified";
+      oneDriveCurrentComputer.innerHTML = `Browser/device ID: ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected computer profile: ${escapeHtml(selectedProfile?.label || "Not selected")}<br>Selected root folder: ${status.handleName || "Not selected on this computer"}<br>Root location hint: ${selectedProfile?.folderHint || cfg.folderHint || "Not set"}<br>Root signature: ${signature}<br>Status: ${status.message}<br><span class="small muted">Root metadata is saved to the shared app state. Actual folder permission is saved in this browser profile and may need to be re-authorized after browser/site storage is cleared or when using a different browser.</span>`;
     }
     if (oneDriveKnownDevices){
       const rows = Object.values(cfg.rootDevices || {});
       oneDriveKnownDevices.innerHTML = rows.length
-        ? rows.map(row=>`<tr><td>${escapeHtml(String(row.deviceNumber || "?"))} (${escapeHtml(String(row.deviceId || ""))})${row.deviceId===status.currentDeviceId?" <strong>(This computer)</strong>":""}</td><td>${escapeHtml(row.folderName || "—")}</td><td>${escapeHtml(row.folderHint || "—")}</td><td>${escapeHtml(row.rootSignature || "—")}</td><td>${escapeHtml(row.lastVerifiedAtISO || "—")}</td></tr>`).join("")
+        ? rows.map(row=>`<tr><td>${escapeHtml(row.label || "Unnamed")}<br><span class="small muted">${escapeHtml(String(row.deviceId || ""))}</span>${row.deviceId===cfg.currentComputerProfileId?" <strong>(Selected)</strong>":""}</td><td>${escapeHtml(row.folderName || "—")}</td><td>${escapeHtml(row.folderHint || "—")}</td><td>${escapeHtml(row.rootSignature || "—")}</td><td>${escapeHtml(row.lastVerifiedAtISO || "—")}<br><span class="small muted">${escapeHtml(String(row.lastSeenBrowserDeviceNumber || "?"))} (${escapeHtml(String(row.lastSeenBrowserDeviceId || ""))})</span></td></tr>`).join("")
         : `<tr><td colspan="5" class="small muted">No computer roots recorded yet.</td></tr>`;
+    }
+  };
+  const updatePermissionBanner = async ()=>{
+    if (!permissionBanner) return;
+    const hasRefs = [...(Array.isArray(cuttingJobs)?cuttingJobs:[]), ...(Array.isArray(completedCuttingJobs)?completedCuttingJobs:[])].some(j => Array.isArray(j?.files) && j.files.some(f=>f?.source==="wj_cuts_reference"));
+    if (!hasRefs){ permissionBanner.hidden = true; return; }
+    const status = await getWJCutsRootStatus();
+    const blocked = !status.hasSavedHandle || status.permission !== "granted";
+    permissionBanner.hidden = !blocked;
+    if (permissionBannerText && blocked){
+      permissionBannerText.textContent = "WJ Cuts file references need folder permission before previews/opening files will work. Grant access to this computer’s WJ Cuts root folder.";
     }
   };
 
@@ -19505,16 +19534,18 @@ function renderJobs(){
       const currentDeviceId = String(getLocalDeviceId() || "");
       const currentDeviceNumber = getLocalDeviceNumber();
       const rootHint = String(oneDriveFolderHintInput?.value || cfg.folderHint || "");
+      const profileId = String(cfg.currentComputerProfileId || currentDeviceId || "");
       const rootDevices = { ...(cfg.rootDevices || {}) };
-      if (currentDeviceId){
-        rootDevices[currentDeviceId] = { ...(rootDevices[currentDeviceId] || {}), deviceId: currentDeviceId, deviceNumber: currentDeviceNumber, label: `Computer ${currentDeviceNumber}`, folderName: String(handle.name || ""), folderHint: rootHint, rootSignature: signature, lastVerifiedAtISO: new Date().toISOString() };
+      if (profileId){
+        rootDevices[profileId] = { ...(rootDevices[profileId] || {}), deviceId: profileId, computerProfileId: profileId, deviceNumber: currentDeviceNumber, label: rootDevices[profileId]?.label || `Computer ${currentDeviceNumber}`, folderName: String(handle.name || ""), folderHint: rootHint, rootSignature: signature, lastVerifiedAtISO: new Date().toISOString(), lastSeenBrowserDeviceId: currentDeviceId, lastSeenBrowserDeviceNumber: currentDeviceNumber };
       }
       updateSharedConfig({
         localRootName: String(handle.name || cfg.localRootName || "Configured"),
         localRootSignature: signature,
         folderHint: rootHint,
         enabled: true,
-        rootDevices
+        rootDevices,
+        currentComputerProfileId: profileId
       });
       await updateOneDriveWizardStatus();
       toast("This computer OneDrive root folder saved and verified.");
@@ -19665,18 +19696,36 @@ function renderJobs(){
     const nextHint = String(oneDriveFolderHintInput?.value || cfg.folderHint || "");
     const existing = cfg.rootDevices || {};
     const rootStatus = await getWJCutsRootStatus();
-    const row = existing[currentDeviceId] || { deviceId: currentDeviceId, deviceNumber: currentDeviceNumber, label: `Computer ${currentDeviceNumber}` };
+    const profileId = String(cfg.currentComputerProfileId || currentDeviceId || "");
+    const row = existing[profileId] || { deviceId: profileId, computerProfileId: profileId, deviceNumber: currentDeviceNumber, label: `Computer ${currentDeviceNumber}` };
     const next = updateSharedConfig({
       enabled: !!oneDriveEnabledInput?.checked,
       folderHint: nextHint,
       rootDevices: {
         ...existing,
-        ...(currentDeviceId ? { [currentDeviceId]: { ...row, folderHint: nextHint, folderName: row.folderName || rootStatus.handleName || "", rootSignature: row.rootSignature || rootStatus.signature || "", lastVerifiedAtISO: rootStatus.message === "Verified" ? new Date().toISOString() : (row.lastVerifiedAtISO || "") } } : {})
+        ...(profileId ? { [profileId]: { ...row, folderHint: nextHint, folderName: row.folderName || rootStatus.handleName || "", rootSignature: row.rootSignature || rootStatus.signature || "", lastSeenBrowserDeviceId: currentDeviceId, lastSeenBrowserDeviceNumber: currentDeviceNumber, lastVerifiedAtISO: rootStatus.message === "Verified" ? new Date().toISOString() : (row.lastVerifiedAtISO || "") } } : {})
       }
     });
     closeOneDriveModal();
     toast(next.enabled ? "OneDrive root setup saved for this computer" : "OneDrive setup saved (disabled)");
     renderJobs();
+  });
+  oneDriveProfileUseBtn?.addEventListener("click", ()=>{
+    const cfg = getSharedConfig();
+    const selected = String(oneDriveProfileSelect?.value || "");
+    if (!selected) return;
+    updateSharedConfig({ currentComputerProfileId: selected });
+    updateOneDriveWizardStatus();
+  });
+  oneDriveProfileSaveBtn?.addEventListener("click", ()=>{
+    const cfg = getSharedConfig();
+    const currentDeviceId = String(getLocalDeviceId() || "");
+    const profileId = String(oneDriveProfileSelect?.value || cfg.currentComputerProfileId || currentDeviceId || genId("computer_profile"));
+    const label = String(oneDriveProfileLabelInput?.value || "").trim() || `Computer ${getLocalDeviceNumber()}`;
+    const rootDevices = { ...(cfg.rootDevices || {}) };
+    rootDevices[profileId] = { ...(rootDevices[profileId] || {}), deviceId: profileId, computerProfileId: profileId, label, lastSeenBrowserDeviceId: currentDeviceId, lastSeenBrowserDeviceNumber: getLocalDeviceNumber() };
+    updateSharedConfig({ rootDevices, currentComputerProfileId: profileId });
+    updateOneDriveWizardStatus();
   });
 
   oneDriveLibraryAddToJobBtn?.addEventListener("click", async ()=>{
@@ -19689,6 +19738,24 @@ function renderJobs(){
   });
 
   updateOneDriveWizardStatus();
+  updatePermissionBanner();
+  permissionSetupBtn?.addEventListener("click", ()=> openOneDriveModal());
+  permissionGrantBtn?.addEventListener("click", async ()=>{
+    const handle = await readLocalRootHandle();
+    if (handle){
+      try {
+        const perm = await handle.requestPermission({ mode: "read" });
+        if (perm !== "granted") toast("Permission is required for referenced files to preview or open.");
+      } catch (_err){
+        toast("Permission is required for referenced files to preview or open.");
+      }
+      await updateOneDriveWizardStatus();
+      await updatePermissionBanner();
+      return;
+    }
+    openOneDriveModal();
+    toast("Root metadata exists for this computer profile, but this browser is not authorized yet. Re-authorize the folder shown in the hint.");
+  });
 
   addFormToggle?.addEventListener("click", ()=>{
     const formState = captureNewJobFormState();
@@ -23254,3 +23321,8 @@ function renderDeletedItems(options){
 }
 
 window.debugPurchaseInventoryLinks = function(){ const scan = scanPurchaseInventoryLinks(); return { totalOrderRequests: Array.isArray(orderRequests)?orderRequests.length:0, totalPurchaseLines: scan.lines.length, linkedCount: scan.linked.length, unlinkedCount: scan.unlinked.length, invalidLinkCount: scan.invalid.length, unlinkedGroupsByPartNumber: scan.groups.filter(g=>g.pn).length, noPartNumberIndividualRecords: scan.groups.filter(g=>!g.pn).length, syncProcessLogCount: Array.isArray(window.syncProcessLog)?window.syncProcessLog.length:0, inventoryTransactionsCount: Array.isArray(window.inventoryTransactions)?window.inventoryTransactions.length:0, sampleUnlinkedRecords: scan.unlinked.slice(0,5), sampleInvalidRecords: scan.invalid.slice(0,5) }; };
+    if (oneDriveProfileSelect){
+      const selected = cfg.currentComputerProfileId || "";
+      const rows = Object.values(cfg.rootDevices || {});
+      oneDriveProfileSelect.innerHTML = rows.map(row=>`<option value="${escapeHtml(row.deviceId || "")}" ${row.deviceId===selected?"selected":""}>${escapeHtml(row.label || row.deviceId || "Unnamed profile")}</option>`).join("");
+    }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -987,7 +987,8 @@ function sanitizeJobFileReferenceForFirestore(fileRef){
     attachedAtISO: String(fileRef.attachedAtISO || fileRef.addedAt || new Date().toISOString()),
     localRootSignature: String(fileRef.localRootSignature || ""),
     localDeviceId: String(fileRef.localDeviceId || ""),
-    ...(fileRef.note ? { note: String(fileRef.note) } : {})
+    ...(fileRef.note ? { note: String(fileRef.note) } : {}),
+    ...(fileRef.rootLocationHint ? { rootLocationHint: String(fileRef.rootLocationHint) } : {})
   };
 }
 
@@ -1075,9 +1076,28 @@ function verifyRootSignatureMatches(signature){
   return { ok: expected === signature, expected };
 }
 
+function describeLocalRootPreviewError(err){
+  const msg = String(err?.message || err || "").toLowerCase();
+  if (msg.includes("notallowederror") || msg.includes("permission") || msg.includes("denied")){
+    return "Preview unavailable: this browser lost access to your WJ Cuts root folder. Re-open OneDrive setup and re-select the root folder.";
+  }
+  if (msg.includes("notfounderror") || msg.includes("not found")){
+    return "Preview unavailable: this file was not found under your selected WJ Cuts root folder. Verify the same shared root folder is selected.";
+  }
+  return "Preview unavailable: unable to read this file from your WJ Cuts root folder. Re-open OneDrive setup and verify root folder access.";
+}
+
 async function resolveLocalFileFromRelativePath(relativePath){
   const rootHandle = await readLocalRootHandle();
-  if (!rootHandle) return null;
+  if (!rootHandle){
+    throw new Error("No saved WJ Cuts root folder on this device.");
+  }
+  const perm = typeof rootHandle.queryPermission === "function"
+    ? await rootHandle.queryPermission({ mode: "read" })
+    : "granted";
+  if (perm !== "granted"){
+    throw new Error("WJ Cuts root folder permission is not granted.");
+  }
   const rel = String(relativePath || "").replace(/^\/+/, "");
   if (!rel) return null;
   const segments = rel.split("/").filter(Boolean);
@@ -1511,23 +1531,10 @@ function readFileAsDataUrl(file){
 
 async function filesToAttachments(fileList){
   const files = Array.from(fileList || []);
-  const attachments = [];
-  for (const file of files){
-    try {
-      attachments.push({
-        id: genId(file.name || "job_file"),
-        name: file.name || "Attachment",
-        type: file.type || "",
-        size: typeof file.size === "number" ? file.size : null,
-        source: "upload_requires_reference",
-        attachedAtISO: new Date().toISOString()
-      });
-    } catch (err){
-      console.error("Unable to read file", err);
-      toast("Use Attach from Reference Folder so this file can be saved as a WJ Cuts relative path.");
-    }
+  if (files.length){
+    toast("Local uploads are temporary and not saved as durable cloud file references. Use Attach from Reference Folder.");
   }
-  return attachments;
+  return [];
 }
 
 const JOB_ONEDRIVE_PREVIEW_CACHE_KEY = "cutting_job_onedrive_preview_cache_v1";
@@ -1581,7 +1588,7 @@ async function resolveOneDriveAttachmentPreview(file){
       const text = window.dxfPreview.arrayBufferToText(bytes);
       const svg = window.dxfPreview.renderCadToSvgDataUrl(text);
       if (!svg){
-        file.preview = { mode: "message", content: "2D preview unavailable for this file." };
+        file.preview = { mode: "message", content: diagnosePreviewFailure(file) };
         return false;
       }
       file.preview = { mode: "image", content: svg };
@@ -1591,7 +1598,7 @@ async function resolveOneDriveAttachmentPreview(file){
       }
       return true;
     } catch (_err){
-      file.preview = file.preview || { mode: "message", content: "Preview unavailable for this OneDrive file." };
+      file.preview = { mode: "message", content: diagnosePreviewFailure(file) };
       return false;
     } finally {
       oneDrivePreviewInFlight.delete(inFlightKey);
@@ -1600,6 +1607,25 @@ async function resolveOneDriveAttachmentPreview(file){
 
   oneDrivePreviewInFlight.set(inFlightKey, task);
   return task;
+}
+
+function diagnosePreviewFailure(file, context = ""){
+  const source = String(file?.source || "");
+  const ext = fileExtFromName(String(file?.name || ""));
+  const href = String(file?.dataUrl || file?.url || "").trim();
+  if (source === "onedrive"){
+    if (!file?.driveId || !file?.itemId) return "Preview unavailable: OneDrive file metadata is incomplete. Relink this file from OneDrive.";
+    return "Preview unavailable: OneDrive content could not be loaded. Check OneDrive sign-in and file permissions, then try again.";
+  }
+  if (source === "wj_cuts_reference"){
+    return "Preview unavailable: unable to read this file from the selected WJ Cuts root. Re-select root folder and verify this exact file path exists.";
+  }
+  if ([".dxf", ".ord", ".omx"].includes(ext)){
+    if (!href) return "Preview unavailable: no file content URL is saved. Re-attach from Reference Folder or add a direct OneDrive URL.";
+    if (/^https?:\/\//i.test(href)) return "Preview unavailable: remote CAD file could not be fetched. Check the link and access permissions.";
+    return "Preview unavailable: CAD data could not be decoded for preview. Re-attach the source file.";
+  }
+  return context || "Preview unavailable: unsupported format or missing data for this attachment.";
 }
 
 async function resolveAttachmentPreview(file){
@@ -1624,7 +1650,7 @@ async function resolveAttachmentPreview(file){
     try {
       const localFile = await resolveWJCutsRelativePath(file.relativePath);
       if (!localFile){
-        file.preview = file.preview || { mode: "message", content: "File reference saved, but the file was not found under your selected WJ Cuts folder." };
+        file.preview = { mode: "message", content: "Preview unavailable: file reference was saved, but the file is missing under your selected WJ Cuts root folder." };
         return false;
       }
       const preview = await buildAttachmentPreview(localFile);
@@ -1632,10 +1658,10 @@ async function resolveAttachmentPreview(file){
         file.preview = preview;
         return preview.mode === "image";
       }
-      file.preview = file.preview || { mode: "message", content: "Preview unavailable for this WJ Cuts referenced file type." };
+      file.preview = { mode: "message", content: "Preview unavailable: this WJ Cuts file type cannot be rendered as a 2D preview." };
       return false;
-    } catch (_err){
-      file.preview = file.preview || { mode: "message", content: "Preview unavailable for this WJ Cuts referenced file." };
+    } catch (err){
+      file.preview = { mode: "message", content: describeLocalRootPreviewError(err) };
       return false;
     }
   }
@@ -1660,10 +1686,10 @@ async function resolveAttachmentPreview(file){
         file.preview = { mode: "image", content: svg };
         return true;
       }
-      file.preview = file.preview || { mode: "message", content: "2D preview unavailable for this file." };
+      file.preview = { mode: "message", content: diagnosePreviewFailure(file) };
       return false;
     } catch (_err){
-      file.preview = file.preview || { mode: "message", content: "2D preview unavailable for this file." };
+      file.preview = { mode: "message", content: diagnosePreviewFailure(file) };
       return false;
     }
   }
@@ -19370,9 +19396,12 @@ function renderJobs(){
   const oneDriveFolderStatus = document.querySelector("[data-onedrive-folder-status]");
   const oneDriveLibraryStatus = document.querySelector("[data-onedrive-library-status]");
   const oneDriveRootStatus = document.querySelector("[data-onedrive-root-status]");
+  const oneDriveRootPathStatus = document.querySelector("[data-onedrive-root-path]");
   const oneDriveDeviceStatus = document.querySelector("[data-onedrive-device-status]");
   const oneDriveLibraryAddToJobBtn = document.getElementById("jobOneDriveLibraryAddBtn");
   const oneDriveRootPickerBtn = document.getElementById("jobOneDriveRootPickerBtn");
+
+  let pendingAttachTarget = null;
 
 
   const getSharedConfig = ()=>{
@@ -19380,6 +19409,20 @@ function renderJobs(){
     return normalizeOneDriveJobConfig(cfg);
   };
 
+
+  const getWJCutsRootStatus = async ()=>{
+    const config = getSharedConfig();
+    if (!supportsLocalRootPicker()) return { supported:false, handle:null, hasSavedHandle:false, permission:"unsupported", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Unsupported browser" };
+    const handle = await readLocalRootHandle();
+    if (!handle) return { supported:true, handle:null, hasSavedHandle:false, permission:"missing", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Not set" };
+    let permission = "prompt";
+    try { permission = typeof handle.queryPermission === "function" ? await handle.queryPermission({ mode:"read" }) : "granted"; } catch(_e){}
+    if (permission !== "granted") return { supported:true, handle, hasSavedHandle:true, permission, config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Permission needed" };
+    const signature = await computeLocalRootSignature(handle);
+    const expectedSignature = expectedRootSignatureFromJobs();
+    const signatureMatches = !expectedSignature || !signature ? true : signature === expectedSignature;
+    return { supported:true, handle, hasSavedHandle:true, permission:"granted", config, signature, expectedSignature, signatureMatches, message: signatureMatches ? "Verified" : "Mismatch" };
+  };
   const updateSharedConfig = (patch)=>{
     const cfg = getSharedConfig();
     return writeOneDriveJobConfig({ ...cfg, ...patch });
@@ -19387,11 +19430,16 @@ function renderJobs(){
 
   const updateOneDriveWizardStatus = async ()=>{
     const cfg = getSharedConfig();
-    if (oneDriveConnStatus) oneDriveConnStatus.textContent = cfg.localRootSignature ? "Configured" : "Not set";
-    if (oneDriveFolderStatus) oneDriveFolderStatus.textContent = cfg.localRootSignature ? "Verified" : "Not ready";
-    if (oneDriveLibraryStatus) oneDriveLibraryStatus.textContent = cfg.localRootSignature ? "Ready" : "Setup required";
+    const status = await getWJCutsRootStatus();
+    if (window.DEBUG_MODE) console.info("[cutting-job-files] root status", status);
+    if (oneDriveConnStatus) oneDriveConnStatus.textContent = status.message;
+    if (oneDriveFolderStatus) oneDriveFolderStatus.textContent = status.permission === "granted" ? (status.signatureMatches ? "Verified" : "Mismatch") : (status.hasSavedHandle ? "Permission needed" : "Not set");
+    if (oneDriveLibraryStatus) oneDriveLibraryStatus.textContent = status.permission === "granted" ? "Ready" : "Setup required";
     if (oneDriveRootStatus){
       oneDriveRootStatus.textContent = cfg.localRootName || "Not set";
+    }
+    if (oneDriveRootPathStatus){
+      oneDriveRootPathStatus.textContent = cfg.folderHint || cfg.localRootName || "Not set";
     }
     if (oneDriveDeviceStatus){
       oneDriveDeviceStatus.textContent = getLocalDeviceId() ? `${getLocalDeviceNumber()} (${getLocalDeviceId()})` : "Unavailable";
@@ -19421,10 +19469,13 @@ function renderJobs(){
         return false;
       }
       await saveLocalRootHandle(handle);
+      const verifyHandle = await readLocalRootHandle();
+      if (!verifyHandle){ toast("Unable to save root handle on this browser."); return false; }
       const cfg = getSharedConfig();
       updateSharedConfig({
         localRootName: String(handle.name || cfg.localRootName || "Configured"),
-        localRootSignature: signature
+        localRootSignature: signature,
+        enabled: true
       });
       await updateOneDriveWizardStatus();
       toast("This computer OneDrive root folder saved and verified.");
@@ -19444,14 +19495,16 @@ function renderJobs(){
     }
     const rootHandle = await readLocalRootHandle();
     if (!rootHandle){
-      toast("Set WJ Cuts Folder to open this file.");
+      pendingAttachTarget = targetJobId ? { mode: "job", jobId: String(targetJobId) } : { mode: "new" };
+      toast("Set this computer’s WJ Cuts root folder before attaching files. The app saves a reference path, not the file itself.");
+      if (window.DEBUG_MODE) console.info("[cutting-job-files] attach blocked root missing", { targetJobId });
       openOneDriveModal();
       return false;
     }
 
     try {
       const cfg = getSharedConfig();
-      const signature = cfg.localRootSignature || await computeLocalRootSignature(rootHandle);
+      const signature = await computeLocalRootSignature(rootHandle);
       if (!signature){
         toast("Unable to verify local OneDrive root folder.");
         return false;
@@ -19501,13 +19554,16 @@ function renderJobs(){
         rootPathStart: "WJ Cuts",
         relativePath: relPath,
         localRootSignature: signature,
+        enabled: true,
         localDeviceId: getLocalDeviceId(),
-        attachedAtISO: new Date().toISOString()
+        attachedAtISO: new Date().toISOString(),
+        rootLocationHint: String(cfg.folderHint || cfg.localRootName || "")
       });
       if (!reference) return false;
       const targetId = String(targetJobId || "");
       if (targetId){
-        const job = cuttingJobs.find(x => String(x?.id) === targetId);
+        const found = findJobRecord(targetId);
+        const job = found && found.job ? found.job : null;
         if (!job){
           toast("Job not found for OneDrive attachment.");
           return false;
@@ -19515,6 +19571,7 @@ function renderJobs(){
         job.files = Array.isArray(job.files) ? job.files : [];
         job.files.push(reference);
         saveCloudDebounced();
+        if (window.DEBUG_MODE) console.info("[cutting-job-files] attached reference", { targetId, relPath });
         toast("WJ Cuts file reference attached to job.");
         renderJobs();
       } else {
@@ -19548,7 +19605,15 @@ function renderJobs(){
     closeFileMenu(); closeActionMenu(); closeHistoryActionMenu(); openOneDriveModal();
   });
   oneDriveRootPickerBtn?.addEventListener("click", async ()=>{
-    await chooseLocalOneDriveRoot();
+    const ok = await chooseLocalOneDriveRoot();
+    if (ok && pendingAttachTarget){
+      const target = pendingAttachTarget;
+      pendingAttachTarget = null;
+      const attached = await attachFromLocalOneDriveRoot(target.mode === "job" ? target.jobId : "");
+      if (attached){
+        closeOneDriveModal();
+      }
+    }
   });
   oneDriveCancelBtns.forEach(btn => btn.addEventListener("click", closeOneDriveModal));
   oneDriveModal?.addEventListener("click", (event)=>{ if (event.target === oneDriveModal) closeOneDriveModal(); });
@@ -20360,10 +20425,16 @@ function renderJobs(){
       const mode = option.getAttribute("data-preview-mode") || "message";
       const contentValue = option.getAttribute("data-preview-content") || "";
       const href = option.getAttribute("data-preview-href") || "";
+      const source = option.getAttribute("data-preview-source") || "";
+      const selectedIndex = option.getAttribute("data-preview-index") || option.value || "0";
+      const expectedPath = option.getAttribute("data-preview-expected-path") || "";
+      const rootLocation = option.getAttribute("data-preview-root-location") || "";
       const nameEl = previewRoot.querySelector("[data-preview-name]");
       const imgEl = previewRoot.querySelector("[data-preview-image]");
       const msgEl = previewRoot.querySelector("[data-preview-message]");
-      const openEl = previewRoot.querySelector("[data-preview-open]");
+      const openLocalEl = previewRoot.querySelector("[data-preview-open-local]");
+      const openUrlEl = previewRoot.querySelector("[data-preview-open-url]");
+      const pathBtn = previewRoot.querySelector("[data-preview-path-btn]");
       if (nameEl){
         nameEl.textContent = name;
         nameEl.setAttribute("title", name);
@@ -20377,9 +20448,20 @@ function renderJobs(){
         msgEl.textContent = mode === "message" ? contentValue : "";
         msgEl.hidden = mode !== "message";
       }
-      if (openEl instanceof HTMLAnchorElement){
-        openEl.href = href;
-        openEl.hidden = !href;
+      if (openLocalEl instanceof HTMLButtonElement){
+        const jobId = previewRoot.getAttribute("data-file-preview-job") || previewSelect.getAttribute("data-file-preview-select") || "";
+        openLocalEl.dataset.jobId = jobId;
+        openLocalEl.dataset.fileIndex = String(selectedIndex);
+        openLocalEl.hidden = source !== "wj_cuts_reference";
+      }
+      if (openUrlEl instanceof HTMLAnchorElement){
+        openUrlEl.href = href;
+        openUrlEl.hidden = source === "wj_cuts_reference" || !href;
+      }
+      if (pathBtn instanceof HTMLButtonElement){
+        pathBtn.hidden = !expectedPath;
+        pathBtn.dataset.previewExpectedPath = expectedPath;
+        pathBtn.dataset.previewRootLocation = rootLocation;
       }
       return;
     }
@@ -20399,17 +20481,22 @@ function renderJobs(){
     if (e.target.matches("input[data-job-file-input]")){
       const id = e.target.getAttribute("data-job-file-input");
       const idStr = String(id || "");
-      const j = cuttingJobs.find(x => String(x?.id) === idStr);
+      const found = findJobRecord(idStr);
+      const j = found && found.job ? found.job : null;
       if (!j){ e.target.value = ""; return; }
       const attachments = await filesToAttachments(e.target.files);
       e.target.value = "";
       if (!attachments.length) return;
       j.files = Array.isArray(j.files) ? j.files : [];
-      toast("Use Attach from Reference Folder so this file can be saved as a WJ Cuts relative path.");
+      j.files.push(...attachments);
+      saveCloudDebounced();
+      toast("Files added. For durable cross-device links, use Attach from Reference Folder.");
+      renderJobs();
     }
   });
 
   const historyBody = content.querySelector(".past-jobs-table tbody");
+  
   historyBody?.addEventListener("change", (e)=>{
     const previewSelect = e.target instanceof Element
       ? e.target.closest("select[data-file-preview-select]")
@@ -20423,10 +20510,16 @@ function renderJobs(){
     const mode = option.getAttribute("data-preview-mode") || "message";
     const contentValue = option.getAttribute("data-preview-content") || "";
     const href = option.getAttribute("data-preview-href") || "";
+    const source = option.getAttribute("data-preview-source") || "";
+    const selectedIndex = option.getAttribute("data-preview-index") || option.value || "0";
+    const expectedPath = option.getAttribute("data-preview-expected-path") || "";
+    const rootLocation = option.getAttribute("data-preview-root-location") || "";
     const nameEl = previewRoot.querySelector("[data-preview-name]");
     const imgEl = previewRoot.querySelector("[data-preview-image]");
     const msgEl = previewRoot.querySelector("[data-preview-message]");
-    const openEl = previewRoot.querySelector("[data-preview-open]");
+    const openLocalEl = previewRoot.querySelector("[data-preview-open-local]");
+    const openUrlEl = previewRoot.querySelector("[data-preview-open-url]");
+    const pathBtn = previewRoot.querySelector("[data-preview-path-btn]");
     if (nameEl){
       nameEl.textContent = name;
       nameEl.setAttribute("title", name);
@@ -20440,9 +20533,20 @@ function renderJobs(){
       msgEl.textContent = mode === "message" ? contentValue : "";
       msgEl.hidden = mode !== "message";
     }
-    if (openEl instanceof HTMLAnchorElement){
-      openEl.href = href;
-      openEl.hidden = !href;
+    if (openLocalEl instanceof HTMLButtonElement){
+      const jobId = previewRoot.getAttribute("data-file-preview-job") || previewSelect.getAttribute("data-file-preview-select") || "";
+      openLocalEl.dataset.jobId = jobId;
+      openLocalEl.dataset.fileIndex = String(selectedIndex);
+      openLocalEl.hidden = source !== "wj_cuts_reference";
+    }
+    if (openUrlEl instanceof HTMLAnchorElement){
+      openUrlEl.href = href;
+      openUrlEl.hidden = source === "wj_cuts_reference" || !href;
+    }
+    if (pathBtn instanceof HTMLButtonElement){
+      pathBtn.hidden = !expectedPath;
+      pathBtn.dataset.previewExpectedPath = expectedPath;
+      pathBtn.dataset.previewRootLocation = rootLocation;
     }
   });
 
@@ -20450,22 +20554,18 @@ function renderJobs(){
     const id = String(jobId || "");
     const idx = Number(fileIndex);
     if (!id || !Number.isInteger(idx) || idx < 0) return false;
-    const sources = [Array.isArray(cuttingJobs) ? cuttingJobs : [], Array.isArray(completedJobs) ? completedJobs : []];
-    let file = null;
-    for (const list of sources){
-      const job = list.find(item => String(item?.id || "") === id);
-      if (!job) continue;
-      const files = Array.isArray(job.files) ? job.files : [];
-      file = files[idx] || null;
-      if (file) break;
-    }
+    const found = findJobRecord(id);
+    const job = found && found.job ? found.job : null;
+    const files = Array.isArray(job?.files) ? job.files : [];
+    const file = files[idx] || null;
     if (!file || file.source !== "wj_cuts_reference" || !file.relativePath){
       toast("File metadata saved only — original file content is not stored.");
       return false;
     }
     try {
       const cfg = getSharedConfig();
-      const currentSignature = cfg.localRootSignature;
+      const rootStatus = await getWJCutsRootStatus();
+      const currentSignature = rootStatus.signature || "";
       if (file.localRootSignature && currentSignature && file.localRootSignature !== currentSignature){
         toast("This computer is linked to a different root folder. Reconfigure this computer root folder.");
         openOneDriveModal();
@@ -20485,7 +20585,27 @@ function renderJobs(){
     }
   };
 
+  const handleCuttingJobFileActionClick = async (e)=>{
+    const act = (matched)=>{ if (!matched) return false; e.preventDefault(); e.stopPropagation(); if (typeof e.stopImmediatePropagation === "function") e.stopImmediatePropagation(); return true; };
+    const fileMenuAdd = e.target.closest("[data-job-file-add]");
+    if (fileMenuAdd && act(true)){ closeFileMenu(); closeActionMenu(); closeHistoryActionMenu(); const id = fileMenuAdd.getAttribute("data-job-file-add"); await attachFromLocalOneDriveRoot(id || ""); return true; }
+    const previewPathBtn = e.target.closest("[data-preview-path-btn]");
+    if (previewPathBtn && act(true)){ const expected = previewPathBtn.getAttribute("data-preview-expected-path") || ""; const rootLocation = previewPathBtn.getAttribute("data-preview-root-location") || "WJ Cuts"; if (expected && navigator?.clipboard?.writeText){ navigator.clipboard.writeText(expected).catch(()=>{}); } const msg = `Root folder: ${rootLocation || "WJ Cuts"}\nExpected file path: ${expected || "Unavailable"}`; if (window.alert) window.alert(msg); else toast(msg); return true; }
+    const localFileBtn = e.target.closest("[data-open-local-file]");
+    if (localFileBtn && act(true)){ await openLocalRootAttachment(localFileBtn.getAttribute("data-job-id"), localFileBtn.getAttribute("data-file-index")); return true; }
+    const upload = e.target.closest("[data-upload-job]");
+    if (upload && act(true)){ const id = upload.getAttribute("data-upload-job"); closeActionMenu(); closeHistoryActionMenu(); content.querySelector(`input[data-job-file-input="${id}"]`)?.click(); return true; }
+    const linkJobFile = e.target.closest("[data-link-job-file]");
+    if (linkJobFile && act(true)){ const idStr = String(linkJobFile.getAttribute("data-link-job-file") || ""); const found = findJobRecord(idStr); const j = found && found.job ? found.job : null; if (!j) return true; try { const picked = await window.oneDrivePicker.openOneDriveDxfPicker(); if (!picked) return true; j.files = Array.isArray(j.files) ? j.files : []; j.files.push({ id: genId(picked.fileName || "job_file"), name: picked.fileName || "Linked file", type: "", size: null, source: "onedrive", driveId: picked.driveId || "", itemId: picked.itemId || "", eTag: picked.eTag || "", lastModifiedDateTime: picked.lastModifiedDateTime || "", webUrl: picked.webUrl || "", url: picked.webUrl || "", addedAt: new Date().toISOString() }); saveCloudDebounced(); toast("OneDrive DXF linked"); renderJobs(); } catch (err){ toast(err?.message || "Unable to link OneDrive DXF."); } return true; }
+    const editFileLink = e.target.closest("[data-edit-file-link]");
+    if (editFileLink && act(true)){ const idStr = String(editFileLink.getAttribute("data-edit-file-link") || ""); const idx = Number(editFileLink.getAttribute("data-file-index")); const found = findJobRecord(idStr); const j = found && found.job ? found.job : null; const file = j && Array.isArray(j.files) && idx >= 0 ? j.files[idx] : null; if (!file) return true; const url = promptOneDriveLinkForFile(file.name || "attachment", file.url || ""); if (url == null) return true; file.url = url; file.source = "onedrive"; saveCloudDebounced(); toast(url ? "File link updated" : "File link cleared"); renderJobs(); return true; }
+    const removeFile = e.target.closest("[data-remove-file]");
+    if (removeFile && act(true)){ const idStr = String(removeFile.getAttribute("data-remove-file") || ""); const idx = Number(removeFile.getAttribute("data-file-index")); const found = findJobRecord(idStr); const j = found && found.job ? found.job : null; if (j && Array.isArray(j.files) && idx >= 0 && idx < j.files.length){ j.files.splice(idx, 1); saveCloudDebounced(); toast("File removed"); renderJobs(); } return true; }
+    return false;
+  };
+
   historyBody?.addEventListener("click", async (e)=>{
+    if (await handleCuttingJobFileActionClick(e)) return;
     const historyActionTrigger = e.target.closest("[data-history-actions-toggle]");
     if (historyActionTrigger){
       const id = historyActionTrigger.getAttribute("data-history-actions-toggle");
@@ -20510,12 +20630,6 @@ function renderJobs(){
       return;
     }
 
-    const localFileBtn = e.target.closest("[data-open-local-file]");
-    if (localFileBtn){
-      e.preventDefault();
-      await openLocalRootAttachment(localFileBtn.getAttribute("data-job-id"), localFileBtn.getAttribute("data-file-index"));
-      return;
-    }
 
     const noteTrigger = e.target.closest("[data-job-note]");
     if (noteTrigger && (!noteBackdrop || !noteBackdrop.contains(noteTrigger))){
@@ -20850,6 +20964,7 @@ function renderJobs(){
 
   // 6) Edit/Remove/Save/Cancel + Log panel + Apply spent/remaining
   content.querySelector(".job-table tbody")?.addEventListener("click", async (e)=>{
+    if (await handleCuttingJobFileActionClick(e)) return;
     const overlapTrigger = e.target.closest("[data-job-overlap-info]");
     if (overlapTrigger){
       e.preventDefault();
@@ -20886,29 +21001,6 @@ function renderJobs(){
       return;
     }
 
-    const fileMenuAdd = e.target.closest("[data-job-file-add]");
-    if (fileMenuAdd){
-      const id = fileMenuAdd.getAttribute("data-job-file-add");
-      if (id){
-        e.preventDefault();
-        closeFileMenu();
-        closeActionMenu();
-        const attached = await attachFromLocalOneDriveRoot(id);
-        if (!attached){
-          window.pendingJobFocus = { type: "jobAddFiles", id };
-          editingJobs.add(id);
-          renderJobs();
-        }
-      }
-      return;
-    }
-
-    const localFileBtn = e.target.closest("[data-open-local-file]");
-    if (localFileBtn){
-      e.preventDefault();
-      await openLocalRootAttachment(localFileBtn.getAttribute("data-job-id"), localFileBtn.getAttribute("data-file-index"));
-      return;
-    }
 
     if (openFileMenuId){
       const activeMenu = content.querySelector(`[data-job-file-menu="${openFileMenuId}"]`);
@@ -20950,81 +21042,6 @@ function renderJobs(){
       return;
     }
 
-    const upload = e.target.closest("[data-upload-job]");
-    if (upload){
-      const id = upload.getAttribute("data-upload-job");
-      closeFileMenu();
-      closeActionMenu();
-      closeHistoryActionMenu();
-      content.querySelector(`input[data-job-file-input="${id}"]`)?.click();
-      return;
-    }
-
-    const linkJobFile = e.target.closest("[data-link-job-file]");
-    if (linkJobFile){
-      const id = linkJobFile.getAttribute("data-link-job-file");
-      const idStr = String(id || "");
-      const j = cuttingJobs.find(x => String(x?.id) === idStr);
-      if (!j) return;
-      try {
-        const picked = await window.oneDrivePicker.openOneDriveDxfPicker();
-        if (!picked) return;
-        j.files = Array.isArray(j.files) ? j.files : [];
-        j.files.push({
-          id: genId(picked.fileName || "job_file"),
-          name: picked.fileName || "Linked file",
-          type: "",
-          size: null,
-          source: "onedrive",
-          driveId: picked.driveId || "",
-          itemId: picked.itemId || "",
-          eTag: picked.eTag || "",
-          lastModifiedDateTime: picked.lastModifiedDateTime || "",
-          webUrl: picked.webUrl || "",
-          url: picked.webUrl || "",
-          addedAt: new Date().toISOString()
-        });
-        saveCloudDebounced();
-        toast("OneDrive DXF linked");
-        renderJobs();
-      } catch (err){
-        toast(err?.message || "Unable to link OneDrive DXF.");
-      }
-      return;
-    }
-
-    const editFileLink = e.target.closest("[data-edit-file-link]");
-    if (editFileLink){
-      const id = editFileLink.getAttribute("data-edit-file-link");
-      const idx = Number(editFileLink.getAttribute("data-file-index"));
-      const idStr = String(id || "");
-      const j = cuttingJobs.find(x => String(x?.id) === idStr);
-      const file = j && Array.isArray(j.files) && idx >= 0 ? j.files[idx] : null;
-      if (!file) return;
-      const url = promptOneDriveLinkForFile(file.name || "attachment", file.url || "");
-      if (url == null) return;
-      file.url = url;
-      file.source = "onedrive";
-      saveCloudDebounced();
-      toast(url ? "File link updated" : "File link cleared");
-      renderJobs();
-      return;
-    }
-
-    const removeFile = e.target.closest("[data-remove-file]");
-    if (removeFile){
-      const id = removeFile.getAttribute("data-remove-file");
-      const idx = Number(removeFile.getAttribute("data-file-index"));
-      const idStr = String(id || "");
-      const j = cuttingJobs.find(x => String(x?.id) === idStr);
-      if (j && Array.isArray(j.files) && idx>=0 && idx<j.files.length){
-        j.files.splice(idx,1);
-        saveCloudDebounced();
-        toast("File removed");
-        renderJobs();
-      }
-      return;
-    }
 
     const ed = e.target.closest("[data-edit-job]");
     const rm = e.target.closest("[data-remove-job]");

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -931,7 +931,14 @@ function getLocalDeviceId(){
   if (typeof window === "undefined" || !window.localStorage) return "";
   let id = String(window.localStorage.getItem(JOB_ONEDRIVE_DEVICE_ID_KEY) || "").trim();
   const profileId = String(window.localStorage.getItem("cutting_job_current_profile_local") || "").trim();
-  const cloudLike = profileId && id === profileId;
+  let cloudLike = profileId && id === profileId;
+  try {
+    const cfg = typeof window.getOneDriveJobConfig === "function" ? window.getOneDriveJobConfig() : null;
+    const currentProfileId = String(cfg?.currentComputerProfileId || "").trim();
+    const rootDeviceKeys = cfg?.rootDevices && typeof cfg.rootDevices === "object" ? Object.keys(cfg.rootDevices) : [];
+    const profileIds = rootDeviceKeys.concat(rootDeviceKeys.map(k=>String(cfg?.rootDevices?.[k]?.computerProfileId || ""))).filter(Boolean);
+    if ((currentProfileId && id === currentProfileId) || profileIds.includes(id)) cloudLike = true;
+  } catch (_err){ }
   const invalid = !id || !/^device_[a-z0-9_-]{8,}$/i.test(id);
   if (!invalid && !cloudLike) return id;
   const uuid = (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function")
@@ -974,9 +981,9 @@ async function setWJCutsRootFolder(){
   return chooseLocalOneDriveRoot();
 }
 
-async function resolveWJCutsRelativePath(relativePath){
+async function resolveWJCutsRelativePath(relativePath, profileId = ""){
   const clean = String(relativePath || "").replace(/^\/+/, "");
-  return resolveLocalFileFromRelativePath(clean);
+  return resolveLocalFileFromRelativePathForProfile(clean, profileId);
 }
 async function readWJCutsRootMarker(rootHandle){
   try {
@@ -1198,6 +1205,45 @@ async function resolveLocalFileFromRelativePath(relativePath){
   }
   const fileHandle = await dir.getFileHandle(segments[segments.length - 1]);
   return fileHandle.getFile();
+}
+async function resolveLocalFileFromRelativePathForProfile(relativePath, profileId){
+  const cfg = (typeof window.getOneDriveJobConfig === "function") ? normalizeOneDriveJobConfig(window.getOneDriveJobConfig()) : normalizeOneDriveJobConfig(null);
+  const selectedProfileId = String(profileId || cfg.currentComputerProfileId || "").trim();
+  const selectedProfile = selectedProfileId ? (cfg.rootDevices?.[selectedProfileId] || null) : null;
+  let rootHandle = selectedProfileId ? await readLocalRootHandleForProfile(selectedProfileId) : null;
+  if (!rootHandle){
+    const legacy = await readLocalRootHandle();
+    if (legacy){
+      const marker = await readWJCutsRootMarker(legacy);
+      const markerRootId = String(marker?.rootId || "").trim();
+      if (!selectedProfile?.rootId || (markerRootId && markerRootId === String(selectedProfile.rootId || "").trim())){
+        rootHandle = legacy;
+        if (selectedProfileId) await saveLocalRootHandleForProfile(selectedProfileId, legacy);
+      }
+    }
+  }
+  if (!rootHandle) throw new Error("No saved WJ Cuts root folder for selected profile.");
+  const perm = typeof rootHandle.queryPermission === "function" ? await rootHandle.queryPermission({ mode: "read" }) : "granted";
+  if (perm !== "granted") throw new Error("WJ Cuts root folder permission is not granted.");
+  const rel = String(relativePath || "").replace(/^\/+/, "");
+  if (!rel) return null;
+  const segments = rel.split("/").filter(Boolean);
+  let dir = rootHandle;
+  for (let idx = 0; idx < segments.length - 1; idx += 1) dir = await dir.getDirectoryHandle(segments[idx]);
+  const fileHandle = await dir.getFileHandle(segments[segments.length - 1]);
+  return fileHandle.getFile();
+}
+function diagnoseWJCutsReferenceStatus(file, currentRootStatus){
+  if (!currentRootStatus?.hasSavedHandle) return { code:"setup_required", message:"Setup required: no selected local WJ Cuts root handle." };
+  if (currentRootStatus?.permission !== "granted") return { code:"permission_needed", message:"Permission needed: grant access to the selected WJ Cuts root folder." };
+  if (!String(file?.relativePath || "").trim()) return { code:"missing_relative_path", message:"Reference is missing a relative path." };
+  const currentRootId = String(currentRootStatus?.markerRootId || "").trim();
+  const fileRootId = String(file?.rootId || "").trim();
+  if (fileRootId && currentRootId && fileRootId !== currentRootId){
+    return { code:"root_mismatch", message:`Root mismatch: this file belongs to root ID ${fileRootId}, but the selected folder is root ID ${currentRootId}.` };
+  }
+  if (!fileRootId) return { code:"legacy_reference", message:"Legacy reference: this file was saved before root IDs. It opened by relative path under the selected root." };
+  return { code:"ready", message:"Ready" };
 }
 
 function triggerFileDownload(file, fileName){
@@ -1759,7 +1805,9 @@ async function resolveAttachmentPreview(file){
 
   if (file.source === "wj_cuts_reference" && file.relativePath){
     try {
-      const localFile = await resolveWJCutsRelativePath(file.relativePath);
+      const cfg = (typeof window.getOneDriveJobConfig === "function") ? normalizeOneDriveJobConfig(window.getOneDriveJobConfig()) : normalizeOneDriveJobConfig(null);
+      const profileId = String(cfg.currentComputerProfileId || "");
+      const localFile = await resolveWJCutsRelativePath(file.relativePath, profileId);
       if (!localFile){
         file.preview = { mode: "message", content: "Preview unavailable: file reference was saved, but the file is missing under your selected WJ Cuts root folder." };
         return false;
@@ -20763,6 +20811,8 @@ function renderJobs(){
       const selectedIndex = option.getAttribute("data-preview-index") || option.value || "0";
       const expectedPath = option.getAttribute("data-preview-expected-path") || "";
       const rootLocation = option.getAttribute("data-preview-root-location") || "";
+      const rootId = option.getAttribute("data-preview-root-id") || "";
+      const rootHint = option.getAttribute("data-preview-root-hint") || "";
       const nameEl = previewRoot.querySelector("[data-preview-name]");
       const imgEl = previewRoot.querySelector("[data-preview-image]");
       const msgEl = previewRoot.querySelector("[data-preview-message]");
@@ -20796,6 +20846,8 @@ function renderJobs(){
         pathBtn.hidden = !expectedPath;
         pathBtn.dataset.previewExpectedPath = expectedPath;
         pathBtn.dataset.previewRootLocation = rootLocation;
+        pathBtn.dataset.previewRootId = rootId;
+        pathBtn.dataset.previewRootHint = rootHint;
       }
       return;
     }
@@ -20848,6 +20900,8 @@ function renderJobs(){
     const selectedIndex = option.getAttribute("data-preview-index") || option.value || "0";
     const expectedPath = option.getAttribute("data-preview-expected-path") || "";
     const rootLocation = option.getAttribute("data-preview-root-location") || "";
+    const rootId = option.getAttribute("data-preview-root-id") || "";
+    const rootHint = option.getAttribute("data-preview-root-hint") || "";
     const nameEl = previewRoot.querySelector("[data-preview-name]");
     const imgEl = previewRoot.querySelector("[data-preview-image]");
     const msgEl = previewRoot.querySelector("[data-preview-message]");
@@ -20881,6 +20935,8 @@ function renderJobs(){
       pathBtn.hidden = !expectedPath;
       pathBtn.dataset.previewExpectedPath = expectedPath;
       pathBtn.dataset.previewRootLocation = rootLocation;
+      pathBtn.dataset.previewRootId = rootId;
+      pathBtn.dataset.previewRootHint = rootHint;
     }
   });
 
@@ -20898,9 +20954,12 @@ function renderJobs(){
     }
     try {
       const cfg = getSharedConfig();
+      const profileId = getCurrentComputerProfileId(cfg);
       const rootStatus = await getWJCutsRootStatus();
       const currentSignature = rootStatus.signature || "";
       const currentRootId = rootStatus.markerRootId || "";
+      const diag = diagnoseWJCutsReferenceStatus(file, rootStatus);
+      if (diag.code === "root_mismatch"){ toast(diag.message); openOneDriveModal(); return false; }
       if (file.rootId && currentRootId && file.rootId !== currentRootId){
         toast(`This file belongs to a different WJ Cuts root. Select the root with ID ${file.rootId}.`);
         openOneDriveModal();
@@ -20911,12 +20970,13 @@ function renderJobs(){
         openOneDriveModal();
         return false;
       }
-      const fileBlob = await resolveWJCutsRelativePath(file.relativePath);
+      const fileBlob = await resolveWJCutsRelativePath(file.relativePath, profileId);
       if (!fileBlob){
-        toast("File reference saved, but the file was not found under your selected WJ Cuts folder.");
+        toast(file.rootId ? "File reference saved, but the file was not found under your selected WJ Cuts folder." : "Legacy reference could not be found under the selected WJ Cuts root. Verify the relative path exists or reattach the file.");
         openOneDriveModal();
         return false;
       }
+      if (!file.rootId) toast("Legacy reference: this file was saved before root IDs. It opened by relative path under the selected root.");
       triggerFileDownload(fileBlob, file.name || fileBlob.name || "attachment");
       return true;
     } catch (err){

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -972,6 +972,28 @@ async function resolveWJCutsRelativePath(relativePath){
   const clean = String(relativePath || "").replace(/^\/+/, "");
   return resolveLocalFileFromRelativePath(clean);
 }
+async function readWJCutsRootMarker(rootHandle){
+  try {
+    const markerHandle = await rootHandle.getFileHandle(".wj-cuts-root.json");
+    const markerFile = await markerHandle.getFile();
+    const raw = await markerFile.text();
+    const parsed = JSON.parse(raw || "{}");
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch (_err){ return null; }
+}
+async function writeWJCutsRootMarker(rootHandle, marker){
+  const markerHandle = await rootHandle.getFileHandle(".wj-cuts-root.json", { create:true });
+  const writable = await markerHandle.createWritable();
+  await writable.write(JSON.stringify(marker, null, 2));
+  await writable.close();
+  return marker;
+}
+async function getOrCreateWJCutsRootMarker(rootHandle){
+  const existing = await readWJCutsRootMarker(rootHandle);
+  if (existing && existing.rootId) return existing;
+  const next = { rootId: `wjroot_${Date.now().toString(36)}_${Math.random().toString(36).slice(2,8)}`, createdAtISO: new Date().toISOString(), label: "WJ Cuts" };
+  return writeWJCutsRootMarker(rootHandle, next);
+}
 
 function sanitizeJobFileReferenceForFirestore(fileRef){
   if (!fileRef || typeof fileRef !== "object") return null;
@@ -988,6 +1010,7 @@ function sanitizeJobFileReferenceForFirestore(fileRef){
     localRootSignature: String(fileRef.localRootSignature || ""),
     localDeviceId: String(fileRef.localDeviceId || ""),
     ...(fileRef.computerProfileId ? { computerProfileId: String(fileRef.computerProfileId) } : {}),
+    ...(fileRef.rootId ? { rootId: String(fileRef.rootId) } : {}),
     ...(fileRef.note ? { note: String(fileRef.note) } : {}),
     ...(fileRef.rootLocationHint ? { rootLocationHint: String(fileRef.rootLocationHint) } : {})
   };
@@ -1137,6 +1160,7 @@ function normalizeOneDriveJobConfig(config){
       folderName: typeof row.folderName === "string" ? row.folderName : "",
       folderHint: typeof row.folderHint === "string" ? row.folderHint : "",
       rootSignature: typeof row.rootSignature === "string" ? row.rootSignature : "",
+      rootId: typeof row.rootId === "string" ? row.rootId : "",
       lastVerifiedAtISO: typeof row.lastVerifiedAtISO === "string" ? row.lastVerifiedAtISO : "",
       lastSeenBrowserDeviceId: typeof row.lastSeenBrowserDeviceId === "string" ? row.lastSeenBrowserDeviceId : "",
       lastSeenBrowserDeviceNumber: Number.isFinite(Number(row.lastSeenBrowserDeviceNumber)) ? Number(row.lastSeenBrowserDeviceNumber) : null
@@ -19469,11 +19493,15 @@ function renderJobs(){
     if (permission !== "granted") return { supported:true, handle, hasSavedHandle:true, permission, config, signature:"", profileSignature:String(currentDeviceMeta?.rootSignature || "").trim(), profileMatches:true, expectedSignature: expectedRootSignatureFromJobs(), expectedMatches:true, signatureMatches:true, message:"Folder permission is required for WJ Cuts file previews and Open actions.", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || ""), profileId };
     const signature = await computeLocalRootSignature(handle);
     const profileSignature = String(currentDeviceMeta?.rootSignature || "").trim();
+    const profileRootId = String(currentDeviceMeta?.rootId || "").trim();
+    const marker = await readWJCutsRootMarker(handle);
+    const markerRootId = String(marker?.rootId || "").trim();
     const expectedSignature = expectedRootSignatureFromJobs();
     const profileMatches = !profileSignature || !signature || profileSignature === signature;
     const expectedMatches = !expectedSignature || !signature || expectedSignature === signature;
-    const signatureMatches = profileMatches && expectedMatches;
-    return { supported:true, handle, hasSavedHandle:true, permission:"granted", config, signature, profileSignature, profileMatches, expectedSignature, expectedMatches, signatureMatches, message: signatureMatches ? "Verified" : "Mismatch", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || ""), profileId };
+    const markerMatchesProfile = !profileRootId || !markerRootId || profileRootId === markerRootId;
+    const signatureMatches = profileMatches && expectedMatches && markerMatchesProfile;
+    return { supported:true, handle, hasSavedHandle:true, permission:"granted", config, signature, profileSignature, profileMatches, expectedSignature, expectedMatches, signatureMatches, message: signatureMatches ? "Verified" : "Mismatch", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || ""), profileId, markerRootId, markerMatchesProfile };
   };
   const updateSharedConfig = (patch)=>{
     const cfg = getSharedConfig();
@@ -19511,7 +19539,7 @@ function renderJobs(){
       const selectedProfile = (cfg.rootDevices || {})[getCurrentComputerProfileId(cfg) || ""] || null;
       const signature = status.signature || selectedProfile?.rootSignature || "Not verified";
       const authState = status.permission === "granted" && status.signatureMatches ? "Authorized" : (status.hasSavedHandle ? "Needs permission" : "Not authorized");
-      oneDriveCurrentComputer.innerHTML = `Browser/device ID: ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected computer profile: ${escapeHtml(selectedProfile?.label || "Not selected")}<br>Local root authorization: ${authState}<br>Selected root folder: ${status.handleName || "Not selected in this browser"}<br>Root location hint: ${selectedProfile?.folderHint || cfg.folderHint || "Not set"}<br>Root signature: ${signature}<br>Root profile match: ${status.profileSignature ? (status.profileMatches ? "Match" : "Mismatch") : "Not recorded"}<br>Existing file root match: ${status.expectedSignature ? (status.expectedMatches ? "Match" : "Mismatch") : "No existing references"}<br>Status: ${status.message}`;
+      oneDriveCurrentComputer.innerHTML = `Browser/device ID: ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected computer profile: ${escapeHtml(selectedProfile?.label || "Not selected")}<br>Local root authorization: ${authState}<br>Selected root folder: ${status.handleName || "Not selected in this browser"}<br>Root marker ID: ${escapeHtml(String(status.markerRootId || selectedProfile?.rootId || "Not verified"))}<br>Root location hint: ${selectedProfile?.folderHint || cfg.folderHint || "Not set"}<br>Root signature: ${signature}<br>Root profile match: ${status.profileSignature ? (status.profileMatches ? "Match" : "Mismatch") : "Not recorded"}<br>Existing file root match: ${status.expectedSignature ? (status.expectedMatches ? "Match" : "Mismatch") : "No existing references"}<br>Status: ${status.message}`;
     }
     if (oneDriveStatusInline){
       const hint = (status.currentDeviceMeta?.folderHint || cfg.folderHint || status.handleName || "").trim();
@@ -19526,7 +19554,7 @@ function renderJobs(){
     if (oneDriveKnownDevices){
       const rows = Object.values(cfg.rootDevices || {});
       oneDriveKnownDevices.innerHTML = rows.length
-        ? rows.map(row=>{ const sig=String(row.rootSignature||""); const shortSig=sig?`${sig.slice(0,16)}${sig.length>16?"…":""}`:"Not verified"; const last=row.lastVerifiedAtISO?new Date(row.lastVerifiedAtISO).toLocaleString():"Never"; return `<tr><td>${escapeHtml(row.label || "Unnamed")}<br><span class="small muted">${escapeHtml(String(row.deviceId || ""))}</span>${(row.computerProfileId || row.deviceId)===getCurrentComputerProfileId(cfg)?" <strong>(Selected)</strong>":""}</td><td>${escapeHtml(row.folderName || "Not selected yet")}</td><td>${escapeHtml(row.folderHint || "—")}</td><td>${escapeHtml(shortSig)}</td><td>${escapeHtml(last)}</td><td>${escapeHtml(String(row.lastSeenBrowserDeviceNumber || "?"))} (${escapeHtml(String(row.lastSeenBrowserDeviceId || ""))})</td></tr>`; }).join("")
+        ? rows.map(row=>{ const sig=String(row.rootId||""); const shortSig=sig?`${sig.slice(0,16)}${sig.length>16?"…":""}`:"Not verified"; const last=row.lastVerifiedAtISO?new Date(row.lastVerifiedAtISO).toLocaleString():"Never"; return `<tr><td>${escapeHtml(row.label || "Unnamed")}<br><span class="small muted">${escapeHtml(String(row.deviceId || ""))}</span>${(row.computerProfileId || row.deviceId)===getCurrentComputerProfileId(cfg)?" <strong>(Selected)</strong>":""}</td><td>${escapeHtml(row.folderName || "Not selected yet")}</td><td>${escapeHtml(row.folderHint || "—")}</td><td>${escapeHtml(shortSig)}</td><td>${escapeHtml(last)}</td><td>${escapeHtml(String(row.lastSeenBrowserDeviceNumber || "?"))} (${escapeHtml(String(row.lastSeenBrowserDeviceId || ""))})</td></tr>`; }).join("")
         : `<tr><td colspan="6" class="small muted">No computer roots recorded yet.</td></tr>`;
     }
   };
@@ -19556,9 +19584,21 @@ function renderJobs(){
     let perm = "prompt"; try { perm = await handle.requestPermission({ mode:"read" }); } catch(_){}
     if (perm !== "granted"){ logSetupReason("permission_denied", { handle, permission:perm }); openOneDriveModal(); toast("Permission is required before WJ Cuts files can be added or previewed."); return { ok:false }; }
     const signature = await computeLocalRootSignature(handle); if (!signature) return { ok:false };
+    let marker = await readWJCutsRootMarker(handle);
+    if (!marker?.rootId){
+      try { marker = await getOrCreateWJCutsRootMarker(handle); }
+      catch (_err){
+        pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" };
+        logSetupReason("root marker missing and write permission denied", { handle, permission:perm, signature });
+        openOneDriveModal();
+        toast("Setup opened because: root marker missing and write permission denied.");
+        return { ok:false };
+      }
+    }
     const match = verifyRootSignatureMatches(signature); if (!match.ok){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; logSetupReason("existing_reference_signature_mismatch", { handle, permission:perm, signature, profileMatches: !(profile?.rootSignature) || profile.rootSignature===signature, expectedMatches:false }); openOneDriveModal(); toast("This folder does not match files already attached by other computers. Select the same shared root folder."); return { ok:false }; }
     if (profile?.rootSignature && profile.rootSignature !== signature){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; logSetupReason("profile_signature_mismatch", { handle, permission:perm, signature, profileMatches:false, expectedMatches:true }); openOneDriveModal(); toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile."); return { ok:false }; }
-    return { ok:true, handle, signature, profileId, profile };
+    if (profile?.rootId && marker?.rootId && profile.rootId !== marker.rootId){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; logSetupReason("selected root does not match this profile", { handle, permission:perm, signature }); openOneDriveModal(); toast("This file was attached under a different WJ Cuts root. Select the matching root folder or reattach the file."); return { ok:false }; }
+    return { ok:true, handle, signature, profileId, profile, rootId: String(marker?.rootId || "") };
   }
   const updatePermissionBanner = async ()=>{
     if (!permissionBanner) return;
@@ -19604,12 +19644,21 @@ function renderJobs(){
         toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile.");
         return false;
       }
+      let marker = await readWJCutsRootMarker(handle);
+      if (!marker?.rootId){
+        try { marker = await getOrCreateWJCutsRootMarker(handle); }
+        catch (_err){ toast("Root marker missing and write permission denied."); return false; }
+      }
+      if (selectedProfile?.rootId && marker?.rootId && selectedProfile.rootId !== marker.rootId){
+        toast("This file was attached under a different WJ Cuts root. Select the matching root folder or reattach the file.");
+        return false;
+      }
       await saveLocalRootHandle(handle);
       const verifyHandle = await readLocalRootHandle();
       if (!verifyHandle){ toast("Unable to save root handle on this browser."); return false; }
       const rootDevices = { ...(cfg.rootDevices || {}) };
       if (profileId){
-        rootDevices[profileId] = { ...(rootDevices[profileId] || {}), deviceId: profileId, computerProfileId: profileId, deviceNumber: currentDeviceNumber, label: rootDevices[profileId]?.label || `Computer ${currentDeviceNumber}`, folderName: String(handle.name || ""), folderHint: rootHint, rootSignature: signature, lastVerifiedAtISO: new Date().toISOString(), lastSeenBrowserDeviceId: currentDeviceId, lastSeenBrowserDeviceNumber: currentDeviceNumber };
+        rootDevices[profileId] = { ...(rootDevices[profileId] || {}), deviceId: profileId, computerProfileId: profileId, deviceNumber: currentDeviceNumber, label: rootDevices[profileId]?.label || `Computer ${currentDeviceNumber}`, folderName: String(handle.name || ""), folderHint: rootHint, rootSignature: signature, rootId: String(marker?.rootId || ""), lastVerifiedAtISO: new Date().toISOString(), lastSeenBrowserDeviceId: currentDeviceId, lastSeenBrowserDeviceNumber: currentDeviceNumber };
       }
       updateSharedConfig({
         localRootName: String(handle.name || cfg.localRootName || "Configured"),
@@ -19646,6 +19695,7 @@ function renderJobs(){
       const profileId = ensured.profileId;
       const currentProfile = ensured.profile;
       const signature = ensured.signature;
+      const rootId = ensured.rootId || "";
       const pickedHandles = await window.showOpenFilePicker({
         multiple: false,
         startIn: rootHandle,
@@ -19680,6 +19730,7 @@ function renderJobs(){
         rootPathStart: "WJ Cuts",
         relativePath: relPath,
         localRootSignature: signature,
+        rootId,
         enabled: true,
         localDeviceId: getLocalDeviceId(),
         computerProfileId: profileId,
@@ -20745,6 +20796,12 @@ function renderJobs(){
       const cfg = getSharedConfig();
       const rootStatus = await getWJCutsRootStatus();
       const currentSignature = rootStatus.signature || "";
+      const currentRootId = rootStatus.markerRootId || "";
+      if (file.rootId && currentRootId && file.rootId !== currentRootId){
+        toast("This file was attached under a different WJ Cuts root. Select the matching root folder or reattach the file.");
+        openOneDriveModal();
+        return false;
+      }
       if (file.localRootSignature && currentSignature && file.localRootSignature !== currentSignature){
         toast("This computer is linked to a different root folder. Reconfigure this computer root folder.");
         openOneDriveModal();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -930,8 +930,14 @@ const JOB_ONEDRIVE_DEVICE_ID_KEY = "cutting_job_onedrive_device_id_v1";
 function getLocalDeviceId(){
   if (typeof window === "undefined" || !window.localStorage) return "";
   let id = String(window.localStorage.getItem(JOB_ONEDRIVE_DEVICE_ID_KEY) || "").trim();
-  if (id) return id;
-  id = `device_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  const profileId = String(window.localStorage.getItem("cutting_job_current_profile_local") || "").trim();
+  const cloudLike = profileId && id === profileId;
+  const invalid = !id || !/^device_[a-z0-9_-]{8,}$/i.test(id);
+  if (!invalid && !cloudLike) return id;
+  const uuid = (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function")
+    ? crypto.randomUUID()
+    : `${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 14)}`;
+  id = `device_${uuid.replace(/[^a-z0-9_-]/ig, "")}`;
   try { window.localStorage.setItem(JOB_ONEDRIVE_DEVICE_ID_KEY, id); } catch (_err){ }
   return id;
 }
@@ -1138,9 +1144,11 @@ function expectedRootIdFromJobs(){
   return rootIds.size ? Array.from(rootIds)[0] : "";
 }
 
-async function ensureWJCutsRootMarker(rootHandle){
+async function ensureWJCutsRootMarker(rootHandle, opts = {}){
+  const expectedRootId = String(opts.expectedRootId || "").trim();
   const marker = await readWJCutsRootMarker(rootHandle);
   if (marker?.rootId) return { ok:true, marker, writeNeeded:false };
+  if (expectedRootId) return { ok:false, reason:"expected_marker_missing" };
   let writePermission = "prompt";
   try {
     writePermission = typeof rootHandle?.requestPermission === "function"
@@ -19521,6 +19529,7 @@ function renderJobs(){
     missing_local_root_folder: "Missing local root folder",
     folder_permission_needed: "Folder permission needed",
     marker_missing_write_denied: "WJ Cuts marker missing and write permission denied",
+    expected_marker_missing: "Selected folder is missing the expected WJ Cuts marker",
     profile_root_mismatch: "Selected root does not match this PC/profile",
     existing_reference_root_mismatch: "Selected root does not match existing file references",
     unsupported_browser: "Unsupported browser"
@@ -19624,7 +19633,7 @@ function renderJobs(){
       const selectedProfile = (cfg.rootDevices || {})[getCurrentComputerProfileId(cfg) || ""] || null;
       const signature = status.signature || selectedProfile?.rootSignature || "Not verified";
       const authState = status.permission === "granted" && status.signatureMatches ? "Authorized" : (status.hasSavedHandle ? "Needs permission" : "Not authorized");
-      oneDriveCurrentComputer.innerHTML = `Browser/device ID: ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected computer profile: ${escapeHtml(selectedProfile?.label || "Not selected")}<br>Local root authorization: ${authState}<br>Selected root folder: ${status.handleName || "Not selected in this browser"}<br>Root marker ID: ${escapeHtml(String(status.markerRootId || selectedProfile?.rootId || "Not verified"))}<br>Root location hint: ${selectedProfile?.folderHint || cfg.folderHint || "Not set"}<br>Root signature: ${signature}<br>Root profile match: ${status.profileSignature ? (status.profileMatches ? "Match" : "Mismatch") : "Not recorded"}<br>Existing file root match: ${status.expectedSignature ? (status.expectedMatches ? "Match" : "Mismatch") : "No existing references"}<br>Status: ${status.message}`;
+      oneDriveCurrentComputer.innerHTML = `Browser/device ID (local): ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected PC/profile ID (shared label): ${escapeHtml(getCurrentComputerProfileId(cfg) || "Not selected")}<br>Selected computer profile: ${escapeHtml(selectedProfile?.label || "Not selected")}<br>Local root authorization: ${authState}<br>Selected root folder: ${status.handleName || "Not selected in this browser"}<br>Expected root ID for profile: ${escapeHtml(String(selectedProfile?.rootId || "Not set"))}<br>Selected folder root ID: ${escapeHtml(String(status.markerRootId || "Marker missing"))}<br>Root match: ${selectedProfile?.rootId ? (status.markerRootId ? (selectedProfile.rootId === status.markerRootId ? "Match" : "Mismatch") : "Marker missing") : "No profile root set"}<br>Root location hint: ${selectedProfile?.folderHint || cfg.folderHint || "Not set"}<br>Root signature (compat): ${signature}<br>Status: ${status.message}`;
     }
     if (oneDriveStatusInline){
       const hint = (status.currentDeviceMeta?.folderHint || cfg.folderHint || status.handleName || "").trim();
@@ -19677,13 +19686,15 @@ function renderJobs(){
     let perm = "prompt"; try { perm = await handle.requestPermission({ mode:"read" }); } catch(_){}
     if (perm !== "granted"){ setSetupReason("folder_permission_needed"); logSetupReason("permission_denied", { handle, permission:perm }); openOneDriveModal(); toast("Permission is required before WJ Cuts files can be added or previewed."); return { ok:false }; }
     const signature = await computeLocalRootSignature(handle); if (!signature) return { ok:false };
-    const markerResult = await ensureWJCutsRootMarker(handle);
+    const markerResult = await ensureWJCutsRootMarker(handle, { expectedRootId: String(profile?.rootId || "") });
     if (!markerResult.ok){
       pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" };
-      setSetupReason("marker_missing_write_denied");
-      logSetupReason("root marker missing and write permission denied", { handle, permission:perm, signature });
+      setSetupReason(markerResult.reason === "expected_marker_missing" ? "expected_marker_missing" : "marker_missing_write_denied");
+      logSetupReason(markerResult.reason || "root marker missing and write permission denied", { handle, permission:perm, signature });
       openOneDriveModal();
-      toast("Setup opened because: WJ Cuts marker missing and write permission was denied.");
+      toast(markerResult.reason === "expected_marker_missing"
+        ? `This folder does not contain the expected WJ Cuts root marker for this PC/profile. Select the synced shared folder that contains root ID ${profile?.rootId || "required root ID"}, or create a new PC/root profile.`
+        : "Setup opened because: WJ Cuts marker missing and write permission was denied.");
       return { ok:false };
     }
     const marker = markerResult.marker;
@@ -19726,9 +19737,13 @@ function renderJobs(){
       const rootHint = String(oneDriveFolderHintInput?.value || cfg.folderHint || "");
       const profileId = getCurrentComputerProfileId(cfg);
       const selectedProfile = (cfg.rootDevices || {})[profileId] || null;
-      const markerResult = await ensureWJCutsRootMarker(handle);
+      const markerResult = await ensureWJCutsRootMarker(handle, { expectedRootId: String(selectedProfile?.rootId || "") });
       if (!markerResult.ok){
-        toast("Write permission is required once to create the WJ Cuts root marker. This lets other computers confirm they selected the same shared folder.");
+        if (markerResult.reason === "expected_marker_missing"){
+          toast(`The selected folder does not contain the synced WJ Cuts marker. Make sure this OneDrive account has the shared folder synced locally, then select that folder. Expected root ID: ${selectedProfile?.rootId || "required"}.`);
+        } else {
+          toast("Write permission is required once to create the WJ Cuts root marker. This lets other computers confirm they selected the same shared folder.");
+        }
         return false;
       }
       const marker = markerResult.marker;
@@ -20887,7 +20902,7 @@ function renderJobs(){
       const currentSignature = rootStatus.signature || "";
       const currentRootId = rootStatus.markerRootId || "";
       if (file.rootId && currentRootId && file.rootId !== currentRootId){
-        toast("This file was attached under a different WJ Cuts root. Select the matching root folder or reattach the file.");
+        toast(`This file belongs to a different WJ Cuts root. Select the root with ID ${file.rootId}.`);
         openOneDriveModal();
         return false;
       }
@@ -20915,7 +20930,7 @@ function renderJobs(){
     const fileMenuAdd = e.target.closest("[data-job-file-add]");
     if (fileMenuAdd && act(true)){ closeFileMenu(); closeActionMenu(); closeHistoryActionMenu(); const id = fileMenuAdd.getAttribute("data-job-file-add"); await attachFromLocalOneDriveRoot(id || ""); return true; }
     const previewPathBtn = e.target.closest("[data-preview-path-btn]");
-    if (previewPathBtn && act(true)){ const expected = previewPathBtn.getAttribute("data-preview-expected-path") || ""; const rootLocation = previewPathBtn.getAttribute("data-preview-root-location") || "WJ Cuts"; if (expected && navigator?.clipboard?.writeText){ navigator.clipboard.writeText(expected).catch(()=>{}); } const msg = `Root folder: ${rootLocation || "WJ Cuts"}\nExpected file path: ${expected || "Unavailable"}`; if (window.alert) window.alert(msg); else toast(msg); return true; }
+    if (previewPathBtn && act(true)){ const expected = previewPathBtn.getAttribute("data-preview-expected-path") || ""; const rootLocation = previewPathBtn.getAttribute("data-preview-root-location") || "WJ Cuts"; const rootId = previewPathBtn.getAttribute("data-preview-root-id") || "Not verified"; const manualHint = previewPathBtn.getAttribute("data-preview-root-hint") || ""; if (expected && navigator?.clipboard?.writeText){ navigator.clipboard.writeText(expected).catch(()=>{}); } const msg = `Root:\n${rootLocation || "WJ Cuts"}\n\nRoot ID:\n${rootId || "Not verified"}\n\nRelative path under root:\n${expected || "Unavailable"}\n\nHow to find it:\nOpen the selected WJ Cuts root folder on this computer, then follow the relative path above.${manualHint ? `\n\nOptional hint:\n${manualHint} (Manual hint, not verified full path)` : ""}`; if (window.alert) window.alert(msg); else toast(msg); return true; }
     const localFileBtn = e.target.closest("[data-open-local-file]");
     if (localFileBtn && act(true)){ await openLocalRootAttachment(localFileBtn.getAttribute("data-job-id"), localFileBtn.getAttribute("data-file-index")); return true; }
     const upload = e.target.closest("[data-upload-job]");

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1094,6 +1094,38 @@ function expectedRootSignatureFromJobs(){
   return signatures.size ? Array.from(signatures)[0] : "";
 }
 
+function expectedRootIdFromJobs(){
+  const rootIds = new Set();
+  const take = list=>{
+    if (!Array.isArray(list)) return;
+    list.forEach(job=>{
+      const files = Array.isArray(job?.files) ? job.files : [];
+      files.forEach(file=>{
+        if (String(file?.source || "") !== "wj_cuts_reference") return;
+        const rootId = String(file?.rootId || "").trim();
+        if (rootId) rootIds.add(rootId);
+      });
+    });
+  };
+  take(window.cuttingJobs);
+  take(window.completedCuttingJobs);
+  return rootIds.size ? Array.from(rootIds)[0] : "";
+}
+
+async function ensureWJCutsRootMarker(rootHandle){
+  const marker = await readWJCutsRootMarker(rootHandle);
+  if (marker?.rootId) return { ok:true, marker, writeNeeded:false };
+  let writePermission = "prompt";
+  try {
+    writePermission = typeof rootHandle?.requestPermission === "function"
+      ? await rootHandle.requestPermission({ mode:"readwrite" })
+      : "denied";
+  } catch (_err){ writePermission = "denied"; }
+  if (writePermission !== "granted") return { ok:false, reason:"marker_missing_write_denied" };
+  const nextMarker = await getOrCreateWJCutsRootMarker(rootHandle);
+  return { ok:true, marker: nextMarker, writeNeeded:true };
+}
+
 function verifyRootSignatureMatches(signature){
   const expected = expectedRootSignatureFromJobs();
   if (!expected || !signature) return { ok: true, expected };
@@ -19445,6 +19477,7 @@ function renderJobs(){
   const oneDriveDeviceStatus = document.querySelector("[data-onedrive-device-status]");
   const oneDriveCurrentComputer = document.querySelector("[data-onedrive-current-computer]");
   const oneDriveKnownDevices = document.querySelector("[data-onedrive-known-devices]");
+  const oneDriveSetupReason = document.querySelector("[data-onedrive-setup-reason]");
   const oneDriveLibraryAddToJobBtn = document.getElementById("jobOneDriveLibraryAddBtn");
   const oneDriveRootPickerBtn = document.getElementById("jobOneDriveRootPickerBtn");
   const permissionBanner = content.querySelector("[data-wjcuts-permission-banner]");
@@ -19458,6 +19491,25 @@ function renderJobs(){
   const oneDriveStatusInline = content.querySelector(".job-onedrive-status");
 
   let pendingAttachTarget = null;
+  const setupReasonLabels = {
+    missing_local_root_folder: "Missing local root folder",
+    folder_permission_needed: "Folder permission needed",
+    marker_missing_write_denied: "WJ Cuts marker missing and write permission denied",
+    profile_root_mismatch: "Selected root does not match this PC/profile",
+    existing_reference_root_mismatch: "Selected root does not match existing file references",
+    unsupported_browser: "Unsupported browser"
+  };
+  const setSetupReason = (reasonKey = "")=>{
+    if (!oneDriveSetupReason) return;
+    const reason = String(reasonKey || "").trim();
+    if (!reason){
+      oneDriveSetupReason.textContent = "";
+      oneDriveSetupReason.hidden = true;
+      return;
+    }
+    oneDriveSetupReason.textContent = `Setup opened because: ${setupReasonLabels[reason] || reason}`;
+    oneDriveSetupReason.hidden = false;
+  };
   const ensureCurrentProfile = (cfg)=>{
     const deviceId = String(getLocalDeviceId() || "");
     const nextCfg = { ...cfg };
@@ -19496,9 +19548,12 @@ function renderJobs(){
     const profileRootId = String(currentDeviceMeta?.rootId || "").trim();
     const marker = await readWJCutsRootMarker(handle);
     const markerRootId = String(marker?.rootId || "").trim();
+    const expectedRootId = expectedRootIdFromJobs();
     const expectedSignature = expectedRootSignatureFromJobs();
     const profileMatches = !profileSignature || !signature || profileSignature === signature;
-    const expectedMatches = !expectedSignature || !signature || expectedSignature === signature;
+    const expectedMatches = expectedRootId
+      ? (!markerRootId || expectedRootId === markerRootId)
+      : (!expectedSignature || !signature || expectedSignature === signature);
     const markerMatchesProfile = !profileRootId || !markerRootId || profileRootId === markerRootId;
     const signatureMatches = profileMatches && expectedMatches && markerMatchesProfile;
     return { supported:true, handle, hasSavedHandle:true, permission:"granted", config, signature, profileSignature, profileMatches, expectedSignature, expectedMatches, signatureMatches, message: signatureMatches ? "Verified" : "Mismatch", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || ""), profileId, markerRootId, markerMatchesProfile };
@@ -19575,30 +19630,42 @@ function renderJobs(){
       });
     };
     if (!supportsLocalRootPicker()){
+      setSetupReason("unsupported_browser");
       logSetupReason("unsupported_browser", {});
       toast("This browser does not support local root folder access.");
       return { ok:false };
     }
     const handle = await readLocalRootHandle();
-    if (!handle){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; logSetupReason("missing_local_handle", { handle:null }); openOneDriveModal(); toast(profile ? "This computer profile has saved root metadata, but this browser is not authorized. Select/Re-authorize the WJ Cuts root folder shown in the hint, then the file picker will open." : "Create/select a computer profile and choose this computer’s WJ Cuts root folder first."); return { ok:false }; }
+    if (!handle){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; setSetupReason("missing_local_root_folder"); logSetupReason("missing_local_handle", { handle:null }); openOneDriveModal(); toast(profile ? "This computer profile has saved root metadata, but this browser is not authorized. Select/Re-authorize the WJ Cuts root folder shown in the hint, then the file picker will open." : "Create/select a computer profile and choose this computer’s WJ Cuts root folder first."); return { ok:false }; }
     let perm = "prompt"; try { perm = await handle.requestPermission({ mode:"read" }); } catch(_){}
-    if (perm !== "granted"){ logSetupReason("permission_denied", { handle, permission:perm }); openOneDriveModal(); toast("Permission is required before WJ Cuts files can be added or previewed."); return { ok:false }; }
+    if (perm !== "granted"){ setSetupReason("folder_permission_needed"); logSetupReason("permission_denied", { handle, permission:perm }); openOneDriveModal(); toast("Permission is required before WJ Cuts files can be added or previewed."); return { ok:false }; }
     const signature = await computeLocalRootSignature(handle); if (!signature) return { ok:false };
-    let marker = await readWJCutsRootMarker(handle);
-    if (!marker?.rootId){
-      try { marker = await getOrCreateWJCutsRootMarker(handle); }
-      catch (_err){
+    const markerResult = await ensureWJCutsRootMarker(handle);
+    if (!markerResult.ok){
+      pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" };
+      setSetupReason("marker_missing_write_denied");
+      logSetupReason("root marker missing and write permission denied", { handle, permission:perm, signature });
+      openOneDriveModal();
+      toast("Setup opened because: WJ Cuts marker missing and write permission was denied.");
+      return { ok:false };
+    }
+    const marker = markerResult.marker;
+    const expectedRootId = expectedRootIdFromJobs();
+    if (expectedRootId){
+      if (String(marker?.rootId || "") !== expectedRootId){
         pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" };
-        logSetupReason("root marker missing and write permission denied", { handle, permission:perm, signature });
+        setSetupReason("existing_reference_root_mismatch");
+        logSetupReason("existing_reference_root_mismatch", { handle, permission:perm, signature, expectedMatches:false });
         openOneDriveModal();
-        toast("Setup opened because: root marker missing and write permission denied.");
+        toast("This folder does not match files already attached by other computers. Select the same shared root folder.");
         return { ok:false };
       }
+    } else {
+      const match = verifyRootSignatureMatches(signature); if (!match.ok){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; setSetupReason("existing_reference_root_mismatch"); logSetupReason("existing_reference_signature_mismatch", { handle, permission:perm, signature, profileMatches: !(profile?.rootSignature) || profile.rootSignature===signature, expectedMatches:false }); openOneDriveModal(); toast("This folder does not match files already attached by other computers. Select the same shared root folder."); return { ok:false }; }
     }
-    const match = verifyRootSignatureMatches(signature); if (!match.ok){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; logSetupReason("existing_reference_signature_mismatch", { handle, permission:perm, signature, profileMatches: !(profile?.rootSignature) || profile.rootSignature===signature, expectedMatches:false }); openOneDriveModal(); toast("This folder does not match files already attached by other computers. Select the same shared root folder."); return { ok:false }; }
-    if (profile?.rootSignature && profile.rootSignature !== signature){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; logSetupReason("profile_signature_mismatch", { handle, permission:perm, signature, profileMatches:false, expectedMatches:true }); openOneDriveModal(); toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile."); return { ok:false }; }
-    if (profile?.rootId && marker?.rootId && profile.rootId !== marker.rootId){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; logSetupReason("selected root does not match this profile", { handle, permission:perm, signature }); openOneDriveModal(); toast("This file was attached under a different WJ Cuts root. Select the matching root folder or reattach the file."); return { ok:false }; }
-    return { ok:true, handle, signature, profileId, profile, rootId: String(marker?.rootId || "") };
+    if (profile?.rootId && marker?.rootId && profile.rootId !== marker.rootId){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; setSetupReason("profile_root_mismatch"); logSetupReason("selected root does not match this profile", { handle, permission:perm, signature }); openOneDriveModal(); toast("This file was attached under a different WJ Cuts root. Select the matching root folder or reattach the file."); return { ok:false }; }
+    if (!expectedRootId && profile?.rootSignature && profile.rootSignature !== signature){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; setSetupReason("profile_root_mismatch"); logSetupReason("profile_signature_mismatch", { handle, permission:perm, signature, profileMatches:false, expectedMatches:true }); openOneDriveModal(); toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile."); return { ok:false }; }
+    return { ok:true, handle, signature, profileId, profile, rootId: String(marker?.rootId || ""), marker };
   }
   const updatePermissionBanner = async ()=>{
     if (!permissionBanner) return;
@@ -19618,20 +19685,15 @@ function renderJobs(){
       return false;
     }
     try {
-      const handle = await window.showDirectoryPicker({ mode: "read" });
-      const perm = await handle.requestPermission({ mode: "read" });
+      const handle = await window.showDirectoryPicker({ mode: "readwrite" });
+      const perm = await handle.requestPermission({ mode: "readwrite" });
       if (perm !== "granted"){
-        toast("Folder access was not granted.");
+        toast("Write permission is required once to create the WJ Cuts root marker. This lets other computers confirm they selected the same shared folder.");
         return false;
       }
       const signature = await computeLocalRootSignature(handle);
       if (!signature){
         toast("Unable to verify the selected folder.");
-        return false;
-      }
-      const match = verifyRootSignatureMatches(signature);
-      if (!match.ok){
-        toast("This folder does not match files already attached by other computers. Select the same shared root folder.");
         return false;
       }
       const cfg = getSharedConfig();
@@ -19640,18 +19702,31 @@ function renderJobs(){
       const rootHint = String(oneDriveFolderHintInput?.value || cfg.folderHint || "");
       const profileId = getCurrentComputerProfileId(cfg);
       const selectedProfile = (cfg.rootDevices || {})[profileId] || null;
-      if (selectedProfile?.rootSignature && selectedProfile.rootSignature !== signature){
-        toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile.");
+      const markerResult = await ensureWJCutsRootMarker(handle);
+      if (!markerResult.ok){
+        toast("Write permission is required once to create the WJ Cuts root marker. This lets other computers confirm they selected the same shared folder.");
         return false;
       }
-      let marker = await readWJCutsRootMarker(handle);
-      if (!marker?.rootId){
-        try { marker = await getOrCreateWJCutsRootMarker(handle); }
-        catch (_err){ toast("Root marker missing and write permission denied."); return false; }
+      const marker = markerResult.marker;
+      const expectedRootId = expectedRootIdFromJobs();
+      if (expectedRootId){
+        if (String(marker?.rootId || "") !== expectedRootId){
+          toast("This folder does not match files already attached by other computers. Select the same shared root folder.");
+          return false;
+        }
+      } else {
+        const match = verifyRootSignatureMatches(signature);
+        if (!match.ok){
+          toast("This folder does not match files already attached by other computers. Select the same shared root folder.");
+          return false;
+        }
       }
       if (selectedProfile?.rootId && marker?.rootId && selectedProfile.rootId !== marker.rootId){
-        toast("This file was attached under a different WJ Cuts root. Select the matching root folder or reattach the file.");
-        return false;
+        const allowSwitch = window.confirm("This is a different WJ Cuts root. Existing attached files from the old root will show as mismatched until reattached. Continue?");
+        if (!allowSwitch) return false;
+      } else if (!expectedRootId && selectedProfile?.rootSignature && selectedProfile.rootSignature !== signature){
+        const allowSwitch = window.confirm("This is a different WJ Cuts root. Existing attached files from the old root will show as mismatched until reattached. Continue?");
+        if (!allowSwitch) return false;
       }
       await saveLocalRootHandle(handle);
       const verifyHandle = await readLocalRootHandle();

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -19532,13 +19532,32 @@ function renderJobs(){
   };
   async function ensureLocalRootAuthorizedForAttach(targetJobId = ""){
     const cfg = getSharedConfig(); const profileId = getCurrentComputerProfileId(cfg); const profile = cfg.rootDevices?.[profileId] || null;
+    const logSetupReason = (reason, extra = {})=>{
+      if (!window.DEBUG_MODE) return;
+      console.info("[cutting-job-files] opening setup instead of picker", {
+        reason,
+        hasHandle: !!extra.handle,
+        permission: extra.permission || "",
+        signature: extra.signature || "",
+        profileSignature: String(profile?.rootSignature || ""),
+        expectedSignature: expectedRootSignatureFromJobs(),
+        profileMatches: extra.profileMatches ?? null,
+        expectedMatches: extra.expectedMatches ?? null,
+        selectedProfileId: profileId
+      });
+    };
+    if (!supportsLocalRootPicker()){
+      logSetupReason("unsupported_browser", {});
+      toast("This browser does not support local root folder access.");
+      return { ok:false };
+    }
     const handle = await readLocalRootHandle();
-    if (!handle){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; openOneDriveModal(); toast(profile ? "This computer profile has saved root metadata, but this browser is not authorized. Select/Re-authorize the WJ Cuts root folder shown in the hint, then the file picker will open." : "Create/select a computer profile and choose this computer’s WJ Cuts root folder first."); return { ok:false }; }
+    if (!handle){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; logSetupReason("missing_local_handle", { handle:null }); openOneDriveModal(); toast(profile ? "This computer profile has saved root metadata, but this browser is not authorized. Select/Re-authorize the WJ Cuts root folder shown in the hint, then the file picker will open." : "Create/select a computer profile and choose this computer’s WJ Cuts root folder first."); return { ok:false }; }
     let perm = "prompt"; try { perm = await handle.requestPermission({ mode:"read" }); } catch(_){}
-    if (perm !== "granted"){ toast("Permission is required before WJ Cuts files can be added or previewed."); return { ok:false }; }
+    if (perm !== "granted"){ logSetupReason("permission_denied", { handle, permission:perm }); openOneDriveModal(); toast("Permission is required before WJ Cuts files can be added or previewed."); return { ok:false }; }
     const signature = await computeLocalRootSignature(handle); if (!signature) return { ok:false };
-    const match = verifyRootSignatureMatches(signature); if (!match.ok){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; openOneDriveModal(); toast("This folder does not match files already attached by other computers. Select the same shared root folder."); return { ok:false }; }
-    if (profile?.rootSignature && profile.rootSignature !== signature){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; openOneDriveModal(); toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile."); return { ok:false }; }
+    const match = verifyRootSignatureMatches(signature); if (!match.ok){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; logSetupReason("existing_reference_signature_mismatch", { handle, permission:perm, signature, profileMatches: !(profile?.rootSignature) || profile.rootSignature===signature, expectedMatches:false }); openOneDriveModal(); toast("This folder does not match files already attached by other computers. Select the same shared root folder."); return { ok:false }; }
+    if (profile?.rootSignature && profile.rootSignature !== signature){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; logSetupReason("profile_signature_mismatch", { handle, permission:perm, signature, profileMatches:false, expectedMatches:true }); openOneDriveModal(); toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile."); return { ok:false }; }
     return { ok:true, handle, signature, profileId, profile };
   }
   const updatePermissionBanner = async ()=>{

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -1124,6 +1124,20 @@ function triggerFileDownload(file, fileName){
 
 function normalizeOneDriveJobConfig(config){
   const source = config && typeof config === "object" ? config : {};
+  const rawDevices = source.rootDevices && typeof source.rootDevices === "object" ? source.rootDevices : {};
+  const rootDevices = Object.fromEntries(Object.entries(rawDevices).map(([key, value])=>{
+    const row = value && typeof value === "object" ? value : {};
+    const id = String(row.deviceId || key || "");
+    return [id, {
+      deviceId: id,
+      deviceNumber: Number.isFinite(Number(row.deviceNumber)) ? Number(row.deviceNumber) : null,
+      label: typeof row.label === "string" ? row.label : "",
+      folderName: typeof row.folderName === "string" ? row.folderName : "",
+      folderHint: typeof row.folderHint === "string" ? row.folderHint : "",
+      rootSignature: typeof row.rootSignature === "string" ? row.rootSignature : "",
+      lastVerifiedAtISO: typeof row.lastVerifiedAtISO === "string" ? row.lastVerifiedAtISO : ""
+    }];
+  }));
   return {
     enabled: source.enabled === true,
     folderHint: typeof source.folderHint === "string" ? source.folderHint.trim() : "",
@@ -1137,7 +1151,8 @@ function normalizeOneDriveJobConfig(config){
     shareToken: typeof source.shareToken === "string" ? source.shareToken : "",
     accessToken: typeof source.accessToken === "string" ? source.accessToken : "",
     accessTokenExpiresAt: typeof source.accessTokenExpiresAt === "string" ? source.accessTokenExpiresAt : "",
-    lastLinkedAt: typeof source.lastLinkedAt === "string" ? source.lastLinkedAt : ""
+    lastLinkedAt: typeof source.lastLinkedAt === "string" ? source.lastLinkedAt : "",
+    rootDevices
   };
 }
 
@@ -19398,6 +19413,8 @@ function renderJobs(){
   const oneDriveRootStatus = document.querySelector("[data-onedrive-root-status]");
   const oneDriveRootPathStatus = document.querySelector("[data-onedrive-root-path]");
   const oneDriveDeviceStatus = document.querySelector("[data-onedrive-device-status]");
+  const oneDriveCurrentComputer = document.querySelector("[data-onedrive-current-computer]");
+  const oneDriveKnownDevices = document.querySelector("[data-onedrive-known-devices]");
   const oneDriveLibraryAddToJobBtn = document.getElementById("jobOneDriveLibraryAddBtn");
   const oneDriveRootPickerBtn = document.getElementById("jobOneDriveRootPickerBtn");
 
@@ -19412,16 +19429,19 @@ function renderJobs(){
 
   const getWJCutsRootStatus = async ()=>{
     const config = getSharedConfig();
+    const currentDeviceId = String(getLocalDeviceId() || "");
+    const currentDeviceNumber = getLocalDeviceNumber();
+    const currentDeviceMeta = (config.rootDevices && currentDeviceId) ? config.rootDevices[currentDeviceId] : null;
     if (!supportsLocalRootPicker()) return { supported:false, handle:null, hasSavedHandle:false, permission:"unsupported", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Unsupported browser" };
     const handle = await readLocalRootHandle();
-    if (!handle) return { supported:true, handle:null, hasSavedHandle:false, permission:"missing", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Not set" };
+    if (!handle) return { supported:true, handle:null, hasSavedHandle:false, permission:"missing", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Not set", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:"" };
     let permission = "prompt";
     try { permission = typeof handle.queryPermission === "function" ? await handle.queryPermission({ mode:"read" }) : "granted"; } catch(_e){}
-    if (permission !== "granted") return { supported:true, handle, hasSavedHandle:true, permission, config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Permission needed" };
+    if (permission !== "granted") return { supported:true, handle, hasSavedHandle:true, permission, config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Permission needed", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || "") };
     const signature = await computeLocalRootSignature(handle);
     const expectedSignature = expectedRootSignatureFromJobs();
     const signatureMatches = !expectedSignature || !signature ? true : signature === expectedSignature;
-    return { supported:true, handle, hasSavedHandle:true, permission:"granted", config, signature, expectedSignature, signatureMatches, message: signatureMatches ? "Verified" : "Mismatch" };
+    return { supported:true, handle, hasSavedHandle:true, permission:"granted", config, signature, expectedSignature, signatureMatches, message: signatureMatches ? "Verified" : "Mismatch", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || "") };
   };
   const updateSharedConfig = (patch)=>{
     const cfg = getSharedConfig();
@@ -19436,13 +19456,23 @@ function renderJobs(){
     if (oneDriveFolderStatus) oneDriveFolderStatus.textContent = status.permission === "granted" ? (status.signatureMatches ? "Verified" : "Mismatch") : (status.hasSavedHandle ? "Permission needed" : "Not set");
     if (oneDriveLibraryStatus) oneDriveLibraryStatus.textContent = status.permission === "granted" ? "Ready" : "Setup required";
     if (oneDriveRootStatus){
-      oneDriveRootStatus.textContent = cfg.localRootName || "Not set";
+      oneDriveRootStatus.textContent = status.handleName || "Not selected on this computer";
     }
     if (oneDriveRootPathStatus){
-      oneDriveRootPathStatus.textContent = cfg.folderHint || cfg.localRootName || "Not set";
+      oneDriveRootPathStatus.textContent = status.currentDeviceMeta?.folderHint || cfg.folderHint || cfg.localRootName || "Not set";
     }
     if (oneDriveDeviceStatus){
       oneDriveDeviceStatus.textContent = getLocalDeviceId() ? `${getLocalDeviceNumber()} (${getLocalDeviceId()})` : "Unavailable";
+    }
+    if (oneDriveCurrentComputer){
+      const signature = status.signature || status.currentDeviceMeta?.rootSignature || "Not verified";
+      oneDriveCurrentComputer.innerHTML = `Computer ID: ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected root folder: ${status.handleName || "Not selected on this computer"}<br>Root location hint: ${status.currentDeviceMeta?.folderHint || cfg.folderHint || "Not set"}<br>Root signature: ${signature}<br>Status: ${status.message}<br><span class="small muted">The browser cannot reveal the full local Windows path. Use the root location hint to record where this folder is on this computer.</span>`;
+    }
+    if (oneDriveKnownDevices){
+      const rows = Object.values(cfg.rootDevices || {});
+      oneDriveKnownDevices.innerHTML = rows.length
+        ? rows.map(row=>`<tr><td>${escapeHtml(String(row.deviceNumber || "?"))} (${escapeHtml(String(row.deviceId || ""))})${row.deviceId===status.currentDeviceId?" <strong>(This computer)</strong>":""}</td><td>${escapeHtml(row.folderName || "—")}</td><td>${escapeHtml(row.folderHint || "—")}</td><td>${escapeHtml(row.rootSignature || "—")}</td><td>${escapeHtml(row.lastVerifiedAtISO || "—")}</td></tr>`).join("")
+        : `<tr><td colspan="5" class="small muted">No computer roots recorded yet.</td></tr>`;
     }
   };
 
@@ -19472,10 +19502,19 @@ function renderJobs(){
       const verifyHandle = await readLocalRootHandle();
       if (!verifyHandle){ toast("Unable to save root handle on this browser."); return false; }
       const cfg = getSharedConfig();
+      const currentDeviceId = String(getLocalDeviceId() || "");
+      const currentDeviceNumber = getLocalDeviceNumber();
+      const rootHint = String(oneDriveFolderHintInput?.value || cfg.folderHint || "");
+      const rootDevices = { ...(cfg.rootDevices || {}) };
+      if (currentDeviceId){
+        rootDevices[currentDeviceId] = { ...(rootDevices[currentDeviceId] || {}), deviceId: currentDeviceId, deviceNumber: currentDeviceNumber, label: `Computer ${currentDeviceNumber}`, folderName: String(handle.name || ""), folderHint: rootHint, rootSignature: signature, lastVerifiedAtISO: new Date().toISOString() };
+      }
       updateSharedConfig({
         localRootName: String(handle.name || cfg.localRootName || "Configured"),
         localRootSignature: signature,
-        enabled: true
+        folderHint: rootHint,
+        enabled: true,
+        rootDevices
       });
       await updateOneDriveWizardStatus();
       toast("This computer OneDrive root folder saved and verified.");
@@ -19504,6 +19543,7 @@ function renderJobs(){
 
     try {
       const cfg = getSharedConfig();
+      const currentDeviceMeta = cfg.rootDevices?.[String(getLocalDeviceId() || "")];
       const signature = await computeLocalRootSignature(rootHandle);
       if (!signature){
         toast("Unable to verify local OneDrive root folder.");
@@ -19557,7 +19597,7 @@ function renderJobs(){
         enabled: true,
         localDeviceId: getLocalDeviceId(),
         attachedAtISO: new Date().toISOString(),
-        rootLocationHint: String(cfg.folderHint || cfg.localRootName || "")
+        rootLocationHint: String(currentDeviceMeta?.folderHint || cfg.folderHint || cfg.localRootName || "")
       });
       if (!reference) return false;
       const targetId = String(targetJobId || "");
@@ -19618,11 +19658,21 @@ function renderJobs(){
   oneDriveCancelBtns.forEach(btn => btn.addEventListener("click", closeOneDriveModal));
   oneDriveModal?.addEventListener("click", (event)=>{ if (event.target === oneDriveModal) closeOneDriveModal(); });
 
-  oneDriveSaveBtn?.addEventListener("click", ()=>{
+  oneDriveSaveBtn?.addEventListener("click", async ()=>{
     const cfg = getSharedConfig();
+    const currentDeviceId = String(getLocalDeviceId() || "");
+    const currentDeviceNumber = getLocalDeviceNumber();
+    const nextHint = String(oneDriveFolderHintInput?.value || cfg.folderHint || "");
+    const existing = cfg.rootDevices || {};
+    const rootStatus = await getWJCutsRootStatus();
+    const row = existing[currentDeviceId] || { deviceId: currentDeviceId, deviceNumber: currentDeviceNumber, label: `Computer ${currentDeviceNumber}` };
     const next = updateSharedConfig({
       enabled: !!oneDriveEnabledInput?.checked,
-      folderHint: String(oneDriveFolderHintInput?.value || cfg.folderHint || "")
+      folderHint: nextHint,
+      rootDevices: {
+        ...existing,
+        ...(currentDeviceId ? { [currentDeviceId]: { ...row, folderHint: nextHint, folderName: row.folderName || rootStatus.handleName || "", rootSignature: row.rootSignature || rootStatus.signature || "", lastVerifiedAtISO: rootStatus.message === "Verified" ? new Date().toISOString() : (row.lastVerifiedAtISO || "") } } : {})
+      }
     });
     closeOneDriveModal();
     toast(next.enabled ? "OneDrive root setup saved for this computer" : "OneDrive setup saved (disabled)");

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -19461,16 +19461,19 @@ function renderJobs(){
     const currentDeviceNumber = getLocalDeviceNumber();
     const profileId = getCurrentComputerProfileId(config);
     const currentDeviceMeta = (config.rootDevices && profileId) ? config.rootDevices[profileId] : null;
-    if (!supportsLocalRootPicker()) return { supported:false, handle:null, hasSavedHandle:false, permission:"unsupported", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Unsupported browser" };
+    if (!supportsLocalRootPicker()) return { supported:false, handle:null, hasSavedHandle:false, permission:"unsupported", config, signature:"", profileSignature:"", profileMatches:true, expectedSignature: expectedRootSignatureFromJobs(), expectedMatches:true, signatureMatches:true, message:"Unsupported browser" };
     const handle = await readLocalRootHandle();
-    if (!handle) return { supported:true, handle:null, hasSavedHandle:false, permission:"missing", config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message: currentDeviceMeta ? "Root metadata exists for this computer profile, but this browser is not authorized yet. Re-authorize the folder shown in the hint." : "Not set", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:"", profileId };
+    if (!handle) return { supported:true, handle:null, hasSavedHandle:false, permission:"missing", config, signature:"", profileSignature:String(currentDeviceMeta?.rootSignature || "").trim(), profileMatches:true, expectedSignature: expectedRootSignatureFromJobs(), expectedMatches:true, signatureMatches:true, message: currentDeviceMeta ? "Root metadata exists for this computer profile, but this browser is not authorized yet. Re-authorize the folder shown in the hint." : "Not set", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:"", profileId };
     let permission = "prompt";
     try { permission = typeof handle.queryPermission === "function" ? await handle.queryPermission({ mode:"read" }) : "granted"; } catch(_e){}
-    if (permission !== "granted") return { supported:true, handle, hasSavedHandle:true, permission, config, signature:"", expectedSignature: expectedRootSignatureFromJobs(), signatureMatches:true, message:"Folder permission is required for WJ Cuts file previews and Open actions.", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || ""), profileId };
+    if (permission !== "granted") return { supported:true, handle, hasSavedHandle:true, permission, config, signature:"", profileSignature:String(currentDeviceMeta?.rootSignature || "").trim(), profileMatches:true, expectedSignature: expectedRootSignatureFromJobs(), expectedMatches:true, signatureMatches:true, message:"Folder permission is required for WJ Cuts file previews and Open actions.", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || ""), profileId };
     const signature = await computeLocalRootSignature(handle);
+    const profileSignature = String(currentDeviceMeta?.rootSignature || "").trim();
     const expectedSignature = expectedRootSignatureFromJobs();
-    const signatureMatches = !expectedSignature || !signature ? true : signature === expectedSignature;
-    return { supported:true, handle, hasSavedHandle:true, permission:"granted", config, signature, expectedSignature, signatureMatches, message: signatureMatches ? "Verified" : "Mismatch", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || ""), profileId };
+    const profileMatches = !profileSignature || !signature || profileSignature === signature;
+    const expectedMatches = !expectedSignature || !signature || expectedSignature === signature;
+    const signatureMatches = profileMatches && expectedMatches;
+    return { supported:true, handle, hasSavedHandle:true, permission:"granted", config, signature, profileSignature, profileMatches, expectedSignature, expectedMatches, signatureMatches, message: signatureMatches ? "Verified" : "Mismatch", currentDeviceId, currentDeviceNumber, currentDeviceMeta, handleName:String(handle?.name || ""), profileId };
   };
   const updateSharedConfig = (patch)=>{
     const cfg = getSharedConfig();
@@ -19508,15 +19511,17 @@ function renderJobs(){
       const selectedProfile = (cfg.rootDevices || {})[getCurrentComputerProfileId(cfg) || ""] || null;
       const signature = status.signature || selectedProfile?.rootSignature || "Not verified";
       const authState = status.permission === "granted" && status.signatureMatches ? "Authorized" : (status.hasSavedHandle ? "Needs permission" : "Not authorized");
-      oneDriveCurrentComputer.innerHTML = `Browser/device ID: ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected computer profile: ${escapeHtml(selectedProfile?.label || "Not selected")}<br>Local root authorization: ${authState}<br>Selected root folder: ${status.handleName || "Not selected in this browser"}<br>Root location hint: ${selectedProfile?.folderHint || cfg.folderHint || "Not set"}<br>Root signature: ${signature}<br>Status: ${status.message}`;
+      oneDriveCurrentComputer.innerHTML = `Browser/device ID: ${status.currentDeviceNumber || "?"} (${status.currentDeviceId || "Unavailable"})<br>Selected computer profile: ${escapeHtml(selectedProfile?.label || "Not selected")}<br>Local root authorization: ${authState}<br>Selected root folder: ${status.handleName || "Not selected in this browser"}<br>Root location hint: ${selectedProfile?.folderHint || cfg.folderHint || "Not set"}<br>Root signature: ${signature}<br>Root profile match: ${status.profileSignature ? (status.profileMatches ? "Match" : "Mismatch") : "Not recorded"}<br>Existing file root match: ${status.expectedSignature ? (status.expectedMatches ? "Match" : "Mismatch") : "No existing references"}<br>Status: ${status.message}`;
     }
     if (oneDriveStatusInline){
       const hint = (status.currentDeviceMeta?.folderHint || cfg.folderHint || status.handleName || "").trim();
-      oneDriveStatusInline.textContent = status.permission === "granted" && status.signature && status.signatureMatches
+      oneDriveStatusInline.textContent = status.permission === "granted" && status.signature && status.profileMatches && status.expectedMatches
         ? `WJ Cuts root authorized${hint ? ` · ${hint}` : ""}`
-        : ((status.currentDeviceMeta || cfg.folderHint || cfg.localRootName)
+        : (status.permission === "granted" && status.signature && !status.signatureMatches
+          ? "WJ Cuts root mismatch · re-authorize"
+          : ((status.currentDeviceMeta || cfg.folderHint || cfg.localRootName)
           ? `WJ Cuts root needs permission${hint ? ` · ${hint}` : ""}`
-          : "WJ Cuts root not set");
+          : "WJ Cuts root not set"));
     }
     if (oneDriveKnownDevices){
       const rows = Object.values(cfg.rootDevices || {});
@@ -19532,8 +19537,8 @@ function renderJobs(){
     let perm = "prompt"; try { perm = await handle.requestPermission({ mode:"read" }); } catch(_){}
     if (perm !== "granted"){ toast("Permission is required before WJ Cuts files can be added or previewed."); return { ok:false }; }
     const signature = await computeLocalRootSignature(handle); if (!signature) return { ok:false };
-    if (profile?.rootSignature && profile.rootSignature !== signature){ toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile."); return { ok:false }; }
-    const match = verifyRootSignatureMatches(signature); if (!match.ok){ toast("This folder does not match files already attached by other computers. Select the same shared root folder."); return { ok:false }; }
+    const match = verifyRootSignatureMatches(signature); if (!match.ok){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; openOneDriveModal(); toast("This folder does not match files already attached by other computers. Select the same shared root folder."); return { ok:false }; }
+    if (profile?.rootSignature && profile.rootSignature !== signature){ pendingAttachTarget = targetJobId ? { mode:"job", jobId:String(targetJobId) } : { mode:"new" }; openOneDriveModal(); toast("This folder does not match the saved root for this computer profile. Select the matching WJ Cuts root or create a new computer profile."); return { ok:false }; }
     return { ok:true, handle, signature, profileId, profile };
   }
   const updatePermissionBanner = async ()=>{
@@ -19541,7 +19546,7 @@ function renderJobs(){
     const hasRefs = [...(Array.isArray(cuttingJobs)?cuttingJobs:[]), ...(Array.isArray(completedCuttingJobs)?completedCuttingJobs:[])].some(j => Array.isArray(j?.files) && j.files.some(f=>f?.source==="wj_cuts_reference"));
     if (!hasRefs){ permissionBanner.hidden = true; return; }
     const status = await getWJCutsRootStatus();
-    const blocked = !status.hasSavedHandle || status.permission !== "granted";
+    const blocked = !status.hasSavedHandle || status.permission !== "granted" || !status.signatureMatches;
     permissionBanner.hidden = !blocked;
     if (permissionBannerText && blocked){
       permissionBannerText.textContent = "WJ Cuts file references need folder permission before previews/opening files will work. Grant access to this computer’s WJ Cuts root folder.";

--- a/js/views.js
+++ b/js/views.js
@@ -2699,10 +2699,7 @@ function viewJobs(){
   const oneDriveLibrary = (typeof window.getOneDriveJobLibrary === "function")
     ? window.getOneDriveJobLibrary()
     : [];
-  const oneDriveReady = !!(oneDriveConfig && oneDriveConfig.enabled && oneDriveConfig.localRootSignature);
-  const oneDriveStatusLabel = oneDriveReady
-    ? `OneDrive root ready${oneDriveConfig.folderHint ? ` · ${oneDriveConfig.folderHint}` : ""}`
-    : "OneDrive root not set on this computer";
+  const oneDriveStatusLabel = "WJ Cuts root not set";
   const defaultJobDateISO = (() => {
     const now = new Date();
     const local = new Date(now.getTime() - now.getTimezoneOffset() * 60000);
@@ -4665,7 +4662,7 @@ function viewJobs(){
           <div class="job-note-modal-body">
             <p id="jobOneDriveModalDescription" class="job-note-modal-description small muted">Attach files from this computer's synced OneDrive root folder. Each computer can map a different local path to the same shared folder and the app will verify folder identity.</p>
             <ol class="job-onedrive-steps small">
-              <li><strong>Step 1:</strong> Click <strong>Set this computer root folder</strong> and pick your synced shared OneDrive folder.</li>
+              <li><strong>Step 1:</strong> Click <strong>Select / re-authorize this computer root folder</strong> and pick your synced shared OneDrive folder.</li>
               <li><strong>Step 2:</strong> Save setup for this computer only (it does not copy to other computers).</li>
               <li><strong>Step 3:</strong> Use <strong>Add from this computer OneDrive folder</strong> when attaching files.</li>
             </ol>
@@ -4693,12 +4690,12 @@ function viewJobs(){
             <div class="job-onedrive-known">
               <div class="small"><strong>Known computer root folders</strong></div>
               <table class="small">
-                <thead><tr><th>Computer</th><th>Folder name</th><th>Root location hint</th><th>Root signature</th><th>Last verified</th></tr></thead>
+                <thead><tr><th>Computer profile</th><th>Folder name</th><th>Root location hint</th><th>Root signature</th><th>Last verified</th><th>Last browser/device</th></tr></thead>
                 <tbody data-onedrive-known-devices></tbody>
               </table>
             </div>
                         <div class="job-onedrive-sync-actions">
-              <button type="button" class="job-note-modal-secondary" id="jobOneDriveRootPickerBtn">Set this computer root folder</button>
+              <button type="button" class="job-note-modal-secondary" id="jobOneDriveRootPickerBtn">Select / re-authorize this computer root folder</button>
             </div>
             <label class="job-edit-note">Folder label (optional)
               <input type="text" id="jobOneDriveFolderHint" placeholder="Shop drawings" value="${esc(oneDriveConfig.folderHint || "")}">

--- a/js/views.js
+++ b/js/views.js
@@ -4656,11 +4656,11 @@ function viewJobs(){
       <div class="job-note-modal-backdrop" id="jobOneDriveModal" hidden>
         <div class="job-note-modal" role="dialog" aria-modal="true" aria-labelledby="jobOneDriveModalTitle" aria-describedby="jobOneDriveModalDescription">
           <div class="job-note-modal-header">
-            <h4 id="jobOneDriveModalTitle">OneDrive shared-folder setup</h4>
+            <h4 id="jobOneDriveModalTitle">WJ Cuts Root Folder Setup</h4>
             <button type="button" class="job-note-modal-close" data-onedrive-cancel aria-label="Close OneDrive setup">×</button>
           </div>
           <div class="job-note-modal-body">
-            <p id="jobOneDriveModalDescription" class="job-note-modal-description small muted">Attach files from this computer's synced OneDrive root folder. Each computer can map a different local path to the same shared folder and the app will verify folder identity.</p>
+            <p id="jobOneDriveModalDescription" class="job-note-modal-description small muted">Choose the local OneDrive-synced WJ Cuts folder for this browser. The app saves file references, not file contents.</p>
             <ol class="job-onedrive-steps small">
               <li><strong>Step 1:</strong> Click <strong>Select / re-authorize this computer root folder</strong> and pick your synced shared OneDrive folder.</li>
               <li><strong>Step 2:</strong> Save setup for this computer only (it does not copy to other computers).</li>
@@ -4684,7 +4684,7 @@ function viewJobs(){
               </label>
               <div class="job-onedrive-sync-actions">
                 <button type="button" class="job-note-modal-secondary" id="jobOneDriveProfileUseBtn">Use selected profile</button>
-                <button type="button" class="job-note-modal-secondary" id="jobOneDriveProfileSaveBtn">Save profile label</button>
+                <button type="button" class="job-note-modal-secondary" id="jobOneDriveProfileSaveBtn">Save PC name / hint</button>
               </div>
             </div>
             <div class="job-onedrive-known">

--- a/js/views.js
+++ b/js/views.js
@@ -3981,16 +3981,17 @@ function viewJobs(){
                   const href = f.dataUrl || f.url || f.externalUrl || f.downloadUrl || f.oneDriveUrl || "";
                   const usableLink = !!href && !/^data:(image|application)\//i.test(String(href || "")) && /^https?:\/\//i.test(String(href || ""));
                   const isRef = f?.source === "wj_cuts_reference" && !!f?.relativePath;
-                  const expectedPath = isRef ? `WJ Cuts\\${String(f.relativePath || "").replace(/^\\+/, "").replace(/\//g, "\\")}` : "";
+                  const expectedPath = isRef ? `${String(f.relativePath || "").replace(/^\\+/, "").replace(/\//g, "\\")}` : "";
                   const link = isRef
                     ? `<button type="button" class="link" data-open-local-file data-job-id="${job.id}" data-file-index="${idx}">${safeName}</button>`
                     : (usableLink ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : `${safeName} <span class="small muted">— File metadata saved only — original file content is not stored.</span>`);
                   const sourceTag = isRef
                     ? `<span class="job-file-source-badge">Reference folder</span>`
                     : (f?.source === "onedrive" ? `<span class="job-file-source-badge">OneDrive</span>` : "");
-                  const pathAction = expectedPath ? `<button type="button" class="link" data-preview-path-btn data-preview-expected-path="${esc(expectedPath)}" data-preview-root-location="${esc(f?.rootLocationHint || 'WJ Cuts')}">Show path</button>` : "";
+                  const rootLabel = `WJ Cuts / ${String(f?.computerProfileId || "selected profile")}`;
+                  const pathAction = expectedPath ? `<button type="button" class="link" data-preview-path-btn data-preview-expected-path="${esc(expectedPath)}" data-preview-root-location="${esc(rootLabel)}" data-preview-root-id="${esc(String(f?.rootId || 'Not verified'))}" data-preview-root-hint="${esc(String(f?.rootLocationHint || ''))}">Show path</button>` : "";
                   const linkAction = !isRef ? `<button type="button" class="link" data-edit-file-link="${job.id}" data-file-index="${idx}">Link</button>` : "";
-                  return `<li>${link} ${sourceTag} ${expectedPath ? `<span class="small muted">— ${esc(expectedPath)}</span>` : ""} ${pathAction} ${linkAction} <button type="button" class="link" data-remove-file="${job.id}" data-file-index="${idx}">Remove</button></li>`;
+                  return `<li>${link} ${sourceTag} ${expectedPath ? `<span class="small muted">— Root: ${esc(rootLabel)} · Relative path: ${esc(expectedPath)} · Root ID: ${esc(String(f?.rootId || "Not verified").slice(0,16))}</span>` : ""} ${pathAction} ${linkAction} <button type="button" class="link" data-remove-file="${job.id}" data-file-index="${idx}">Remove</button></li>`;
                 }).join("") : `<li class="muted">No files attached</li>`}
               </ul>
             </div>
@@ -4415,16 +4416,17 @@ function viewJobs(){
                     const href = f.dataUrl || f.url || f.externalUrl || f.downloadUrl || f.oneDriveUrl || "";
                     const usableLink = !!href && !/^data:(image|application)\//i.test(String(href || "")) && /^https?:\/\//i.test(String(href || ""));
                     const isRef = f?.source === "wj_cuts_reference" && !!f?.relativePath;
-                    const expectedPath = isRef ? `WJ Cuts\\${String(f.relativePath || "").replace(/^\\+/, "").replace(/\//g, "\\")}` : "";
+                    const expectedPath = isRef ? `${String(f.relativePath || "").replace(/^\\+/, "").replace(/\//g, "\\")}` : "";
                     const link = isRef
                       ? `<button type="button" class="link" data-open-local-file data-job-id="${j.id}" data-file-index="${idx}">${safeName}</button>`
                       : (usableLink ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : `${safeName} <span class="small muted">— File metadata saved only — original file content is not stored.</span>`);
                     const sourceTag = isRef
                       ? `<span class="job-file-source-badge">Reference folder</span>`
                       : (f?.source === "onedrive" ? `<span class="job-file-source-badge">OneDrive</span>` : "");
-                    const pathAction = expectedPath ? `<button type="button" class="link" data-preview-path-btn data-preview-expected-path="${esc(expectedPath)}" data-preview-root-location="${esc(f?.rootLocationHint || 'WJ Cuts')}">Show path</button>` : "";
+                    const rootLabel = `WJ Cuts / ${String(f?.computerProfileId || "selected profile")}`;
+                    const pathAction = expectedPath ? `<button type="button" class="link" data-preview-path-btn data-preview-expected-path="${esc(expectedPath)}" data-preview-root-location="${esc(rootLabel)}" data-preview-root-id="${esc(String(f?.rootId || 'Not verified'))}" data-preview-root-hint="${esc(String(f?.rootLocationHint || ''))}">Show path</button>` : "";
                     const linkAction = !isRef ? `<button type="button" class="link" data-edit-file-link="${j.id}" data-file-index="${idx}">Link</button>` : "";
-                    return `<li>${link} ${sourceTag} ${expectedPath ? `<span class="small muted">— ${esc(expectedPath)}</span>` : ""} ${pathAction} ${linkAction} <button type="button" class="link" data-remove-file="${j.id}" data-file-index="${idx}">Remove</button></li>`;
+                    return `<li>${link} ${sourceTag} ${expectedPath ? `<span class="small muted">— Root: ${esc(rootLabel)} · Relative path: ${esc(expectedPath)} · Root ID: ${esc(String(f?.rootId || "Not verified").slice(0,16))}</span>` : ""} ${pathAction} ${linkAction} <button type="button" class="link" data-remove-file="${j.id}" data-file-index="${idx}">Remove</button></li>`;
                   }).join("") : `<li class=\"muted\">No files attached</li>`}
                 </ul>
               </div>

--- a/js/views.js
+++ b/js/views.js
@@ -4448,6 +4448,11 @@ function viewJobs(){
     </div>
 
     ${avgBanner}
+    <div class="job-onedrive-permission-banner small" data-wjcuts-permission-banner hidden>
+      <span data-wjcuts-permission-text>WJ Cuts file references need folder permission before previews/opening files will work. Grant access to this computer’s WJ Cuts root folder.</span>
+      <button type="button" data-wjcuts-grant-permission>Grant permission</button>
+      <button type="button" data-wjcuts-open-setup>Open WJ Cuts setup</button>
+    </div>
 
     <div class="dashboard-layout job-layout" id="jobLayout">
       <div class="dashboard-window" data-job-window="categories">
@@ -4673,6 +4678,18 @@ function viewJobs(){
               <div>Indexed files: <span data-onedrive-library-status>0</span></div>
             </div>
             <div class="job-onedrive-current small muted" data-onedrive-current-computer></div>
+            <div class="job-onedrive-profile-controls">
+              <label class="job-edit-note">Selected computer profile
+                <select id="jobOneDriveComputerProfile"></select>
+              </label>
+              <label class="job-edit-note">New/rename profile label
+                <input type="text" id="jobOneDriveProfileLabel" placeholder="Shop PC">
+              </label>
+              <div class="job-onedrive-sync-actions">
+                <button type="button" class="job-note-modal-secondary" id="jobOneDriveProfileUseBtn">Use selected profile</button>
+                <button type="button" class="job-note-modal-secondary" id="jobOneDriveProfileSaveBtn">Save profile label</button>
+              </div>
+            </div>
             <div class="job-onedrive-known">
               <div class="small"><strong>Known computer root folders</strong></div>
               <table class="small">
@@ -4686,6 +4703,7 @@ function viewJobs(){
             <label class="job-edit-note">Folder label (optional)
               <input type="text" id="jobOneDriveFolderHint" placeholder="Shop drawings" value="${esc(oneDriveConfig.folderHint || "")}">
             </label>
+            <div class="small muted">Manual path hint only — the browser cannot use this path automatically.</div>
             <label class="job-edit-note">
               <input type="checkbox" id="jobOneDriveEnabled" ${oneDriveConfig.enabled ? "checked" : ""}> Enable OneDrive linking for cutting jobs
             </label>

--- a/js/views.js
+++ b/js/views.js
@@ -2695,7 +2695,7 @@ function viewJobs(){
   };
   const oneDriveConfig = (typeof window.getOneDriveJobConfig === "function")
     ? window.getOneDriveJobConfig()
-    : { enabled: false, rootDriveId: "", rootFolderItemId: "", rootName: "", rootWebUrl: "", folderHint: "", localRootName: "", localRootSignature: "", shareToken: "", accessToken: "", accessTokenExpiresAt: "", lastLinkedAt: "" };
+    : { enabled: false, rootDriveId: "", rootFolderItemId: "", rootName: "", rootWebUrl: "", folderHint: "", localRootName: "", localRootSignature: "", shareToken: "", accessToken: "", accessTokenExpiresAt: "", lastLinkedAt: "", rootDevices: {} };
   const oneDriveLibrary = (typeof window.getOneDriveJobLibrary === "function")
     ? window.getOneDriveJobLibrary()
     : [];
@@ -4671,6 +4671,14 @@ function viewJobs(){
               <div>Root path hint: <span data-onedrive-root-path>Not set</span></div>
               <div>This computer ID: <span data-onedrive-device-status>Not set</span></div>
               <div>Indexed files: <span data-onedrive-library-status>0</span></div>
+            </div>
+            <div class="job-onedrive-current small muted" data-onedrive-current-computer></div>
+            <div class="job-onedrive-known">
+              <div class="small"><strong>Known computer root folders</strong></div>
+              <table class="small">
+                <thead><tr><th>Computer</th><th>Folder name</th><th>Root location hint</th><th>Root signature</th><th>Last verified</th></tr></thead>
+                <tbody data-onedrive-known-devices></tbody>
+              </table>
             </div>
                         <div class="job-onedrive-sync-actions">
               <button type="button" class="job-note-modal-secondary" id="jobOneDriveRootPickerBtn">Set this computer root folder</button>

--- a/js/views.js
+++ b/js/views.js
@@ -4690,7 +4690,7 @@ function viewJobs(){
             <div class="job-onedrive-known">
               <div class="small"><strong>Known computer root folders</strong></div>
               <table class="small">
-                <thead><tr><th>Computer profile</th><th>Folder name</th><th>Root location hint</th><th>Root signature</th><th>Last verified</th><th>Last browser/device</th></tr></thead>
+                <thead><tr><th>PC/profile</th><th>Root folder</th><th>Root hint</th><th>Root ID</th><th>Last verified</th><th>Last browser/device</th></tr></thead>
                 <tbody data-onedrive-known-devices></tbody>
               </table>
             </div>

--- a/js/views.js
+++ b/js/views.js
@@ -2907,21 +2907,23 @@ function viewJobs(){
     const previewUrl = String(file?.previewUrl || "");
     const ext = extractFileExtension(name);
     const source = String(file?.source || "");
-    const rootLocation = String(file?.rootLocationHint || "");
+    const rootLocation = String(file?.computerProfileId || file?.rootLocationHint || "");
+    const rootId = String(file?.rootId || "");
+    const rootHint = String(file?.rootLocationHint || "");
     const savedPreview = file && typeof file === "object" ? file.preview : null;
     if (savedPreview && typeof savedPreview === "object"){
       const mode = savedPreview.mode === "image" ? "image" : "message";
       const content = String(savedPreview.content || "").trim();
-      if (content) return { name, href, mode, content, expectedPath, rootLocation, source };
+      if (content) return { name, href, mode, content, expectedPath, rootLocation, source, rootId, rootHint };
     }
-    if (/^data:image\//i.test(previewUrl) || /^https?:\/\//i.test(previewUrl)) return { name, href: href || previewUrl, mode: "image", content: previewUrl, expectedPath, rootLocation, source };
+    if (/^data:image\//i.test(previewUrl) || /^https?:\/\//i.test(previewUrl)) return { name, href: href || previewUrl, mode: "image", content: previewUrl, expectedPath, rootLocation, source, rootId, rootHint };
     if (!href){
-      if (source === "wj_cuts_reference") return { name, href: "", mode: "message", content: "Preview unavailable: this file is stored as a WJ Cuts reference path only. Select/verify your WJ Cuts root folder on this device, then reopen this job.", expectedPath, rootLocation, source };
+      if (source === "wj_cuts_reference") return { name, href: "", mode: "message", content: "Preview unavailable: this file is stored as a WJ Cuts reference path only. Select/verify your WJ Cuts root folder on this device, then reopen this job.", expectedPath, rootLocation, source, rootId, rootHint };
       if (source === "onedrive") return { name, href: "", mode: "message", content: "Preview unavailable: OneDrive link metadata is incomplete. Relink this file from OneDrive so preview content can load.", expectedPath, rootLocation, source };
       if ([".dxf", ".ord", ".omx"].includes(ext)) return { name, href: "", mode: "message", content: "Preview unavailable: no file content URL is saved for this CAD file. Re-attach from Reference Folder or add a direct OneDrive URL.", expectedPath, rootLocation, source };
       return { name, href: "", mode: "message", content: "Preview unavailable: no file content was saved for this attachment.", expectedPath, rootLocation, source };
     }
-    if (ext === ".svg") return { name, href, mode: "image", content: href, expectedPath, rootLocation, source };
+    if (ext === ".svg") return { name, href, mode: "image", content: href, expectedPath, rootLocation, source, rootId, rootHint };
     if (/^data:image\//i.test(href)) return { name, href, mode: "image", content: href, expectedPath, rootLocation, source };
     if (/^https?:\/\//i.test(href) && [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"].includes(ext)){
       return { name, href, mode: "image", content: href, expectedPath, rootLocation, source };
@@ -2933,7 +2935,7 @@ function viewJobs(){
         ? { name, href, mode: "image", content: cadSvg, expectedPath, rootLocation, source }
         : { name, href, mode: "message", content: "2D preview unavailable. Add a OneDrive direct file URL or re-upload to refresh preview.", expectedPath, rootLocation, source };
     }
-    return { name, href, mode: "message", content: "Preview unavailable for this file type.", expectedPath, rootLocation, source };
+    return { name, href, mode: "message", content: "Preview unavailable for this file type.", expectedPath, rootLocation, source, rootId, rootHint };
   };
   const buildFileCellMarkup = (jobId, files)=>{
     const previews = (Array.isArray(files) ? files : []).map(filePreviewModel);
@@ -2943,7 +2945,7 @@ function viewJobs(){
     return `
       <div class="job-file-preview" data-file-preview data-file-preview-job="${esc(jobId)}">
         ${previews.length > 1
-          ? `<label class="sr-only" for="${selectId}">Choose file preview</label><select id="${selectId}" class="job-file-preview-select" data-file-preview-select="${esc(jobId)}">${previews.map((f, idx)=>`<option value="${idx}" data-preview-index="${idx}" data-preview-source="${esc(f.source || "")}" data-preview-name="${esc(f.name)}" data-preview-mode="${esc(f.mode)}" data-preview-content="${esc(f.content)}" data-preview-href="${esc(f.href || "")}" data-preview-expected-path="${esc(f.expectedPath || "")}" data-preview-root-location="${esc(f.rootLocation || "")}">${esc(f.name)}</option>`).join("")}</select>`
+          ? `<label class="sr-only" for="${selectId}">Choose file preview</label><select id="${selectId}" class="job-file-preview-select" data-file-preview-select="${esc(jobId)}">${previews.map((f, idx)=>`<option value="${idx}" data-preview-index="${idx}" data-preview-source="${esc(f.source || "")}" data-preview-name="${esc(f.name)}" data-preview-mode="${esc(f.mode)}" data-preview-content="${esc(f.content)}" data-preview-href="${esc(f.href || "")}" data-preview-expected-path="${esc(f.expectedPath || "")}" data-preview-root-location="${esc(f.rootLocation || "")}" data-preview-root-id="${esc(f.rootId || "")}" data-preview-root-hint="${esc(f.rootHint || "")}">${esc(f.name)}</option>`).join("")}</select>`
           : ""}
         <div class="job-file-preview-panes" data-file-preview-panes>
           <div class="job-file-preview-pane" data-file-preview-pane>
@@ -2953,7 +2955,7 @@ function viewJobs(){
               <span class="job-file-preview-message small muted" data-preview-message ${first.mode === "message" ? "" : "hidden"}>${first.mode === "message" ? esc(first.content) : ""}</span>
             </div>
             <div class="job-file-preview-actions">
-              <button type="button" class="job-file-preview-link" data-preview-path-btn data-preview-expected-path="${esc(first.expectedPath || "")}" data-preview-root-location="${esc(first.rootLocation || "")}" ${first.expectedPath ? "" : "hidden"}>Show path</button>
+              <button type="button" class="job-file-preview-link" data-preview-path-btn data-preview-expected-path="${esc(first.expectedPath || "")}" data-preview-root-location="${esc(first.rootLocation || "")}" data-preview-root-id="${esc(first.rootId || "")}" data-preview-root-hint="${esc(first.rootHint || "")}" ${first.expectedPath ? "" : "hidden"}>Show path</button>
               <button type="button" class="job-file-preview-link" data-preview-open-local data-open-local-file data-job-id="${esc(jobId)}" data-file-index="0" ${first.source === "wj_cuts_reference" ? "" : "hidden"}>Open</button>
               <a class="job-file-preview-link" data-preview-open-url href="${esc(first.href || "")}" target="_blank" rel="noopener" ${(first.source !== "wj_cuts_reference" && first.href) ? "" : "hidden"}>Open</a>
             </div>

--- a/js/views.js
+++ b/js/views.js
@@ -2904,39 +2904,49 @@ function viewJobs(){
   const filePreviewModel = (file)=>{
     const name = String(file?.name || "Attached file");
     const href = String(file?.dataUrl || file?.url || "");
+    const expectedPath = file?.source === "wj_cuts_reference" && file?.relativePath
+      ? `${String(file?.rootPathStart || "WJ Cuts")}\\${String(file.relativePath || "").replace(/\//g, "\\")}`
+      : "";
     const previewUrl = String(file?.previewUrl || "");
     const ext = extractFileExtension(name);
+    const source = String(file?.source || "");
+    const rootLocation = String(file?.rootLocationHint || "");
     const savedPreview = file && typeof file === "object" ? file.preview : null;
     if (savedPreview && typeof savedPreview === "object"){
       const mode = savedPreview.mode === "image" ? "image" : "message";
       const content = String(savedPreview.content || "").trim();
-      if (content) return { name, href, mode, content };
+      if (content) return { name, href, mode, content, expectedPath, rootLocation, source };
     }
-    if (/^data:image\//i.test(previewUrl) || /^https?:\/\//i.test(previewUrl)) return { name, href: href || previewUrl, mode: "image", content: previewUrl };
-    if (!href) return { name, href: "", mode: "message", content: "Preview unavailable" };
-    if (ext === ".svg") return { name, href, mode: "image", content: href };
-    if (/^data:image\//i.test(href)) return { name, href, mode: "image", content: href };
+    if (/^data:image\//i.test(previewUrl) || /^https?:\/\//i.test(previewUrl)) return { name, href: href || previewUrl, mode: "image", content: previewUrl, expectedPath, rootLocation, source };
+    if (!href){
+      if (source === "wj_cuts_reference") return { name, href: "", mode: "message", content: "Preview unavailable: this file is stored as a WJ Cuts reference path only. Select/verify your WJ Cuts root folder on this device, then reopen this job.", expectedPath, rootLocation, source };
+      if (source === "onedrive") return { name, href: "", mode: "message", content: "Preview unavailable: OneDrive link metadata is incomplete. Relink this file from OneDrive so preview content can load.", expectedPath, rootLocation, source };
+      if ([".dxf", ".ord", ".omx"].includes(ext)) return { name, href: "", mode: "message", content: "Preview unavailable: no file content URL is saved for this CAD file. Re-attach from Reference Folder or add a direct OneDrive URL.", expectedPath, rootLocation, source };
+      return { name, href: "", mode: "message", content: "Preview unavailable: no file content was saved for this attachment.", expectedPath, rootLocation, source };
+    }
+    if (ext === ".svg") return { name, href, mode: "image", content: href, expectedPath, rootLocation, source };
+    if (/^data:image\//i.test(href)) return { name, href, mode: "image", content: href, expectedPath, rootLocation, source };
     if (/^https?:\/\//i.test(href) && [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"].includes(ext)){
-      return { name, href, mode: "image", content: href };
+      return { name, href, mode: "image", content: href, expectedPath, rootLocation, source };
     }
     if ([".dxf", ".ord", ".omx"].includes(ext)) {
       const text = decodeDataUrlText(href);
       const cadSvg = text ? renderCadToSvgDataUrl(text) : "";
       return cadSvg
-        ? { name, href, mode: "image", content: cadSvg }
-        : { name, href, mode: "message", content: "2D preview unavailable. Add a OneDrive direct file URL or re-upload to refresh preview." };
+        ? { name, href, mode: "image", content: cadSvg, expectedPath, rootLocation, source }
+        : { name, href, mode: "message", content: "2D preview unavailable. Add a OneDrive direct file URL or re-upload to refresh preview.", expectedPath, rootLocation, source };
     }
-    return { name, href, mode: "message", content: "Preview unavailable for this file type." };
+    return { name, href, mode: "message", content: "Preview unavailable for this file type.", expectedPath, rootLocation, source };
   };
   const buildFileCellMarkup = (jobId, files)=>{
     const previews = (Array.isArray(files) ? files : []).map(filePreviewModel);
     if (!previews.length) return '<div class="job-file-preview-empty small muted">No files attached</div>';
-    const first = previews[0] || { name: "Attached file", mode: "message", content: "Preview unavailable", href: "" };
+    const first = previews[0] || { name: "Attached file", mode: "message", content: "Preview unavailable", href: "", expectedPath: "", rootLocation: "" };
     const selectId = `jobFileSelect_${esc(jobId)}`;
     return `
       <div class="job-file-preview" data-file-preview data-file-preview-job="${esc(jobId)}">
         ${previews.length > 1
-          ? `<label class="sr-only" for="${selectId}">Choose file preview</label><select id="${selectId}" class="job-file-preview-select" data-file-preview-select="${esc(jobId)}">${previews.map((f, idx)=>`<option value="${idx}" data-preview-name="${esc(f.name)}" data-preview-mode="${esc(f.mode)}" data-preview-content="${esc(f.content)}" data-preview-href="${esc(f.href || "")}">${esc(f.name)}</option>`).join("")}</select>`
+          ? `<label class="sr-only" for="${selectId}">Choose file preview</label><select id="${selectId}" class="job-file-preview-select" data-file-preview-select="${esc(jobId)}">${previews.map((f, idx)=>`<option value="${idx}" data-preview-index="${idx}" data-preview-source="${esc(f.source || "")}" data-preview-name="${esc(f.name)}" data-preview-mode="${esc(f.mode)}" data-preview-content="${esc(f.content)}" data-preview-href="${esc(f.href || "")}" data-preview-expected-path="${esc(f.expectedPath || "")}" data-preview-root-location="${esc(f.rootLocation || "")}">${esc(f.name)}</option>`).join("")}</select>`
           : ""}
         <div class="job-file-preview-panes" data-file-preview-panes>
           <div class="job-file-preview-pane" data-file-preview-pane>
@@ -2945,7 +2955,11 @@ function viewJobs(){
               <img src="${first.mode === "image" ? esc(first.content) : ""}" alt="Preview of ${esc(first.name)}" class="job-file-preview-image" data-preview-image ${first.mode === "image" ? "" : "hidden"}>
               <span class="job-file-preview-message small muted" data-preview-message ${first.mode === "message" ? "" : "hidden"}>${first.mode === "message" ? esc(first.content) : ""}</span>
             </div>
-            <a class="job-file-preview-open small" data-preview-open href="${esc(first.href || "")}" target="_blank" rel="noopener" ${first.href ? "" : "hidden"}>Open file</a>
+            <div class="job-file-preview-actions">
+              <button type="button" class="job-file-preview-link" data-preview-path-btn data-preview-expected-path="${esc(first.expectedPath || "")}" data-preview-root-location="${esc(first.rootLocation || "")}" ${first.expectedPath ? "" : "hidden"}>Show path</button>
+              <button type="button" class="job-file-preview-link" data-preview-open-local data-open-local-file data-job-id="${esc(jobId)}" data-file-index="0" ${first.source === "wj_cuts_reference" ? "" : "hidden"}>Open</button>
+              <a class="job-file-preview-link" data-preview-open-url href="${esc(first.href || "")}" target="_blank" rel="noopener" ${(first.source !== "wj_cuts_reference" && first.href) ? "" : "hidden"}>Open</a>
+            </div>
           </div>
         </div>
       </div>
@@ -3961,6 +3975,28 @@ function viewJobs(){
               </aside>
             </div>
             <label class="job-edit-note">Notes<textarea data-history-field="notes" data-history-id="${job.id}" rows="3" placeholder="Notes...">${textEsc(job?.notes || "")}</textarea></label>
+            <div class="job-edit-files">
+              <div class="job-edit-files-actions"><button type="button" data-job-file-add="${job.id}">Attach from Reference Folder</button><button type="button" data-upload-job="${job.id}">Temporary local upload — not saved</button><button type="button" data-link-job-file="${job.id}">Link OneDrive URL</button></div>
+              <input type="file" data-job-file-input="${job.id}" multiple style="display:none">
+              <ul class="job-file-list">
+                ${jobFiles.length ? jobFiles.map((f, idx)=>{
+                  const safeName = f.name || `file_${idx+1}`;
+                  const href = f.dataUrl || f.url || f.externalUrl || f.downloadUrl || f.oneDriveUrl || "";
+                  const usableLink = !!href && !/^data:(image|application)\//i.test(String(href || "")) && /^https?:\/\//i.test(String(href || ""));
+                  const isRef = f?.source === "wj_cuts_reference" && !!f?.relativePath;
+                  const expectedPath = isRef ? `WJ Cuts\\${String(f.relativePath || "").replace(/^\\+/, "").replace(/\//g, "\\")}` : "";
+                  const link = isRef
+                    ? `<button type="button" class="link" data-open-local-file data-job-id="${job.id}" data-file-index="${idx}">${safeName}</button>`
+                    : (usableLink ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : `${safeName} <span class="small muted">— File metadata saved only — original file content is not stored.</span>`);
+                  const sourceTag = isRef
+                    ? `<span class="job-file-source-badge">Reference folder</span>`
+                    : (f?.source === "onedrive" ? `<span class="job-file-source-badge">OneDrive</span>` : "");
+                  const pathAction = expectedPath ? `<button type="button" class="link" data-preview-path-btn data-preview-expected-path="${esc(expectedPath)}" data-preview-root-location="${esc(f?.rootLocationHint || 'WJ Cuts')}">Show path</button>` : "";
+                  const linkAction = !isRef ? `<button type="button" class="link" data-edit-file-link="${job.id}" data-file-index="${idx}">Link</button>` : "";
+                  return `<li>${link} ${sourceTag} ${expectedPath ? `<span class="small muted">— ${esc(expectedPath)}</span>` : ""} ${pathAction} ${linkAction} <button type="button" class="link" data-remove-file="${job.id}" data-file-index="${idx}">Remove</button></li>`;
+                }).join("") : `<li class="muted">No files attached</li>`}
+              </ul>
+            </div>
             <div class="job-edit-actions">
               <button type="button" data-history-save="${job.id}">Save</button>
               <button type="button" class="danger" data-history-cancel="${job.id}">Cancel</button>
@@ -4374,16 +4410,24 @@ function viewJobs(){
             </div>
               <label class="job-edit-note">Notes<textarea data-j="notes" data-id="${j.id}" rows="3" placeholder="Notes...">${j.notes||""}</textarea></label>
               <div class="job-edit-files">
-                <div class="job-edit-files-actions"><button type="button" data-upload-job="${j.id}">Add Files</button><button type="button" data-link-job-file="${j.id}">Link OneDrive URL</button></div>
+                <div class="job-edit-files-actions"><button type="button" data-job-file-add="${j.id}">Attach from Reference Folder</button><button type="button" data-upload-job="${j.id}">Temporary local upload — not saved</button><button type="button" data-link-job-file="${j.id}">Link OneDrive URL</button></div>
                 <input type="file" data-job-file-input="${j.id}" multiple style="display:none">
                 <ul class="job-file-list">
                   ${jobFiles.length ? jobFiles.map((f, idx)=>{
                     const safeName = f.name || `file_${idx+1}`;
                     const href = f.dataUrl || f.url || f.externalUrl || f.downloadUrl || f.oneDriveUrl || "";
                     const usableLink = !!href && !/^data:(image|application)\//i.test(String(href || "")) && /^https?:\/\//i.test(String(href || ""));
-                    const link = usableLink ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : `${safeName} <span class="small muted">— File metadata saved only — original file content is not stored.</span>`;
-                    const sourceTag = f?.source === "onedrive" ? `<span class="job-file-source-badge">OneDrive</span>` : "";
-                    return `<li>${link} ${sourceTag} <button type="button" class="link" data-edit-file-link="${j.id}" data-file-index="${idx}">Link</button> <button type="button" class="link" data-remove-file="${j.id}" data-file-index="${idx}">Remove</button></li>`;
+                    const isRef = f?.source === "wj_cuts_reference" && !!f?.relativePath;
+                    const expectedPath = isRef ? `WJ Cuts\\${String(f.relativePath || "").replace(/^\\+/, "").replace(/\//g, "\\")}` : "";
+                    const link = isRef
+                      ? `<button type="button" class="link" data-open-local-file data-job-id="${j.id}" data-file-index="${idx}">${safeName}</button>`
+                      : (usableLink ? `<a href="${href}" download="${safeName}" target="_blank" rel="noopener">${safeName}</a>` : `${safeName} <span class="small muted">— File metadata saved only — original file content is not stored.</span>`);
+                    const sourceTag = isRef
+                      ? `<span class="job-file-source-badge">Reference folder</span>`
+                      : (f?.source === "onedrive" ? `<span class="job-file-source-badge">OneDrive</span>` : "");
+                    const pathAction = expectedPath ? `<button type="button" class="link" data-preview-path-btn data-preview-expected-path="${esc(expectedPath)}" data-preview-root-location="${esc(f?.rootLocationHint || 'WJ Cuts')}">Show path</button>` : "";
+                    const linkAction = !isRef ? `<button type="button" class="link" data-edit-file-link="${j.id}" data-file-index="${idx}">Link</button>` : "";
+                    return `<li>${link} ${sourceTag} ${expectedPath ? `<span class="small muted">— ${esc(expectedPath)}</span>` : ""} ${pathAction} ${linkAction} <button type="button" class="link" data-remove-file="${j.id}" data-file-index="${idx}">Remove</button></li>`;
                   }).join("") : `<li class=\"muted\">No files attached</li>`}
                 </ul>
               </div>
@@ -4624,6 +4668,7 @@ function viewJobs(){
               <div>Root setup: <span data-onedrive-connection-status>Not set</span></div>
               <div>Folder status: <span data-onedrive-folder-status>Not ready</span></div>
               <div>This computer root: <span data-onedrive-root-status>Not set</span></div>
+              <div>Root path hint: <span data-onedrive-root-path>Not set</span></div>
               <div>This computer ID: <span data-onedrive-device-status>Not set</span></div>
               <div>Indexed files: <span data-onedrive-library-status>0</span></div>
             </div>

--- a/js/views.js
+++ b/js/views.js
@@ -4666,6 +4666,7 @@ function viewJobs(){
               <li><strong>Step 2:</strong> Save setup for this computer only (it does not copy to other computers).</li>
               <li><strong>Step 3:</strong> Use <strong>Add from this computer OneDrive folder</strong> when attaching files.</li>
             </ol>
+            <p class="small muted" data-onedrive-setup-reason hidden></p>
             <div class="job-onedrive-status-grid small muted" data-onedrive-status-grid>
               <div>Root setup: <span data-onedrive-connection-status>Not set</span></div>
               <div>Folder status: <span data-onedrive-folder-status>Not ready</span></div>

--- a/style.css
+++ b/style.css
@@ -3325,14 +3325,15 @@ body.modal-open .auth-bar {
 }
 .job-file-preview-frame {
   width: 100%;
-  height: 94px;
+  min-height: 64px;
+  height: auto;
   border-radius: 10px;
   border: 1px solid #d6e0f3;
   background: #fff;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
+  align-items: flex-start;
+  justify-content: flex-start;
+  overflow: visible;
   padding: 4px;
 }
 .job-file-preview-image {
@@ -3342,22 +3343,22 @@ body.modal-open .auth-bar {
   display: block;
 }
 .job-file-preview-message {
-  text-align: center;
+  font-size: 13px;
+  text-align: left;
   line-height: 1.35;
   padding: 0 6px;
+  width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  display: block;
+  max-height: none;
+  overflow: visible;
 }
 .job-file-preview-empty {
   margin: 0;
 }
-.job-file-preview-open {
-  color: #1f3b67;
-  text-decoration: none;
-  font-weight: 600;
-}
-.job-file-preview-open:hover,
-.job-file-preview-open:focus-visible {
-  text-decoration: underline;
-}
+.job-file-preview-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 4px; }
+.job-file-preview-link { background: transparent; border: 0; padding: 0; color: #1f3b67; text-decoration: underline; font-size: 12px; font-weight: 600; cursor: pointer; }
 .job-edit-files-actions {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
### Motivation
- Improve error messages and diagnostics when loading previews from OneDrive or local WJ Cuts reference folders to reduce user confusion. 
- Make the saved local root flow more robust by explicitly handling missing handles and permissions and by surfacing verification/signature state. 
- Surface expected reference paths and local open actions in the UI and discourage temporary local uploads that are not durable across devices.

### Description
- Added `describeLocalRootPreviewError` and `diagnosePreviewFailure` and updated preview code paths (including `resolveAttachmentPreview` and OneDrive preview logic) to return contextual, actionable messages instead of generic failures. 
- `sanitizeJobFileReferenceForFirestore` now records `rootLocationHint`, and `resolveLocalFileFromRelativePath` now throws clear errors when the saved root handle is missing or lacks permission and queries `queryPermission` where available. 
- Added `getWJCutsRootStatus`, `pendingAttachTarget` resume logic, and improved root-picking flow so the picker can continue a pending attach after saving the root; choosing/saving the root now updates shared config (including `enabled`) and verifies signatures. 
- Consolidated click actions into `handleCuttingJobFileActionClick`, replaced ad-hoc DOM/file handlers with the unified handler, updated many interactions to use `findJobRecord`, and changed `filesToAttachments` to warn and return an empty list for temporary local uploads. 
- Updated `views.js` to include `expectedPath`, `rootLocation`, and `source` in file preview metadata, added UI controls for "Show path", local "Open", and improved file list actions, and adjusted `style.css` for the new preview/action layout.

### Testing
- Ran linting with `npm run lint` and a production build with `npm run build`, both completed successfully. 
- Ran project unit tests with `npm test` where present, and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb1aa0ee88325b4d23412651539a5)