### PR TITLE
SAFE-03: Add registry-driven dangerous-save preflight and integrity diagnostics

### DIFF
--- a/docs/data-safety-implementation-status.md
+++ b/docs/data-safety-implementation-status.md
@@ -1,0 +1,153 @@
+# Data Safety Implementation Status
+
+Date: 2026-06-17
+
+## SAFE-03 — Hard Dangerous-Save Preflight Using Protected Field Registry
+
+Status: implemented as the active dangerous-save blocker.
+
+SAFE-03 upgrades the SAFE-02 registry and read-only integrity summaries into a hard save preflight before the main Firestore state write. It does not restore, delete, migrate, compact, reset, sanitize, restructure, or rewrite production data. It does not change Firestore paths, unlock writes, implement restore points, expand trash behavior, add backend trash, move local caches, or implement field-level restore.
+
+## Files changed
+
+- `js/core.js`
+  - Added registry-driven dangerous-save preflight functions.
+  - Wired the preflight into `saveCloudInternal` after the latest remote read and before `FB.docRef.set(snap, { merge:true })`.
+  - Preserved the existing remote revision conflict guard and legacy compatibility diagnostics.
+  - Added blocked-save diagnostics in `window.__lastDangerousSaveBlock`.
+  - Added best-effort blocked-save metadata writes to the existing `saveLogs` subcollection; failed log writes do not bypass or break the blocker.
+  - Added `window.runDataSafetyPreflightSelfCheck()` for in-memory developer self-checks.
+  - Extended Recovery Mode diagnostics with last dangerous-save block details.
+- `docs/data-safety-implementation-status.md`
+  - Updated this status document for SAFE-03.
+- `docs/data-safety-recovery-plan.md`
+  - Added a SAFE-03 status pointer.
+
+## Enforcement functions added or upgraded
+
+- `detectDangerousIntegrityReduction(baseSummary, pendingSummary, options)`
+  - Registry-driven comparison of protected field presence, shape, counts, nested counts, total protected counts, payload size, and registry coverage.
+- `validateProtectedSavePreflight({ baselineState, pendingState, latestRemoteState, localBackupState, reason, revisionConflict, allowFirstRun })`
+  - Builds pending and baseline integrity summaries, chooses the strongest available baseline, applies runtime gate checks, includes revision conflict status, and returns structured allow/block output.
+- `chooseProtectedSaveBaseline({ baselineState, latestRemoteState, localBackupState, allowFirstRun })`
+  - Baseline priority: latest remote state, loaded cloud state, local backup state, explicit first-run workspace.
+- `rememberDangerousSaveBlock(preflight, context)`
+  - Records `window.__lastDangerousSaveBlock`, logs diagnostics, shows a toast if available, and refreshes Recovery diagnostics.
+- `writeBlockedSaveLog(preflight, context)`
+  - Best-effort, non-blocking save-log metadata write for blocked saves only.
+- `runDataSafetyPreflightSelfCheck()`
+  - In-memory fixture checks only; no Firebase/localStorage writes.
+
+## Protected save-blocker coverage
+
+SAFE-03 blocker uses `PROTECTED_FIELD_REGISTRY` and covers all SAFE-02 required top-level protected fields:
+
+- `cuttingJobs`
+- `completedCuttingJobs`
+- `cuttingJobDatabase`
+- `tasksInterval`
+- `tasksAsReq`
+- `settingsFolders`
+- `folders`
+- `jobFolders`
+- `inventory`
+- `inventoryFolders`
+- `inventoryMaterials`
+- `inventoryTransactions`
+- `receiptTrackerWeeks`
+- `orderRequests`
+- `weeklyCostReports`
+- `dailyCutHours`
+- `totalHistory`
+- `pumpEff`
+- `garnetCleanings`
+- `appConfig`
+- `dashboardLayout`
+- `costLayout`
+- `jobLayout`
+- `maintenanceTasksV2`
+- `maintenanceCalendarInstancesV2`
+- `maintenanceOccurrencesV2`
+- `oneDriveJobConfig`
+
+SAFE-03 blocker also covers all SAFE-02 required nested protected histories:
+
+- `cuttingJobs.manualLogs`
+- `completedCuttingJobs.manualLogs`
+- `tasksInterval.completedDates`
+- `tasksInterval.manualHistory`
+- `tasksInterval.occurrenceNotes`
+- `tasksInterval.occurrenceHours`
+- `tasksInterval.removedOccurrences`
+- `tasksAsReq.completedDates`
+- `tasksAsReq.manualHistory`
+- `tasksAsReq.occurrenceNotes`
+- `tasksAsReq.occurrenceHours`
+- `tasksAsReq.removedOccurrences`
+
+## Blocking thresholds and rules
+
+The preflight blocks the main Firestore state write when any of these are detected:
+
+- registry coverage is incomplete;
+- pending integrity summary cannot be built;
+- no trusted baseline exists while protected fields/data are present;
+- Recovery Mode is active;
+- local-backup-only mode is active;
+- initial cloud load/adoption is incomplete;
+- remote revision conflict is present;
+- a protected field present in baseline is missing in pending;
+- dangerous shape change from array/object to null/string/undefined/other primitive;
+- protected count or nested-history count drops from nonzero to zero;
+- protected count or nested-history count drops by 50% or more when baseline count is at least 3;
+- total protected count drops by 50% or more when baseline total is at least 3;
+- total payload size drops by 50% or more while baseline protected count is nonzero.
+
+Allowed normal saves include count increases, same counts, and small changes below thresholds when a trusted baseline is available. Brand-new workspace saves are allowed only when the latest remote document is absent and no loaded cloud/local backup baseline has meaningful data.
+
+## Developer self-checks
+
+`window.runDataSafetyPreflightSelfCheck()` runs these in-memory checks:
+
+- same baseline/pending state allows;
+- nonzero `completedCuttingJobs` to zero blocks;
+- `tasksInterval.completedDates` to zero blocks;
+- `cuttingJobs.manualLogs` to zero blocks;
+- `inventory` to zero blocks;
+- missing protected field after present blocks;
+- protected array shape changed to string blocks;
+- registry coverage is complete;
+- synthetic missing registry coverage blocks.
+
+## Still not implemented
+
+- SAFE-04 durable backup-before-save.
+- Firestore transaction/CAS save path.
+- Daily restore points.
+- Weekly desktop backup workflow.
+- Frontend trash expansion.
+- Backend trash bin.
+- Field-level restore tooling.
+- Migration of large backup/preview data out of localStorage.
+- Browser/manual recovery workflow validation.
+
+## Behavior confirmation
+
+SAFE-03 changes save behavior only by blocking dangerous protected-data reductions before the main Firestore state write. It does not add destructive override UI and does not provide a save-anyway bypass. Existing revision guards remain in place and are also included in the registry preflight result.
+
+## Previous SAFE-02 foundation retained
+
+SAFE-02 added:
+
+- `REQUIRED_PROTECTED_DATA_PATHS`
+- `PROTECTED_FIELD_REGISTRY`
+- `buildProtectedFieldIntegritySummary(state)`
+- `buildDataIntegritySummary(state)`
+- `compareIntegritySummaries(baseSummary, nextSummary)`
+- registry coverage diagnostics and Recovery Mode read-only summaries.
+
+## Next recommended step
+
+SAFE-04 — Durable Backup-Before-Save.
+
+Make cloud saves require a verified durable pre-save snapshot in IndexedDB/OPFS or equivalent before any main Firestore state write can proceed. Keep the SAFE-03 hard blocker in place.

--- a/docs/data-safety-recovery-plan.md
+++ b/docs/data-safety-recovery-plan.md
@@ -1,0 +1,498 @@
+# SAFE-01 Data Safety Architecture Audit and Recovery System Plan
+
+Date: 2026-06-17  
+Scope: audit/planning only. No production data was restored, deleted, migrated, compacted, reset, sanitized, or restructured by this change.
+
+## Executive Summary
+
+OMAX currently stores business state mostly as one Firestore state document plus several local browser caches for backups, layouts, OneDrive/reference-folder settings, and legacy fallbacks. The highest-risk architecture pattern is that many UI handlers mutate global arrays/objects and then call a whole-state cloud save. Several recovery guards already exist, including protected-field reduction checks, revision metadata, recovery-mode save blocking, and a local backup attempt, but these guards are incomplete because local backup success is not a hard precondition for cloud writes, protected field coverage is partial, localStorage is still used for important backups/caches, and some seed/adoption/legacy hydration paths can synthesize defaults or partial state.
+
+The recommended recovery system is a layered set of safety walls: a central protected field registry, count/checksum integrity summaries, backup-before-save enforcement, Firestore CAS/revision checks, daily restore points, weekly desktop exports, frontend/backend trash bins, mass-loss auto recovery mode, field-level restore tooling, and moving large state/caches out of localStorage.
+
+## Files Inspected
+
+- `index.html`: Firebase SDK and project config.
+- `js/core.js`: Firebase initialization, state adoption, snapshot/save/load, recovery diagnostics, protected-field summary, dangerous save checks, local backup, clear-all path, legacy migration, deleted-item trash logic.
+- `js/renderers.js`: UI render/mutation handlers for cutting jobs, cost/dashboard/job layouts, OneDrive/reference-folder storage, IndexedDB directory handles, legacy task hydration, inventory/order/receipt/history flows, deleted-items rendering.
+- `js/calendar.js`: maintenance recurrence/task restoration helper paths.
+- `js/pump.js`: pump efficiency/history mutation paths.
+- `js/opportunity.js`: opportunity rollup cloud-save wrapper and appSetting localStorage paths.
+- `js/onedrive/onedriveLibrary.js`: OneDrive library localStorage cache.
+- `js/auth/msalClient.js`: MSAL cache in localStorage.
+- `js/router.js`: render-cache localStorage cleanup.
+- `style.css`: presence of deleted-items/inventory/cost UI classes only; no data-path logic.
+- Existing docs under `docs/`, especially data-loss and maintenance audit docs, for context only.
+
+## 1. Current Data Storage Map
+
+### Firestore project/path assumptions
+
+- Firebase SDKs are loaded from Google CDN in `index.html`.
+- Firebase config identifies project `omax-maintenance`, auth domain `omax-maintenance.firebaseapp.com`, storage bucket `omax-maintenance.firebasestorage.app`, and related app IDs.
+- The active application code initializes Firebase Auth and Firestore in `js/core.js`.
+- `WORKSPACE_ID` is used to derive Firestore paths; current diagnostics format assumes `workspaces/{WORKSPACE_ID}/app/state`.
+
+### Main state document path
+
+- Active state document: `workspaces/{WORKSPACE_ID}/app/state` via `FB.docRef`.
+- `FB.workspaceDoc` appears to reference `workspaces/{WORKSPACE_ID}` metadata/legacy document.
+- `FB.workspaceRef`/`FB.docRef` are set during auth/workspace setup.
+
+### Save logs path
+
+- Save logs are written to `workspaces/{WORKSPACE_ID}/app/saveLogs/entries` through `FB.workspaceDoc.collection("app").doc("saveLogs").collection("entries").add(...)`.
+- The log currently records save metadata such as timestamp, status, size, and workspace ID; it is not a full backup.
+
+### Firestore subcollection/metadata paths
+
+- `workspaces/{WORKSPACE_ID}`: workspace metadata/legacy document; migration reads meaningful old data and writes to `app/state`.
+- `workspaces/{WORKSPACE_ID}/app/state`: main app state.
+- `workspaces/{WORKSPACE_ID}/app/saveLogs/entries`: save-event log.
+- No evidence in the audited code of protected business records being stored as dedicated field-level Firestore subcollections yet.
+
+### localStorage keys
+
+Known keys and purpose:
+
+- `omax_local_state_backup_v1`: current local backup snapshot.
+- `omax_local_state_backup_v0`: legacy backup/cache key removed during emergency backup retry.
+- `cloud_sync_client_id_v1`: client identity used in sync metadata.
+- `cutting_job_onedrive_config_v1`: OneDrive/reference-folder configuration.
+- `cutting_job_onedrive_library_v1` or equivalent constant: OneDrive linked-file library.
+- `cutting_job_onedrive_preview_cache_v1` or equivalent constant: preview cache, intentionally local.
+- `cutting_job_current_profile_local`: selected local computer/profile ID.
+- `job_onedrive_device_id` or equivalent constant: local device ID for reference-folder metadata.
+- `dashboard_layout_windows_v1`: dashboard layout fallback/local cache.
+- `cost_layout_windows_v1`: cost layout fallback/local cache.
+- `job_layout_windows_v1`: job layout fallback/local cache.
+- `omax_tasks_interval_v6`: legacy interval-task fallback.
+- `omax_tasks_asreq_v6`: legacy as-required-task fallback.
+- `omax_debug_cache`, `omax_sync_cache`, `omax_render_cache`, `_omax_last_render_cache`: debug/render/cache keys.
+- `appSetting_{key}`: opportunity/settings wrapper cache.
+- tolerance table keys in `js/renderers.js` storage helper.
+- cost history suppression keys in `js/renderers.js` storage helper.
+- MSAL auth cache uses `localStorage` through `js/auth/msalClient.js`.
+- `omax_onedrive_library_cache` or equivalent `CACHE_KEY` in `js/onedrive/onedriveLibrary.js`.
+
+Risk note: localStorage has a small browser quota and synchronous failure mode. It must not remain the only pre-save backup layer for large state.
+
+### IndexedDB database/store names
+
+- `JOB_ONEDRIVE_LOCAL_ROOT_DB`: stores File System Access API directory handles.
+- `JOB_ONEDRIVE_LOCAL_ROOT_STORE`: object store for the root handle.
+- Keys include the default root key and `profile:{profileId}` for profile-specific handles.
+- Stored values are browser `FileSystemDirectoryHandle` objects, not business records.
+
+### Browser file-system handles
+
+- The WJ Cuts/reference-folder root is selected through File System Access API and persisted in IndexedDB.
+- A `.wj-cuts-root.json` marker file is read/written inside the selected root folder to identify the reference folder.
+- Job file references saved to Firestore are sanitized metadata only: name, type, size, relative path, root/device/profile IDs, and timestamps. Large file/base64 content should not be stored in state.
+
+### OneDrive/reference-folder storage
+
+- OneDrive job config and library are mirrored in localStorage and `window.oneDriveJobConfig` / `window.oneDriveJobLibrary`.
+- OneDrive linked-file entries store metadata/URLs/eTags, not raw file contents.
+- MSAL auth token cache is localStorage-based.
+
+### GitHub/static-file assumptions
+
+- This repo is a static site: HTML/CSS/JS with Firebase.
+- No server-side API or build pipeline is required.
+- `vercel.json` must remain exactly `{ "cleanUrls": true }`.
+
+## 2. Protected Field Registry Draft
+
+Validation rules should be implemented centrally as code, not scattered through renderers. `dangerous drop` means a save or restore would reduce counts by the thresholds below without an explicit recovery workflow and verified backup.
+
+| Field | Type/shape | Created | Edited | Deleted | Rendered/read | Count/validate | Dangerous drop |
+|---|---|---|---|---|---|---|---|
+| `cuttingJobs` | array of active cutting job objects; may include `manualLogs`, material/cost/file metadata | job creation/edit UI in `js/renderers.js`; legacy `Reference for task 1` confirms shape | job board/table/edit forms, manual logs, file/reference actions | job completion/removal handlers | cutting jobs views, dashboard/cost widgets | array length; IDs; sum `manualLogs.length`; bytes; required job identity | non-empty to empty; >50% length drop; manual logs drop |
+| `completedCuttingJobs` | array of completed job objects | completion action from cutting jobs | history edits, cost/report adapters | clear/delete/history actions | job history, cost reports | length; IDs; manual logs; completed dates | any unexplained decrease should be suspicious |
+| `cuttingJobDatabase` | array/object historical database if present | job database/import/history code | job database UI | delete/database cleanup if any | job database/history views | count object keys/array length | missing after present; large key/length drop |
+| `tasksInterval` | array of interval maintenance task templates/instances | defaults, Settings maintenance UI, legacy hydration | maintenance settings/calendar completion | task delete, inventory-linked task delete | settings, calendar, dashboard | length; IDs; nested `completedDates`, `manualHistory`, notes/hours/removals | non-empty to empty; >50% length/history drop |
+| `tasksAsReq` | array of as-required maintenance tasks | defaults, Settings maintenance UI, legacy hydration | settings/calendar | task delete | settings, calendar | length; IDs; nested histories | non-empty to empty; >50% drop |
+| `settingsFolders` | array of settings folder metadata | settings folder UI/defaults | rename/move | folder delete | settings navigation | length; IDs; parent graph | missing/non-empty to empty |
+| `folders` | generic folder array | folder UI/import/adoption | rename/move | folder delete | settings/jobs where used | length; IDs | missing/non-empty to empty |
+| `jobFolders` | array of job folder metadata | job settings/defaults | rename/move | folder delete | job views | length; IDs | missing/non-empty to empty |
+| `inventory` | array of inventory items | inventory add/import/order link repair | quantity edits, order receipt, maintenance link | inventory delete | inventory, orders, maintenance | length; IDs; sum quantities; link counts | non-empty to empty; >50% drop |
+| `inventoryFolders` | array folder metadata | inventory folder UI | rename/reparent | folder delete moves contained items to root | inventory tree | length; IDs; orphan count | missing/non-empty to empty |
+| `inventoryMaterials` | material matrix/object/array | material settings UI | material grid edit mode | row/column delete | inventory material grid | material type/column counts | large row/column drop |
+| `inventoryTransactions` | array of inventory/order transaction logs | order receipt/inventory adjustments | append-only adjustments | no normal delete expected | data center/order reports | length; monotonic append; IDs/timestamps | any decrease without recovery |
+| `receiptTrackerWeeks` | array weekly receipt tracker objects | receipt modal/week save | receipt rows/status | week/row delete if present | receipt tracker/cost dashboard | week count; row counts | any unexplained decrease |
+| `orderRequests` | array of purchase/order request objects with line items | order request UI | approval/status/item edits, inventory link repair | item/request delete | order UI, data center | request count; total line items; statuses | non-empty to empty; >50% request/line drop |
+| `weeklyCostReports` | array/object weekly reports | cost dashboard/report generator | report edits/suppression | cleanup if present | cost dashboard/data center | report count; week keys | large week drop |
+| `dailyCutHours` | array daily cut-hour entries | cutting hours UI/import | daily edit | clear/reset if present | dashboards/cost | day count; date uniqueness | drop of recent history or >50% |
+| `totalHistory` | array machine-hour history `{dateISO,hours}` | hour log/reset current | hour entry edits | clear-all/reset | maintenance/dashboard | length; monotonic-ish date/hour sanity | non-empty to empty; truncation beyond retention policy |
+| `pumpEff` | array/object pump efficiency logs/notes | pump UI | pump log/note edits | pump log/note delete | pump widget | entries/notes counts | non-empty to empty; note/history drop |
+| `garnetCleanings` | array cleaning history | garnet/maintenance UI | append/edit | delete if present | dashboard/maintenance | length/date count | non-empty to empty |
+| `appConfig` | object app configuration | defaults/settings | settings controls | reset/clear all | global app behavior | key count/schema/version | object key drop/missing |
+| `dashboardLayout` | object/window layout | dashboard layout UI/localStorage/cloud | drag/resize/save | reset layout | dashboard | key/widget count | missing after customized |
+| `costLayout` | object/window layout | cost layout UI/localStorage/cloud | drag/resize/save | reset layout | cost dashboard | key/widget count | missing after customized |
+| `jobLayout` | object/window layout | job layout UI/localStorage/cloud | drag/resize/save | reset layout | jobs | key/widget count | missing after customized |
+| `maintenanceTasksV2` | array V2 task records | V2 maintenance/calendar migration/UI | V2 maintenance UI | task delete | calendar/settings | length; IDs | non-empty to empty; >50% drop |
+| `maintenanceCalendarInstancesV2` | array V2 instances | recurrence/calendar engine | calendar edits | occurrence delete/remove | calendar | instance count by date | any large date-window drop |
+| `maintenanceOccurrencesV2` | array V2 occurrence history | completion/calendar actions | notes/hours/status | occurrence delete | calendar/history | occurrence count; completion count | any decrease without trash |
+| `oneDriveJobConfig` | object config/profile/root settings | OneDrive/reference-folder settings | settings UI | reset/disconnect | job file UI/settings | key count; profile IDs | missing after configured |
+| cutting job manual logs | nested arrays under active/completed jobs | job manual log UI | edit log entries | delete log | job detail/history | total manual log count | any unexplained decrease |
+| maintenance `completedDates` | nested arrays under maintenance tasks | maintenance completion | completion edit | task delete/date delete | calendar/task views | total nested entries | any unexplained decrease |
+| maintenance `manualHistory` | nested arrays under maintenance tasks | manual history UI | edit | task delete/history delete | maintenance history | total nested entries | any unexplained decrease |
+| `occurrenceNotes` | nested maps/objects | calendar occurrence note UI | edit note | note delete/task delete | calendar occurrence UI | total note keys | any unexplained decrease |
+| `occurrenceHours` | nested maps/objects | calendar occurrence hours UI | edit hours | delete/task delete | calendar occurrence UI | total hour keys | any unexplained decrease |
+| `removedOccurrences` | nested arrays/maps | recurrence skip/remove occurrence | edit recurrence | restore/delete task | calendar recurrence adapter | total removed occurrence markers | any unexplained decrease |
+| future user-entered business/history fields | unknown | any new feature | any new feature | any delete path | any renderer | registry must require owner/count/validator before release | missing registry entry blocks broad save |
+
+## 3. Save Path Risk Map
+
+| Save path | Trigger/event | Whole or partial | Remote revision check | Backup first | Startup/pagehide/adoption capable | Writes after failed local backup? | Risk |
+|---|---|---|---|---|---|---|---|
+| `saveCloudInternal` in `js/core.js` | debounced UI mutations, explicit `saveCloudNow` | whole-state `snapshotState()` then `FB.docRef.set(snap,{merge:true})` | yes, reads remote and compares `syncMeta.rev` to loaded rev | attempts `persistLocalStateBackup(snap)` before write | yes through pagehide/visibility handlers and many startup mutations | yes; local backup failure logs but does not hard block | High |
+| `saveCloudDebounced` / `saveCloudNow` in `js/core.js` | common global save API | whole-state via internal save | delegated | delegated | yes | yes | High |
+| `loadFromCloud` seeding path in `js/core.js` | cloud missing/no meaningful data | whole/merge seed write | sets loaded revision then writes seeded data | not clearly a backup-before-write path | startup/load/adoption | possible | Critical until guarded by explicit setup mode |
+| `migrateLegacyWorkspaceDoc` in `js/core.js` | startup legacy migration | whole legacy state copied to `app/state` merge | no CAS-style transaction seen | no dedicated pre-migration backup | startup | possible | High |
+| `clearAllAppData` path in `js/core.js` | user destructive reset | whole cleared `snapshotState()` set | only `canWriteCloud` guard | no durable pre-action restore point evident | manual UI | possible | Critical/destructive |
+| `updateWorkspaceMetadata` in `js/core.js` | metadata updates/migration | partial metadata | not protected-state relevant | no | startup/migration | n/a | Medium because legacy doc may contain state confusion |
+| `saveTasks` in renderers/calendar helpers | maintenance settings changes | usually mutates global arrays then cloud save | inherited from cloud save | inherited | user actions; legacy hydration may mutate | inherited | High |
+| Inventory/order/receipt handlers in `js/renderers.js` | add/edit/delete inventory, orders, receipts | mutates global arrays then cloud save | inherited | inherited | user actions | inherited | High |
+| Layout saves | drag/resize/reset layout | localStorage plus global/cloud state | inherited if cloud save called | inherited | user actions/startup local load | localStorage failures swallowed | Medium |
+| OneDrive config/library saves | settings/reference-folder actions | localStorage metadata plus optional cloud state fields | no remote check for localStorage | no | user actions/startup | localStorage failures swallowed | Medium |
+| Opportunity rollup `saveOpportunityRollups` | rollup generation | mutates rollup state then cloud save wrapper | inherited | inherited | computed job | inherited | Medium |
+| Save logs write | after successful save | Firestore subcollection add | no | no | after save only | n/a | Low for data loss; useful diagnostics |
+
+## 4. Delete/Reset/Migration Risk Map
+
+| Path | Removes/changes | Confirmations | Trash bin | Pre-action backup | Risk |
+|---|---|---|---|---|---|
+| `deleteInventoryItem` in `js/renderers.js` | inventory item; optionally linked maintenance tasks; unlinks inventory IDs from tasks | modal confirmation; linked-task choice | records deleted inventory and linked tasks via `recordDeletedItem` when available | no durable restore point evident | High |
+| Maintenance task delete paths in `js/renderers.js` | tasks, instances, nested completion history | confirmation paths present in UI code | deleted-items support for tasks exists | no durable restore point evident | High |
+| Cutting job delete/complete/history paths | active/completed jobs and manual logs | UI confirmations vary by path | not fully verified for all job records | no durable restore point evident | High |
+| Order request/item delete paths | purchase request lines/history | UI confirmation/logging varies | some `recordDeletedItem` calls for order items | no durable restore point evident | High |
+| Inventory folder delete | removes folder records; moves contained items to root | confirmation expected | no folder trash verified | no durable restore point evident | Medium |
+| Material grid row/column delete | material matrix rows/columns | edit-mode gates | no trash verified | undo stack limited to 20 local entries | Medium/High |
+| Layout reset paths | dashboard/cost/job layouts | UI reset controls | no trash | localStorage/cloud may be overwritten | Medium |
+| `clearAllAppData` in `js/core.js` | nearly all protected state reset to defaults/empty | likely manual but destructive | no comprehensive trash | no durable pre-action backup evident | Critical |
+| `compactStateForStorage` / `sanitizeValueForStorage` | trims logs and can remove heavy strings; backup mode deletes `deletedItems`, `opportunityRollups`, `weeklyCostReports` | automatic | n/a | used as backup prep itself | High because protected registry currently omits some requested fields |
+| `safeCleanupLoadedState` | deletes debug/sync snapshots; sanitizes cutting job fields | automatic on load path | n/a | none | Medium |
+| `migrateLegacyWorkspaceDoc` | copies legacy workspace doc to state doc and updates metadata | automatic startup migration | no | no | High |
+| Legacy task hydration in `js/renderers.js` | may fill empty task arrays from Firestore/localStorage/defaults | automatic startup | n/a | no | Medium because defaults can hide missing data |
+| Seed/default state adoption in `loadFromCloud` | can adopt seeded defaults and write them to cloud | automatic startup when cloud missing/unmeaningful | no | no durable backup | Critical |
+
+## 5. Partial/Default/Empty State Overwrite Findings
+
+1. Whole-state saves are still the dominant pattern. If in-memory state is partial, `FB.docRef.set(snap,{merge:true})` can overwrite top-level fields with partial/empty arrays.
+2. `adoptState` normalizes missing arrays to defaults/empty arrays. This is useful for rendering but dangerous if followed by a whole-state save without knowing whether the source was partial.
+3. `loadFromCloud` has seed/default write branches. These must be blocked unless this is a confirmed first-run workspace.
+4. Legacy task hydration in `js/renderers.js` can populate missing `tasksInterval`/`tasksAsReq` from old localStorage or defaults. If later saved as whole state, it can make a partial recovery look valid while other protected fields remain empty.
+5. Render/read adapters often use `Array.isArray(x) ? x : []`, which can hide missing/malformed protected data and make the UI appear simply empty.
+6. Backup compaction currently removes some histories/reports in backup mode. That is unacceptable for protected fields such as `weeklyCostReports` and any future business/history field.
+
+## 6. localStorage Quota Failure Findings
+
+- `persistLocalStateBackup` writes to localStorage, catches quota failures, then attempts emergency/tiny backups.
+- The cloud save can continue after local backup failure because backup persistence does not return a required success/failure value.
+- Several important caches/configs use localStorage and swallow write errors, including OneDrive config/library, layout state, preview caches, MSAL, app settings, and legacy task keys.
+- localStorage cleanup during emergency backup removes cache keys, but this is reactive and not a durable backup strategy.
+- Large preview/file caches should not compete with backups for localStorage quota. Move backup snapshots and large caches to IndexedDB or Origin Private File System where available.
+
+## 7. Page/Component Mutation Map
+
+| Area | Protected data mutated | Files/functions |
+|---|---|---|
+| Cutting Jobs / Job History | `cuttingJobs`, `completedCuttingJobs`, manual logs, job folders, file refs | `js/renderers.js` cutting/job sections; core snapshot/adoption |
+| Maintenance Settings/Calendar | `tasksInterval`, `tasksAsReq`, V2 maintenance arrays, nested histories, occurrence notes/hours/removals | `js/renderers.js`, `js/calendar.js`, `js/core.js` |
+| Inventory | `inventory`, `inventoryFolders`, `inventoryMaterials`, `inventoryTransactions` | `js/renderers.js` inventory functions |
+| Purchase / Orders / Receipts | `orderRequests`, `receiptTrackerWeeks`, inventory links/transactions | `js/renderers.js` order/receipt sections |
+| Cost Dashboard/Data Center | `weeklyCostReports`, layouts, suppressions/logs | `js/renderers.js` cost sections |
+| Dashboard | `dashboardLayout`, rollups, daily/hour summaries | `js/renderers.js`, `js/opportunity.js` |
+| Pump | `pumpEff` logs/notes | `js/pump.js` |
+| Garnet / machine-hour history | `garnetCleanings`, `dailyCutHours`, `totalHistory` | `js/core.js`, `js/renderers.js`, related widgets |
+| Settings / Recovery / Trash | `appConfig`, deleted items, diagnostics | `js/core.js`, `js/renderers.js` |
+| OneDrive/reference folder | `oneDriveJobConfig`, file reference metadata; local handles | `js/renderers.js`, `js/onedrive/*`, `js/auth/*` |
+
+## 8. Render/Read Adapters That Can Hide Existing Data
+
+- Any `Array.isArray(field) ? field : []` adapter can mask malformed/missing data.
+- `adoptState` and initialization helpers normalize absent fields to empty arrays/defaults, which is safe for rendering but unsafe for save eligibility.
+- Legacy task hydration uses Firestore -> localStorage -> defaults. Defaults can make empty tasks look intentional.
+- Inventory/material normalizers can generate IDs and normalized rows, which is useful but should be treated as mutation requiring save guards.
+- Cost/job/dashboard layout readers fall back to localStorage/default layouts, which can mask missing cloud layout data.
+- OneDrive config/library readers fall back to normalized empty values if localStorage is unavailable or parse fails.
+
+## 9. Existing Recovery/Diagnostics/Guard Code
+
+Current safety-related code includes:
+
+- `PROTECTED_STATE_FIELDS` in `js/core.js`, but it is missing several required protected fields (`cuttingJobDatabase`, `jobFolders`, `inventoryTransactions`, `weeklyCostReports`, `folders`, `oneDriveJobConfig`, and explicit nested fields).
+- `buildProtectedFieldSummary`, nested history counts, and `detectDangerousProtectedFieldReduction`.
+- `detectRemoteRevisionConflict` using `syncMeta.rev` and loaded cloud revision.
+- `persistLocalStateBackup`, emergency backup, and tiny critical backup paths.
+- Recovery mode checks that block some saves/migrations.
+- Recovery diagnostics panel/export functions.
+- Save logs collection writes.
+- Deleted-items/trash functions `recordDeletedItem`, `restoreDeletedItem`, and related UI.
+
+These are a good start but should be converted into hard safety invariants instead of best-effort diagnostics.
+
+## 10. Proposed Safety Walls
+
+### Wall 1: Central protected field registry
+
+Create a single `protectedFieldRegistry` with owner, path, type, counter, checksum, render locations, delete policy, trash policy, and minimum restore metadata for every protected top-level and nested field. New user-entered business/history fields must fail tests if not registered.
+
+### Wall 2: Data integrity counts/checksums
+
+For every snapshot, compute:
+
+- top-level type, count/key count, byte size;
+- stable ID set checksum;
+- nested history counts/checksums;
+- last-updated timestamp ranges where available.
+
+Store integrity summaries in `syncMeta.integrity` and in restore points/save logs.
+
+### Wall 3: Dangerous-save blocker
+
+Block any save that would reduce protected counts beyond policy unless:
+
+1. a verified pre-action backup exists,
+2. the action carries an explicit destructive operation token,
+3. the user confirmed the exact records/fields being removed,
+4. the removed records are in frontend/backend trash or restore point.
+
+### Wall 4: Remote revision/CAS guard
+
+Replace read-then-set with a Firestore transaction or compare-and-set field update where possible:
+
+- read current `syncMeta.rev`;
+- verify it matches the loaded base revision;
+- write rev+1 and integrity summary atomically;
+- reject if remote changed.
+
+### Wall 5: Backup-before-save snapshot
+
+A cloud save must not proceed unless a durable pre-save snapshot succeeds. Prefer IndexedDB/OPFS for local pre-save snapshots. localStorage may be a last-resort metadata pointer only.
+
+### Wall 6: Daily restore point
+
+Create daily immutable restore points with full protected state and integrity summary, retained by policy. Store outside the main document, e.g. `workspaces/{id}/restorePoints/daily/{yyyy-mm-dd}` or export files.
+
+### Wall 7: Weekly desktop export
+
+Add guided weekly JSON export to a local file/desktop folder. The app should show last successful export date and warn if stale. Do not claim this exists until implemented.
+
+### Wall 8: Pre-restore current-state backup
+
+Before any restore, export/write a current-state backup so restore operations are reversible.
+
+### Wall 9: Frontend trash bin
+
+Expand `deletedItems` to cover all protected deletes, including folders, cutting jobs, order requests, material rows/columns, layouts, nested maintenance histories, occurrence notes/hours, and file reference metadata.
+
+### Wall 10: Backend trash bin
+
+Mirror deleted protected records to Firestore trash subcollections with integrity metadata before removing them from active state. Trash writes should be append-only and independent from the whole-state write.
+
+### Wall 11: Mass-loss auto-detect recovery mode
+
+On startup and before save, compare current/cloud/local summaries. If large loss is detected, enter read-only Recovery Mode automatically, block all cloud writes, and present restore/export instructions.
+
+### Wall 12: Field-level restore instead of blind overwrite
+
+Restore tooling should select fields/records and merge them into current state with conflict reporting. Avoid whole-document replacement except for an offline/admin-only last resort.
+
+### Wall 13: localStorage quota prevention
+
+Move large backups, preview caches, and restore points to IndexedDB/OPFS. Keep localStorage only for small settings/pointers/client IDs. Add quota diagnostics and warnings.
+
+### Wall 14: Recovery tab under Settings gear
+
+Create a Recovery tab with live diagnostics, exports, restore-point listing, trash views, and step-by-step instructions. Initial implementation should be read-only until backup/restore writes are fully guarded.
+
+## 11. Implementation Sequence
+
+### SAFE-02 — Registry and read-only diagnostics
+
+- Add central protected-field registry module.
+- Add counters/checksums for every protected field and nested history.
+- Add tests for registry coverage.
+- No save behavior changes except read-only diagnostics.
+
+### SAFE-03 — Hard dangerous-save preflight
+
+- Convert current dangerous-save checks to registry-driven validation.
+- Include missing protected fields and nested histories.
+- Block saves when pending snapshot is partial or integrity is unknown.
+- Add explicit test fixtures for mass-loss scenarios.
+
+### SAFE-04 — Durable backup-before-save
+
+- Add IndexedDB/OPFS pre-save snapshot store.
+- Make cloud save require verified backup success.
+- Keep localStorage backup as optional fallback pointer only.
+- Add quota diagnostics.
+
+### SAFE-05 — Firestore CAS/revision transaction
+
+- Replace whole-state read-then-set with transaction/CAS guard.
+- Store rev+integrity atomically.
+- Add conflict UI that blocks overwrite and links Recovery tab.
+
+### SAFE-06 — Daily restore points and save logs v2
+
+- Add immutable daily restore point path.
+- Add integrity summary to save logs.
+- Add retention policy but no deletion until explicitly reviewed.
+
+### SAFE-07 — Frontend trash expansion
+
+- Ensure every delete path records a restorable payload.
+- Add trash coverage tests for inventory, maintenance, jobs, orders, folders, layouts, material rows/columns, and nested histories.
+
+### SAFE-08 — Backend trash bin
+
+- Write deleted protected records to Firestore trash subcollections before active-state mutation.
+- Add backend trash restore metadata and tests.
+
+### SAFE-09 — Recovery tab read-only UI
+
+- Add Settings > Recovery tab with diagnostics, storage map, backup status, export buttons, and warnings.
+- No destructive restore yet.
+
+### SAFE-10 — Field-level restore tooling
+
+- Implement restore from daily restore point/local export/backend trash by field/record.
+- Always create pre-restore backup.
+- Add conflict review UI.
+
+### SAFE-11 — Weekly desktop backup guide/export
+
+- Add weekly export workflow and status reminders.
+- Add File System Access API support where available; fallback to JSON download.
+
+### SAFE-12 — Move large local caches out of localStorage
+
+- Migrate preview caches and large backup blobs to IndexedDB/OPFS.
+- Leave localStorage compatibility readers but block new large writes.
+
+### SAFE-13 — Seed/default/adoption hardening
+
+- Separate render defaults from persisted state.
+- Never seed/write defaults over a workspace with prior protected data unless setup wizard explicitly confirms a brand-new workspace.
+
+### SAFE-14 — Manual recovery runbook validation
+
+- Add manual test plan using copied/exported fixtures.
+- Verify yesterday restore, deleted-record restore, mass-loss detection, local quota failure behavior, and revision conflict handling.
+
+## 12. Recovery Tab Content Draft
+
+### Current Storage Locations
+
+- Cloud workspace: `workspaces/{WORKSPACE_ID}/app/state`.
+- Save logs: `workspaces/{WORKSPACE_ID}/app/saveLogs/entries`.
+- Local backup: browser durable backup store; legacy `omax_local_state_backup_v1` localStorage if present.
+- File references: OneDrive/reference-folder metadata only; raw files remain in OneDrive/local WJ Cuts folder.
+- Local folder handles: browser IndexedDB, device-specific.
+
+### Backup Locations
+
+- Current local pre-save snapshot store.
+- Daily cloud restore points.
+- Weekly desktop JSON exports.
+- Backend trash subcollections.
+- Frontend trash bin.
+
+The UI must clearly label which backup systems are active versus planned/not configured.
+
+### Daily Restore Points
+
+- Show dates, protected counts, checksum, size, and created timestamp.
+- Provide read-only preview first.
+- Restore requires pre-restore backup and field selection.
+
+### Weekly Desktop Backups
+
+- Show last export date and file name.
+- Button: `Export full protected data JSON`.
+- Warning if older than 7 days.
+
+### Trash Bin
+
+- Tabs: Jobs, Maintenance, Inventory, Orders, Folders, Layouts, Other.
+- Show deleted time, deleted by client/user, source path, record counts, and restore button.
+
+### Auto Recovery
+
+- Show whether mass-loss detection is active.
+- Show current state vs cloud vs local counts.
+- If mass loss is detected: block saves and show recovery choices.
+
+### Manual Recovery Steps
+
+1. Stop using the app on all other devices.
+2. Do not refresh repeatedly or clear browser storage.
+3. Export current cloud, current browser state, and local backup diagnostics.
+4. Compare protected counts.
+5. Restore individual fields/records from the best restore point.
+6. Verify counts and render views before unlocking writes.
+
+### How to restore yesterday
+
+1. Open Settings > Recovery.
+2. Select Daily Restore Points.
+3. Preview yesterday's restore point.
+4. Select affected fields/records only.
+5. Create pre-restore backup.
+6. Restore selected fields.
+7. Verify dashboard/jobs/inventory/maintenance counts.
+8. Unlock saves only after integrity checks pass.
+
+### How to restore deleted records
+
+1. Open Trash Bin.
+2. Search by type/name/date.
+3. Preview record payload and linked records.
+4. Restore record and links.
+5. Verify it appears in the relevant page.
+
+### What to do if mass data loss is detected
+
+- Stay in Recovery Mode.
+- Do not click reset/clear/import unless instructed.
+- Export diagnostics.
+- Identify the newest backup with correct counts.
+- Restore fields, not the whole document, unless instructed by an admin.
+
+### What not to do during recovery
+
+- Do not clear browser storage.
+- Do not import unknown JSON over the whole app state.
+- Do not force save from another device.
+- Do not delete/compact/sanitize records.
+- Do not reconnect a stale tab until recovery is complete.
+
+## 13. Highest-Risk Findings
+
+1. Whole-state cloud saves can persist partial in-memory state.
+2. Backup-before-save is best-effort, not mandatory.
+3. localStorage quota failure can still leave the app without a reliable pre-save backup.
+4. Seed/default/adoption paths can create plausible empty/default state.
+5. Some protected fields requested in SAFE-01 are missing from the current protected-field guard list.
+6. Backup compaction currently drops fields that should be protected until the registry formally marks them safe.
+7. Delete paths are not uniformly covered by frontend/backend trash and durable pre-action backups.
+8. Render adapters can silently hide missing/malformed data.
+
+## SAFE-02 status pointer
+
+SAFE-02 implementation status is tracked in `docs/data-safety-implementation-status.md`. That status document records the central protected field registry, read-only integrity diagnostics, registry coverage, and remaining follow-up work.
+
+## SAFE-03 status pointer
+
+SAFE-03 hard dangerous-save preflight is tracked in `docs/data-safety-implementation-status.md`. The active save blocker now uses the protected field registry and integrity summaries before the main Firestore state write. The next planned step is SAFE-04 Durable Backup-Before-Save.
+
+## 14. Non-Goals for SAFE-01
+
+- No writes were unlocked.
+- No production recovery was attempted.
+- No app behavior was changed beyond adding this documentation.
+- No fake claim is made that daily restore points, weekly exports, backend trash, or field-level restore are already implemented.

--- a/js/core.js
+++ b/js/core.js
@@ -596,6 +596,90 @@ const FIRESTORE_STRONG_WARN_BYTES = 900000;
 const FIRESTORE_BLOCK_BYTES = 975000;
 const SAVE_LOG_THROTTLE_MS = 30000;
 let lastSaveLogWriteAt = 0;
+const REQUIRED_PROTECTED_DATA_PATHS = [
+  "cuttingJobs",
+  "completedCuttingJobs",
+  "cuttingJobDatabase",
+  "tasksInterval",
+  "tasksAsReq",
+  "settingsFolders",
+  "folders",
+  "jobFolders",
+  "inventory",
+  "inventoryFolders",
+  "inventoryMaterials",
+  "inventoryTransactions",
+  "receiptTrackerWeeks",
+  "orderRequests",
+  "weeklyCostReports",
+  "dailyCutHours",
+  "totalHistory",
+  "pumpEff",
+  "garnetCleanings",
+  "appConfig",
+  "dashboardLayout",
+  "costLayout",
+  "jobLayout",
+  "maintenanceTasksV2",
+  "maintenanceCalendarInstancesV2",
+  "maintenanceOccurrencesV2",
+  "oneDriveJobConfig",
+  "cuttingJobs.manualLogs",
+  "completedCuttingJobs.manualLogs",
+  "tasksInterval.completedDates",
+  "tasksInterval.manualHistory",
+  "tasksInterval.occurrenceNotes",
+  "tasksInterval.occurrenceHours",
+  "tasksInterval.removedOccurrences",
+  "tasksAsReq.completedDates",
+  "tasksAsReq.manualHistory",
+  "tasksAsReq.occurrenceNotes",
+  "tasksAsReq.occurrenceHours",
+  "tasksAsReq.removedOccurrences"
+];
+const PROTECTED_FIELD_REGISTRY = [
+  { path:"cuttingJobs", label:"Active cutting jobs", category:"jobs", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"completedCuttingJobs", label:"Completed cutting jobs", category:"jobs", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"cuttingJobDatabase", label:"Cutting job database", category:"jobs", expectedShape:"arrayOrObject", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"tasksInterval", label:"Interval maintenance tasks", category:"maintenance", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"tasksAsReq", label:"As-required maintenance tasks", category:"maintenance", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"settingsFolders", label:"Settings folders", category:"config", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"folders", label:"General folders", category:"config", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"jobFolders", label:"Job folders", category:"jobs", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"inventory", label:"Inventory items", category:"inventory", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"inventoryFolders", label:"Inventory folders", category:"inventory", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"inventoryMaterials", label:"Inventory material matrix", category:"inventory", expectedShape:"arrayOrObject", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"inventoryTransactions", label:"Inventory transactions", category:"inventory", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"receiptTrackerWeeks", label:"Receipt tracker weeks", category:"orders", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"orderRequests", label:"Order requests", category:"orders", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"weeklyCostReports", label:"Weekly cost reports", category:"orders", expectedShape:"arrayOrObject", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"dailyCutHours", label:"Daily cut hours", category:"machine history", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"totalHistory", label:"Machine hour total history", category:"machine history", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"pumpEff", label:"Pump efficiency history", category:"machine history", expectedShape:"arrayOrObject", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"garnetCleanings", label:"Garnet cleaning history", category:"machine history", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"appConfig", label:"Application configuration", category:"config", expectedShape:"object", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"dashboardLayout", label:"Dashboard layout", category:"layouts", expectedShape:"object", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"costLayout", label:"Cost layout", category:"layouts", expectedShape:"object", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"jobLayout", label:"Job layout", category:"layouts", expectedShape:"object", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"maintenanceTasksV2", label:"Maintenance tasks V2", category:"maintenance", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"maintenanceCalendarInstancesV2", label:"Maintenance calendar instances V2", category:"maintenance", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"maintenanceOccurrencesV2", label:"Maintenance occurrences V2", category:"maintenance", expectedShape:"array", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"oneDriveJobConfig", label:"OneDrive/reference folder config", category:"jobs", expectedShape:"object", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"cuttingJobs.manualLogs", label:"Active cutting job manual logs", category:"jobs", expectedShape:"nestedCount", parentPath:"cuttingJobs", nestedKey:"manualLogs", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"completedCuttingJobs.manualLogs", label:"Completed cutting job manual logs", category:"jobs", expectedShape:"nestedCount", parentPath:"completedCuttingJobs", nestedKey:"manualLogs", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"tasksInterval.completedDates", label:"Interval task completed dates", category:"maintenance", expectedShape:"nestedCount", parentPath:"tasksInterval", nestedKey:"completedDates", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"tasksInterval.manualHistory", label:"Interval task manual history", category:"maintenance", expectedShape:"nestedCount", parentPath:"tasksInterval", nestedKey:"manualHistory", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"tasksInterval.occurrenceNotes", label:"Interval task occurrence notes", category:"maintenance", expectedShape:"nestedCount", parentPath:"tasksInterval", nestedKey:"occurrenceNotes", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"tasksInterval.occurrenceHours", label:"Interval task occurrence hours", category:"maintenance", expectedShape:"nestedCount", parentPath:"tasksInterval", nestedKey:"occurrenceHours", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"tasksInterval.removedOccurrences", label:"Interval task removed occurrences", category:"maintenance", expectedShape:"nestedCount", parentPath:"tasksInterval", nestedKey:"removedOccurrences", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"tasksAsReq.completedDates", label:"As-required task completed dates", category:"maintenance", expectedShape:"nestedCount", parentPath:"tasksAsReq", nestedKey:"completedDates", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"tasksAsReq.manualHistory", label:"As-required task manual history", category:"maintenance", expectedShape:"nestedCount", parentPath:"tasksAsReq", nestedKey:"manualHistory", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"tasksAsReq.occurrenceNotes", label:"As-required task occurrence notes", category:"maintenance", expectedShape:"nestedCount", parentPath:"tasksAsReq", nestedKey:"occurrenceNotes", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"tasksAsReq.occurrenceHours", label:"As-required task occurrence hours", category:"maintenance", expectedShape:"nestedCount", parentPath:"tasksAsReq", nestedKey:"occurrenceHours", allowEmptyOnNewWorkspace:true, dangerousDrop:true },
+  { path:"tasksAsReq.removedOccurrences", label:"As-required task removed occurrences", category:"maintenance", expectedShape:"nestedCount", parentPath:"tasksAsReq", nestedKey:"removedOccurrences", allowEmptyOnNewWorkspace:true, dangerousDrop:true }
+];
+// Legacy diagnostics still iterate this compatibility list, but SAFE-03
+// hard save blocking is registry-driven via PROTECTED_FIELD_REGISTRY.
 const PROTECTED_STATE_FIELDS = [
   "cuttingJobs",
   "completedCuttingJobs",
@@ -866,17 +950,566 @@ function countJobManualLogs(list){
   return (Array.isArray(list) ? list : []).reduce((acc, job)=>acc + (Array.isArray(job?.manualLogs) ? job.manualLogs.length : 0), 0);
 }
 
+function getValueAtPath(source, path){
+  if (!source || typeof source !== "object") return undefined;
+  return String(path || "").split(".").filter(Boolean).reduce((value, key)=>{
+    if (value == null || typeof value !== "object") return undefined;
+    return value[key];
+  }, source);
+}
+
+function getDataSafetyShape(value){
+  if (Array.isArray(value)) return "array";
+  if (value === null) return "null";
+  return typeof value;
+}
+
+function countCollectionValue(value){
+  if (Array.isArray(value)) return value.length;
+  if (value && typeof value === "object") return Object.keys(value).length;
+  if (value == null) return 0;
+  return 1;
+}
+
+function countNestedProtectedValues(list, key){
+  return (Array.isArray(list) ? list : []).reduce((acc, item)=>{
+    const value = item?.[key];
+    if (Array.isArray(value)) return acc + value.length;
+    if (value && typeof value === "object") return acc + Object.keys(value).length;
+    return acc;
+  }, 0);
+}
+
+function stableStringifyForIntegrity(value){
+  const seen = new WeakSet();
+  const normalize = (input)=>{
+    if (!input || typeof input !== "object") return input;
+    if (seen.has(input)) return "[Circular]";
+    seen.add(input);
+    if (Array.isArray(input)) return input.map(normalize);
+    return Object.keys(input).sort().reduce((out, key)=>{
+      const val = input[key];
+      if (typeof val !== "function" && typeof val !== "undefined") out[key] = normalize(val);
+      return out;
+    }, {});
+  };
+  try { return JSON.stringify(normalize(value)); }
+  catch (_err){ return String(value); }
+}
+
+function hashIntegrityString(input){
+  const text = String(input || "");
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i += 1){
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function fingerprintProtectedValue(value, entry){
+  const shape = getDataSafetyShape(value);
+  const count = entry?.expectedShape === "nestedCount"
+    ? Number(value || 0)
+    : countCollectionValue(value);
+  const sample = stableStringifyForIntegrity(value);
+  return `${shape}:${count}:${hashIntegrityString(sample)}`;
+}
+
+function countProtectedField(state, registryEntry){
+  const entry = registryEntry || {};
+  const src = state && typeof state === "object" ? state : {};
+  if (entry.expectedShape === "nestedCount"){
+    const parent = getValueAtPath(src, entry.parentPath);
+    return countNestedProtectedValues(parent, entry.nestedKey);
+  }
+  return countCollectionValue(getValueAtPath(src, entry.path));
+}
+
+function validateProtectedFieldShape(value, entry){
+  const expected = entry?.expectedShape || "unknown";
+  if (expected === "nestedCount") return { ok:true, warning:null };
+  if (expected === "array") return { ok:Array.isArray(value), warning:Array.isArray(value) ? null : "Expected array" };
+  if (expected === "object") return { ok:Boolean(value && typeof value === "object" && !Array.isArray(value)), warning:(value && typeof value === "object" && !Array.isArray(value)) ? null : "Expected object" };
+  if (expected === "arrayOrObject") return { ok:Array.isArray(value) || Boolean(value && typeof value === "object"), warning:(Array.isArray(value) || Boolean(value && typeof value === "object")) ? null : "Expected array or object" };
+  return { ok:true, warning:null };
+}
+
+function getProtectedFieldRegistryCoverage(){
+  const registered = new Set(PROTECTED_FIELD_REGISTRY.map(entry => entry.path));
+  return {
+    required: REQUIRED_PROTECTED_DATA_PATHS.slice(),
+    registered: Array.from(registered),
+    missing: REQUIRED_PROTECTED_DATA_PATHS.filter(path => !registered.has(path)),
+    extra: Array.from(registered).filter(path => !REQUIRED_PROTECTED_DATA_PATHS.includes(path))
+  };
+}
+
+function buildProtectedFieldIntegritySummary(state){
+  const src = state && typeof state === "object" ? state : {};
+  const fields = {};
+  const warnings = [];
+  const totalsByCategory = {};
+  PROTECTED_FIELD_REGISTRY.forEach(entry => {
+    const isNested = entry.expectedShape === "nestedCount";
+    const rawValue = isNested ? countProtectedField(src, entry) : getValueAtPath(src, entry.path);
+    const parentValue = isNested ? getValueAtPath(src, entry.parentPath) : undefined;
+    const present = isNested
+      ? Array.isArray(parentValue)
+      : Object.prototype.hasOwnProperty.call(src, entry.path);
+    const shape = isNested ? "nestedCount" : getDataSafetyShape(rawValue);
+    const count = isNested ? Number(rawValue || 0) : countProtectedField(src, entry);
+    const validation = validateProtectedFieldShape(rawValue, entry);
+    const bytes = isNested ? 0 : estimatePayloadBytes(rawValue);
+    const summary = {
+      path: entry.path,
+      label: entry.label,
+      category: entry.category,
+      expectedShape: entry.expectedShape,
+      present,
+      shape,
+      count,
+      bytes,
+      allowEmptyOnNewWorkspace: entry.allowEmptyOnNewWorkspace === true,
+      dangerousDrop: entry.dangerousDrop === true,
+      fingerprint: fingerprintProtectedValue(rawValue, entry)
+    };
+    if (isNested){
+      summary.parentPath = entry.parentPath;
+      summary.nestedKey = entry.nestedKey;
+      summary.parentPresent = Array.isArray(parentValue);
+    }
+    if (!present){
+      summary.warning = isNested ? "Parent collection missing or not an array" : "Missing protected field";
+      warnings.push({ path: entry.path, type: "missing", message: summary.warning });
+    } else if (!validation.ok){
+      summary.warning = validation.warning;
+      warnings.push({ path: entry.path, type: "malformed", message: validation.warning, shape });
+    }
+    fields[entry.path] = summary;
+    if (!totalsByCategory[entry.category]) totalsByCategory[entry.category] = { count:0, bytes:0, fields:0, warnings:0 };
+    totalsByCategory[entry.category].count += Number(count || 0);
+    totalsByCategory[entry.category].bytes += Number(bytes || 0);
+    totalsByCategory[entry.category].fields += 1;
+    if (summary.warning) totalsByCategory[entry.category].warnings += 1;
+  });
+  return {
+    generatedAtISO: new Date().toISOString(),
+    schema: src.schema ?? null,
+    syncMeta: src.syncMeta && typeof src.syncMeta === "object" ? { ...src.syncMeta } : null,
+    fields,
+    warnings,
+    totalsByCategory,
+    coverage: getProtectedFieldRegistryCoverage(),
+    totalBytes: estimatePayloadBytes(src),
+    totalProtectedCount: Object.values(fields).reduce((sum, field)=>sum + Number(field.count || 0), 0),
+    summaryFingerprint: hashIntegrityString(stableStringifyForIntegrity(Object.fromEntries(Object.entries(fields).map(([path, field]) => [path, {
+      present: field.present,
+      shape: field.shape,
+      count: field.count,
+      fingerprint: field.fingerprint
+    }]))))
+  };
+}
+
+function buildDataIntegritySummary(state){
+  return buildProtectedFieldIntegritySummary(state);
+}
+
+function compareIntegritySummaries(baseSummary, nextSummary){
+  const baseFields = baseSummary?.fields || {};
+  const nextFields = nextSummary?.fields || {};
+  const paths = Array.from(new Set([...Object.keys(baseFields), ...Object.keys(nextFields)])).sort();
+  const changes = [];
+  paths.forEach(path => {
+    const before = baseFields[path] || {};
+    const after = nextFields[path] || {};
+    if (before.present && !after.present){
+      changes.push({ path, type:"missing_after", before, after });
+    } else if (before.shape && after.shape && before.shape !== after.shape){
+      changes.push({ path, type:"shape_changed", beforeShape: before.shape, afterShape: after.shape, before, after });
+    } else if (Number(before.count || 0) !== Number(after.count || 0)){
+      changes.push({ path, type:"count_changed", beforeCount: Number(before.count || 0), afterCount: Number(after.count || 0), before, after });
+    } else if (before.fingerprint && after.fingerprint && before.fingerprint !== after.fingerprint){
+      changes.push({ path, type:"fingerprint_changed", count: Number(after.count || 0), before, after });
+    }
+  });
+  return {
+    generatedAtISO: new Date().toISOString(),
+    baseFingerprint: baseSummary?.summaryFingerprint || "",
+    nextFingerprint: nextSummary?.summaryFingerprint || "",
+    changed: changes.length > 0,
+    changes
+  };
+}
+
+const DATA_SAFETY_PREFLIGHT_COUNT_DROP_RATIO = 0.5;
+const DATA_SAFETY_PREFLIGHT_MIN_BASELINE_COUNT = 3;
+const DATA_SAFETY_PREFLIGHT_TOTAL_DROP_RATIO = 0.5;
+const DATA_SAFETY_PREFLIGHT_SIZE_DROP_RATIO = 0.5;
+
+function hasAnyProtectedData(summary){
+  const fields = summary?.fields || {};
+  return Object.values(fields).some(field => field && field.present && Number(field.count || 0) > 0);
+}
+
+function hasAnyProtectedFieldPresence(summary){
+  const fields = summary?.fields || {};
+  return Object.values(fields).some(field => field && field.present);
+}
+
+function isDangerousShapeChange(before, after){
+  const beforeShape = before?.shape || "";
+  const afterShape = after?.shape || "";
+  if (!beforeShape || !afterShape || beforeShape === afterShape) return false;
+  if (beforeShape === "nestedCount" || afterShape === "nestedCount") return false;
+  const protectedShapes = new Set(["array", "object"]);
+  const dangerousTargets = new Set(["undefined", "null", "string", "number", "boolean"]);
+  return protectedShapes.has(beforeShape) && dangerousTargets.has(afterShape);
+}
+
+function chooseProtectedSaveBaseline({ baselineState, latestRemoteState, localBackupState, allowFirstRun = false } = {}){
+  const candidates = [
+    { source: "latestRemoteState", state: latestRemoteState },
+    { source: "loadedCloudState", state: baselineState },
+    { source: "localBackupState", state: localBackupState }
+  ];
+  for (const candidate of candidates){
+    if (candidate.state && typeof candidate.state === "object" && stateHasMeaningfulData(candidate.state)){
+      return {
+        ...candidate,
+        summary: buildDataIntegritySummary(candidate.state),
+        trusted: true
+      };
+    }
+  }
+  return {
+    source: allowFirstRun ? "explicitFirstRunWorkspace" : "unknown",
+    state: null,
+    summary: null,
+    trusted: Boolean(allowFirstRun)
+  };
+}
+
+function detectDangerousIntegrityReduction(baseSummary, pendingSummary, options = {}){
+  const reasons = [];
+  const fieldChanges = [];
+  const registryCoverage = pendingSummary?.coverage || getProtectedFieldRegistryCoverage();
+  const baselineFields = baseSummary?.fields || {};
+  const pendingFields = pendingSummary?.fields || {};
+  const addReason = (reason)=>{ reasons.push(reason); return reason; };
+  const addFieldChange = (change)=>{
+    fieldChanges.push(change);
+    if (change.reason) reasons.push(change.reason);
+  };
+
+  if (!pendingSummary || typeof pendingSummary !== "object"){
+    addReason({ type:"pending_summary_unavailable", severity:"block", message:"Pending protected-data summary could not be built." });
+  }
+  if (Array.isArray(registryCoverage.missing) && registryCoverage.missing.length){
+    addReason({ type:"registry_coverage_incomplete", severity:"block", paths: registryCoverage.missing.slice(), message:"Protected field registry coverage is incomplete." });
+  }
+  if (!baseSummary && !options.allowUnknownBaseline){
+    addReason({ type:"baseline_unknown", severity:"block", message:"No trusted protected-data baseline is available for this save." });
+  }
+
+  PROTECTED_FIELD_REGISTRY.forEach(entry => {
+    const before = baselineFields[entry.path];
+    const after = pendingFields[entry.path];
+    if (!before && !after) return;
+    if (before?.present && !after?.present){
+      addFieldChange({
+        path: entry.path,
+        label: entry.label,
+        category: entry.category,
+        type:"missing_after_present",
+        baselineCount: Number(before.count || 0),
+        pendingCount: 0,
+        reason: { type:"protected_field_missing", severity:"block", path: entry.path, message:`${entry.label} is missing from the pending save.` }
+      });
+      return;
+    }
+    if (before?.present && after?.present && isDangerousShapeChange(before, after)){
+      addFieldChange({
+        path: entry.path,
+        label: entry.label,
+        category: entry.category,
+        type:"dangerous_shape_change",
+        baselineShape: before.shape,
+        pendingShape: after.shape,
+        baselineCount: Number(before.count || 0),
+        pendingCount: Number(after.count || 0),
+        reason: { type:"protected_field_shape_changed", severity:"block", path: entry.path, baselineShape: before.shape, pendingShape: after.shape, message:`${entry.label} changed from ${before.shape} to ${after.shape}.` }
+      });
+    }
+    const beforeCount = Number(before?.count || 0);
+    const afterCount = Number(after?.count || 0);
+    if (beforeCount > 0 && afterCount === 0){
+      addFieldChange({
+        path: entry.path,
+        label: entry.label,
+        category: entry.category,
+        type: entry.expectedShape === "nestedCount" ? "nested_history_zeroed" : "protected_count_zeroed",
+        baselineCount: beforeCount,
+        pendingCount: afterCount,
+        reason: { type: entry.expectedShape === "nestedCount" ? "nested_history_zeroed" : "protected_count_zeroed", severity:"block", path: entry.path, baselineCount: beforeCount, pendingCount: afterCount, message:`${entry.label} would drop from ${beforeCount} to zero.` }
+      });
+    } else if (beforeCount >= DATA_SAFETY_PREFLIGHT_MIN_BASELINE_COUNT && afterCount <= Math.floor(beforeCount * DATA_SAFETY_PREFLIGHT_COUNT_DROP_RATIO)){
+      addFieldChange({
+        path: entry.path,
+        label: entry.label,
+        category: entry.category,
+        type: entry.expectedShape === "nestedCount" ? "nested_history_large_drop" : "protected_count_large_drop",
+        baselineCount: beforeCount,
+        pendingCount: afterCount,
+        dropRatio: beforeCount ? (beforeCount - afterCount) / beforeCount : 0,
+        reason: { type: entry.expectedShape === "nestedCount" ? "nested_history_large_drop" : "protected_count_large_drop", severity:"block", path: entry.path, baselineCount: beforeCount, pendingCount: afterCount, thresholdRatio: DATA_SAFETY_PREFLIGHT_COUNT_DROP_RATIO, message:`${entry.label} would drop by 50% or more.` }
+      });
+    }
+  });
+
+  const baselineTotal = Number(baseSummary?.totalProtectedCount || 0);
+  const pendingTotal = Number(pendingSummary?.totalProtectedCount || 0);
+  if (baselineTotal >= DATA_SAFETY_PREFLIGHT_MIN_BASELINE_COUNT && pendingTotal <= Math.floor(baselineTotal * DATA_SAFETY_PREFLIGHT_TOTAL_DROP_RATIO)){
+    addReason({ type:"total_protected_count_collapse", severity:"block", baselineTotal, pendingTotal, thresholdRatio: DATA_SAFETY_PREFLIGHT_TOTAL_DROP_RATIO, message:"Total protected record count would collapse by 50% or more." });
+  }
+
+  const baselineBytes = Number(baseSummary?.totalBytes || 0);
+  const pendingBytes = Number(pendingSummary?.totalBytes || 0);
+  if (baselineBytes > 0 && baselineTotal > 0 && pendingBytes > 0 && pendingBytes <= Math.floor(baselineBytes * DATA_SAFETY_PREFLIGHT_SIZE_DROP_RATIO)){
+    addReason({ type:"payload_size_collapse", severity:"block", baselineBytes, pendingBytes, thresholdRatio: DATA_SAFETY_PREFLIGHT_SIZE_DROP_RATIO, message:"State payload size would collapse by 50% or more while protected baseline data exists." });
+  }
+
+  return {
+    generatedAtISO: new Date().toISOString(),
+    allowed: reasons.length === 0,
+    blocked: reasons.length > 0,
+    severity: reasons.length ? "block" : "info",
+    reasons,
+    fieldChanges,
+    baselineFingerprint: baseSummary?.summaryFingerprint || "",
+    pendingFingerprint: pendingSummary?.summaryFingerprint || "",
+    baselineTotalProtectedCount: baselineTotal,
+    pendingTotalProtectedCount: pendingTotal,
+    baselineBytes,
+    pendingBytes
+  };
+}
+
+function validateProtectedSavePreflight({ baselineState, pendingState, latestRemoteState, localBackupState, reason = "cloud save", revisionConflict = null, allowFirstRun = false, skipRuntimeGates = false } = {}){
+  const generatedAtISO = new Date().toISOString();
+  let pendingSummary = null;
+  let baseline = null;
+  const reasons = [];
+  try {
+    pendingSummary = buildDataIntegritySummary(pendingState || {});
+  } catch (err){
+    return {
+      generatedAtISO,
+      allowed:false,
+      blocked:true,
+      severity:"block",
+      reason,
+      reasons:[{ type:"pending_summary_exception", severity:"block", message:String(err?.message || err) }],
+      fieldChanges:[],
+      baselineSource:"unknown",
+      baselineFingerprint:"",
+      pendingFingerprint:""
+    };
+  }
+
+  baseline = chooseProtectedSaveBaseline({ baselineState, latestRemoteState, localBackupState, allowFirstRun });
+  const pendingHasProtectedPresence = hasAnyProtectedFieldPresence(pendingSummary);
+  const pendingHasProtectedData = hasAnyProtectedData(pendingSummary);
+  const baselineHasProtectedData = hasAnyProtectedData(baseline.summary);
+
+  if (typeof window !== "undefined" && !skipRuntimeGates){
+    if (isRecoveryMode()) reasons.push({ type:"recovery_mode_active", severity:"block", message:"Recovery Mode is active; cloud saves must remain blocked." });
+    if (window.__localBackupOnlyMode) reasons.push({ type:"local_backup_only_mode", severity:"block", message:"Local-backup-only state is active without a trusted cloud baseline." });
+    if (!window.__cloudLoadAttemptComplete || !window.__initialAdoptComplete) reasons.push({ type:"cloud_load_or_adoption_incomplete", severity:"block", message:"Initial cloud load/adoption is incomplete." });
+  }
+  if (revisionConflict?.blocked){
+    reasons.push({ type:"remote_revision_conflict", severity:"block", message:"Remote state is newer than this client.", details: revisionConflict });
+  }
+  if (!baseline.trusted && pendingHasProtectedPresence && !allowFirstRun){
+    reasons.push({ type:"unknown_baseline_with_protected_fields", severity:"block", message:"Pending state contains protected fields but no trusted baseline is available." });
+  }
+  if (!baseline.trusted && pendingHasProtectedData && !allowFirstRun){
+    reasons.push({ type:"unknown_baseline_with_protected_data", severity:"block", message:"Pending state contains protected data but no trusted baseline is available." });
+  }
+
+  const reduction = detectDangerousIntegrityReduction(baseline.summary, pendingSummary, { allowUnknownBaseline: baseline.trusted });
+  const allReasons = reasons.concat(reduction.reasons || []);
+  return {
+    generatedAtISO,
+    allowed: allReasons.length === 0,
+    blocked: allReasons.length > 0,
+    severity: allReasons.length ? "block" : "info",
+    reason,
+    reasons: allReasons,
+    fieldChanges: reduction.fieldChanges || [],
+    baselineSource: baseline.source,
+    baselineFingerprint: baseline.summary?.summaryFingerprint || "",
+    pendingFingerprint: pendingSummary?.summaryFingerprint || "",
+    baselineSummary: baseline.summary,
+    pendingSummary,
+    baselineTotalProtectedCount: Number(baseline.summary?.totalProtectedCount || 0),
+    pendingTotalProtectedCount: Number(pendingSummary?.totalProtectedCount || 0),
+    baselineBytes: Number(baseline.summary?.totalBytes || 0),
+    pendingBytes: Number(pendingSummary?.totalBytes || 0),
+    baselineHasProtectedData,
+    pendingHasProtectedData,
+    registryCoverage: pendingSummary.coverage
+  };
+}
+
+function rememberDangerousSaveBlock(preflight, context = {}){
+  const block = {
+    atISO: new Date().toISOString(),
+    ...context,
+    preflight,
+    blockedFieldNames: Array.from(new Set((preflight?.fieldChanges || []).map(change => change.path).filter(Boolean))),
+    recommendedNextAction: "Stay in Recovery Mode if active, export diagnostics, and do not force-save until the protected-data counts are reviewed."
+  };
+  if (typeof window !== "undefined"){
+    window.__lastDangerousSaveBlock = block;
+  }
+  console.error("Dangerous cloud save blocked by protected data preflight", block);
+  try { if (typeof toast === "function") toast("Cloud save blocked: protected data loss detected. Export diagnostics before continuing."); } catch (_err){}
+  try { renderRecoveryDiagnosticsPanel(); } catch (_err){}
+  return block;
+}
+
+async function writeBlockedSaveLog(preflight, context = {}){
+  if (!FB?.workspaceDoc) return;
+  try {
+    await FB.workspaceDoc.collection("app").doc("saveLogs").collection("entries").add({
+      atISO: new Date().toISOString(),
+      status: "blocked",
+      reason: context.reason || preflight?.reason || "protected_save_preflight",
+      reasons: (preflight?.reasons || []).slice(0, 25),
+      fieldChanges: (preflight?.fieldChanges || []).slice(0, 50),
+      baselineSource: preflight?.baselineSource || "",
+      baselineFingerprint: preflight?.baselineFingerprint || "",
+      pendingFingerprint: preflight?.pendingFingerprint || "",
+      baselineTotalProtectedCount: Number(preflight?.baselineTotalProtectedCount || 0),
+      pendingTotalProtectedCount: Number(preflight?.pendingTotalProtectedCount || 0),
+      baselineBytes: Number(preflight?.baselineBytes || 0),
+      pendingBytes: Number(preflight?.pendingBytes || 0),
+      workspaceId: WORKSPACE_ID
+    });
+  } catch (err){
+    console.warn("Failed to write blocked-save diagnostic log", err);
+  }
+}
+
+function runDataSafetyPreflightSelfCheck(){
+  const clone = (value)=>JSON.parse(JSON.stringify(value));
+  const baseline = {
+    schema: APP_SCHEMA,
+    cuttingJobs: [{ id:"job1", manualLogs:[{ dateISO:"2026-01-01", completedHours:2 }] }],
+    completedCuttingJobs: [{ id:"done1", manualLogs:[{ dateISO:"2026-01-02", completedHours:1 }] }],
+    cuttingJobDatabase: [{ id:"db1" }],
+    tasksInterval: [{ id:"t1", completedDates:["2026-01-01"], manualHistory:[{ dateISO:"2026-01-01" }], occurrenceNotes:{ a:"note" }, occurrenceHours:{ a:1 }, removedOccurrences:["2026-01-02"] }],
+    tasksAsReq: [{ id:"a1", completedDates:["2026-01-03"], manualHistory:[{ dateISO:"2026-01-03" }], occurrenceNotes:{ b:"note" }, occurrenceHours:{ b:1 }, removedOccurrences:["2026-01-04"] }],
+    settingsFolders: [{ id:"sf1" }],
+    folders: [{ id:"f1" }],
+    jobFolders: [{ id:"jf1" }],
+    inventory: [{ id:"i1" }, { id:"i2" }, { id:"i3" }],
+    inventoryFolders: [{ id:"if1" }],
+    inventoryMaterials: [{ id:"m1" }],
+    inventoryTransactions: [{ id:"it1" }],
+    receiptTrackerWeeks: [{ id:"rw1" }],
+    orderRequests: [{ id:"or1", items:[{ id:"line1" }] }],
+    weeklyCostReports: [{ id:"w1" }],
+    dailyCutHours: [{ dateISO:"2026-01-01", hours:1 }],
+    totalHistory: [{ dateISO:"2026-01-01", hours:10 }],
+    pumpEff: { entries:[{ id:"p1" }], notes:[{ id:"n1" }] },
+    garnetCleanings: [{ id:"g1" }],
+    appConfig: { theme:"default" },
+    dashboardLayout: { cards:["a"] },
+    costLayout: { cards:["b"] },
+    jobLayout: { cards:["c"] },
+    maintenanceTasksV2: [{ id:"mt1" }],
+    maintenanceCalendarInstancesV2: [{ id:"mi1" }],
+    maintenanceOccurrencesV2: [{ id:"mo1" }],
+    oneDriveJobConfig: { enabled:true }
+  };
+  const run = (name, mutate, expectedBlocked)=>{
+    const pending = clone(baseline);
+    if (typeof mutate === "function") mutate(pending);
+    const result = validateProtectedSavePreflight({
+      baselineState: baseline,
+      pendingState: pending,
+      latestRemoteState: baseline,
+      reason: `self-check:${name}`,
+      allowFirstRun: false,
+      skipRuntimeGates: true
+    });
+    return { name, expectedBlocked, blocked: result.blocked, passed: result.blocked === expectedBlocked, reasons: result.reasons.map(r => r.type), fieldChanges: result.fieldChanges.map(c => c.path) };
+  };
+  const results = [
+    run("same-state-allows", null, false),
+    run("completedCuttingJobs-zero-blocks", pending => { pending.completedCuttingJobs = []; }, true),
+    run("task-completedDates-zero-blocks", pending => { pending.tasksInterval[0].completedDates = []; }, true),
+    run("cutting-manualLogs-zero-blocks", pending => { pending.cuttingJobs[0].manualLogs = []; }, true),
+    run("inventory-zero-blocks", pending => { pending.inventory = []; }, true),
+    run("missing-protected-field-blocks", pending => { delete pending.orderRequests; }, true),
+    run("shape-change-blocks", pending => { pending.inventory = "not an array"; }, true)
+  ];
+  const coverage = getProtectedFieldRegistryCoverage();
+  results.push({ name:"registry-coverage-complete", expectedBlocked:false, blocked:coverage.missing.length > 0, passed:coverage.missing.length === 0, missing:coverage.missing });
+  const baselineSummary = buildDataIntegritySummary(baseline);
+  const pendingSummary = buildDataIntegritySummary(baseline);
+  pendingSummary.coverage = { ...pendingSummary.coverage, missing:["selfCheck.missingRegistryPath"] };
+  const missingCoverage = detectDangerousIntegrityReduction(baselineSummary, pendingSummary);
+  results.push({ name:"registry-missing-coverage-blocks", expectedBlocked:true, blocked:missingCoverage.blocked, passed:missingCoverage.blocked === true, reasons:missingCoverage.reasons.map(r => r.type) });
+  const summary = {
+    generatedAtISO: new Date().toISOString(),
+    passed: results.every(result => result.passed),
+    results
+  };
+  console.info("Data safety preflight self-check", summary);
+  return summary;
+}
+
+if (typeof window !== "undefined"){
+  window.REQUIRED_PROTECTED_DATA_PATHS = REQUIRED_PROTECTED_DATA_PATHS;
+  window.PROTECTED_FIELD_REGISTRY = PROTECTED_FIELD_REGISTRY;
+  window.getProtectedFieldRegistryCoverage = getProtectedFieldRegistryCoverage;
+  window.buildDataIntegritySummary = buildDataIntegritySummary;
+  window.buildProtectedFieldIntegritySummary = buildProtectedFieldIntegritySummary;
+  window.compareIntegritySummaries = compareIntegritySummaries;
+  window.detectDangerousIntegrityReduction = detectDangerousIntegrityReduction;
+  window.validateProtectedSavePreflight = validateProtectedSavePreflight;
+  window.runDataSafetyPreflightSelfCheck = runDataSafetyPreflightSelfCheck;
+  window.buildDataIntegritySummaryForCurrentState = function(){
+    return buildDataIntegritySummary(getCurrentAppStateForDiagnostics());
+  };
+  window.exportDataIntegritySummary = function(){
+    const summary = buildDataIntegritySummary(getCurrentAppStateForDiagnostics());
+    if (typeof exportJsonDownload === "function"){
+      exportJsonDownload(`omax-data-integrity-summary-${Date.now()}.json`, summary);
+    }
+    return summary;
+  };
+}
+
 function buildProtectedFieldSummary(state){
   const src = state && typeof state === "object" ? state : {};
+  const integrity = buildProtectedFieldIntegritySummary(src);
   const protectedFields = {};
   PROTECTED_STATE_FIELDS.forEach(field => {
     const value = src[field];
+    const fieldIntegrity = integrity.fields[field] || {};
     protectedFields[field] = {
       present: Object.prototype.hasOwnProperty.call(src, field),
       type: Array.isArray(value) ? "array" : (value === null ? "null" : typeof value),
       length: Array.isArray(value) ? value.length : null,
       keyCount: value && typeof value === "object" && !Array.isArray(value) ? Object.keys(value).length : null,
-      bytes: estimatePayloadBytes(value)
+      bytes: estimatePayloadBytes(value),
+      count: Number(fieldIntegrity.count || 0),
+      fingerprint: fieldIntegrity.fingerprint || ""
     };
   });
   const interval = Array.isArray(src.tasksInterval) ? src.tasksInterval : [];
@@ -894,6 +1527,7 @@ function buildProtectedFieldSummary(state){
       updatedAtISO: src.syncMeta?.updatedAtISO || "",
       updatedBy: src.syncMeta?.updatedBy || ""
     },
+    integrity,
     protectedFields,
     nestedHistoryCounts: {
       completedDates: countTaskNestedArrayEntries(allTasks, "completedDates"),
@@ -974,8 +1608,17 @@ function compareProtectedFieldSummaries(remoteSummary, pendingSummary){
 function detectDangerousProtectedFieldReduction(remoteState, pendingState){
   const remoteSummary = buildProtectedFieldSummary(remoteState || {});
   const pendingSummary = buildProtectedFieldSummary(pendingState || {});
-  const issues = compareProtectedFieldSummaries(remoteSummary, pendingSummary);
-  return { blocked: issues.length > 0, issues, remoteSummary, pendingSummary };
+  const legacyIssues = compareProtectedFieldSummaries(remoteSummary, pendingSummary);
+  const registryReduction = detectDangerousIntegrityReduction(remoteSummary.integrity, pendingSummary.integrity, { allowUnknownBaseline: true });
+  const issues = legacyIssues.concat(registryReduction.reasons || []);
+  return {
+    blocked: legacyIssues.length > 0 || registryReduction.blocked,
+    issues,
+    legacyIssues,
+    registryReduction,
+    remoteSummary,
+    pendingSummary
+  };
 }
 
 function detectRemoteRevisionConflict(remoteState){
@@ -1028,6 +1671,9 @@ async function buildDiagnosticSummary(){
   const cloudState = await readCurrentCloudStateReadOnly().catch(err => ({ __readError: String(err?.message || err) }));
   const localBackup = loadLocalBackupReadOnly();
   const appState = getCurrentAppStateForDiagnostics();
+  const cloudIntegrity = buildDataIntegritySummary(cloudState || {});
+  const localBackupIntegrity = buildDataIntegritySummary(localBackup || {});
+  const currentIntegrity = buildDataIntegritySummary(appState || {});
   return {
     generatedAtISO: new Date().toISOString(),
     recoveryMode: isRecoveryMode(),
@@ -1037,6 +1683,13 @@ async function buildDiagnosticSummary(){
     cloudLoadAttemptComplete: Boolean(window.__cloudLoadAttemptComplete),
     initialAdoptComplete: Boolean(window.__initialAdoptComplete),
     loadedCloudRevisionForSaveGuard: Number(window.__loadedCloudRevisionForSaveGuard || 0),
+    lastDangerousSaveBlock: (typeof window !== "undefined" && window.__lastDangerousSaveBlock) ? window.__lastDangerousSaveBlock : null,
+    registryCoverage: getProtectedFieldRegistryCoverage(),
+    integrity: {
+      cloud: cloudIntegrity,
+      localBackup: localBackupIntegrity,
+      currentAppState: currentIntegrity
+    },
     cloud: buildProtectedFieldSummary(cloudState || {}),
     localBackup: buildProtectedFieldSummary(localBackup || {}),
     currentAppState: buildProtectedFieldSummary(appState || {})
@@ -1080,13 +1733,46 @@ function renderRecoveryDiagnosticsPanel(){
         <button type="button" data-recovery-export="summary">Export field-count diagnostic summary JSON</button>
         <button type="button" data-recovery-copy="summary">Copy diagnostic summary</button>
       </div>
+      <div data-recovery-integrity-summary style="margin:8px 0;padding:8px;border:1px solid #f0caca;border-radius:8px;background:#fff;"></div>
       <pre data-recovery-output style="white-space:pre-wrap;max-height:260px;overflow:auto;background:#fff;border:1px solid #f0caca;border-radius:8px;padding:8px;"></pre>`;
     const mount = document.getElementById("app") || document.querySelector("main") || document.body;
     if (mount === document.body) document.body.insertBefore(panel, document.body.children[1] || null);
     else mount.prepend(panel);
   }
   const output = panel.querySelector("[data-recovery-output]");
-  const writeOutput = (data)=>{ if (output) output.textContent = typeof data === "string" ? data : JSON.stringify(data, null, 2); };
+  const integritySummaryEl = panel.querySelector("[data-recovery-integrity-summary]");
+  const renderIntegritySummary = (data)=>{
+    if (!integritySummaryEl || !data || typeof data !== "object") return;
+    const escapeDiagnosticHtml = (str)=>String(str ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+    const current = data.integrity?.currentAppState;
+    const local = data.integrity?.localBackup;
+    const cloud = data.integrity?.cloud;
+    if (!current) return;
+    const currentWarnings = Array.isArray(current.warnings) ? current.warnings.length : 0;
+    const localBytes = Number(local?.totalBytes || 0);
+    const cloudRev = Number(cloud?.syncMeta?.rev || 0);
+    const lastBlock = data.lastDangerousSaveBlock || null;
+    const blockedFields = Array.isArray(lastBlock?.blockedFieldNames) ? lastBlock.blockedFieldNames : [];
+    const blockHtml = lastBlock ? `
+      <div style="margin:8px 0 0;padding:8px;border:1px solid #b91c1c;border-radius:8px;background:#fff1f2;">
+        <strong>Last dangerous-save block:</strong> ${escapeDiagnosticHtml(lastBlock.atISO || "")}<br>
+        <span>Fields: ${escapeDiagnosticHtml(blockedFields.join(", ") || "none listed")}</span><br>
+        <span>Baseline → pending protected count: ${Number(lastBlock.preflight?.baselineTotalProtectedCount || 0)} → ${Number(lastBlock.preflight?.pendingTotalProtectedCount || 0)}</span><br>
+        <span>Recommended next action: export diagnostics and stay in Recovery Mode until counts are reviewed.</span>
+      </div>` : "";
+    const categoryRows = Object.entries(current.totalsByCategory || {})
+      .map(([name, totals])=>`<tr><td>${escapeDiagnosticHtml(name)}</td><td>${Number(totals.count || 0)}</td><td>${Number(totals.fields || 0)}</td><td>${Number(totals.warnings || 0)}</td></tr>`)
+      .join("");
+    integritySummaryEl.innerHTML = `
+      <h3 style="margin:0 0 6px;font-size:15px;">Protected data integrity summary (read-only)</h3>
+      <p style="margin:0 0 6px;">Current state bytes: ${Number(current.totalBytes || 0)} · Local backup bytes: ${localBytes} · Cloud rev: ${cloudRev} · Warnings: ${currentWarnings} · Fingerprint: ${escapeDiagnosticHtml(current.summaryFingerprint || "")}</p>
+      <table style="border-collapse:collapse;width:100%;font-size:12px;"><thead><tr><th style="text-align:left;border-bottom:1px solid #f0caca;">Category</th><th style="text-align:left;border-bottom:1px solid #f0caca;">Records</th><th style="text-align:left;border-bottom:1px solid #f0caca;">Fields</th><th style="text-align:left;border-bottom:1px solid #f0caca;">Warnings</th></tr></thead><tbody>${categoryRows}</tbody></table>
+      ${blockHtml}`;
+  };
+  const writeOutput = (data)=>{
+    renderIntegritySummary(data);
+    if (output) output.textContent = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+  };
   if (!panel.__recoveryWired){
     panel.addEventListener("click", async (event)=>{
       const exportBtn = event.target.closest("[data-recovery-export]");
@@ -4344,8 +5030,33 @@ const saveCloudInternal = debounce(async ()=>{
     window.__lastSnapshot = snap;
     const remoteSnap = await FB.docRef.get();
     const remoteData = remoteSnap && remoteSnap.exists ? (typeof remoteSnap.data === "function" ? remoteSnap.data() : remoteSnap.data) : null;
+    const localBackupForPreflight = readLocalStateBackup();
+    const revisionConflict = remoteData && typeof remoteData === "object"
+      ? detectRemoteRevisionConflict(remoteData)
+      : { blocked:false };
+    const allowFirstRunPreflight = Boolean(remoteSnap && !remoteSnap.exists)
+      && !stateHasMeaningfulData(window.__lastLoadedCloudState || {})
+      && !stateHasMeaningfulData(localBackupForPreflight || {});
+    const registryPreflight = validateProtectedSavePreflight({
+      baselineState: window.__lastLoadedCloudState || null,
+      pendingState: snap,
+      latestRemoteState: remoteData,
+      localBackupState: localBackupForPreflight,
+      reason: "saveCloudInternal",
+      revisionConflict,
+      allowFirstRun: allowFirstRunPreflight
+    });
+    if (registryPreflight.blocked){
+      rememberDangerousSaveBlock(registryPreflight, {
+        reason: "saveCloudInternal",
+        firestorePath: FB.docRef?.path || "",
+        remoteExists: Boolean(remoteSnap && remoteSnap.exists)
+      });
+      hasPendingLocalChanges = true;
+      await writeBlockedSaveLog(registryPreflight, { reason: "saveCloudInternal" });
+      return;
+    }
     if (remoteData && typeof remoteData === "object"){
-      const revisionConflict = detectRemoteRevisionConflict(remoteData);
       if (revisionConflict.blocked){
         blockCloudSave("remote state is newer than this client. Export/reload/merge review before saving.", revisionConflict);
         hasPendingLocalChanges = true;


### PR DESCRIPTION
### Motivation

- Prevent accidental mass-loss or destructive whole-document saves by enforcing a registry-driven preflight that detects dangerous reductions in protected fields before the main Firestore write. 
- Centralize protected-field definitions, counts, fingerprints, and coverage so save gating can be consistent and auditable. 
- Improve recovery diagnostics and developer tooling so blocked saves are visible, logged, and easier to investigate.

### Description

- Added a protected-field registry and coverage list via `PROTECTED_FIELD_REGISTRY` and `REQUIRED_PROTECTED_DATA_PATHS` and built registry-driven integrity summaries with `buildProtectedFieldIntegritySummary` / `buildDataIntegritySummary`.
- Implemented preflight evaluation functions `detectDangerousIntegrityReduction`, `validateProtectedSavePreflight`, and `chooseProtectedSaveBaseline` and hooked the preflight into the cloud save path in `saveCloudInternal` before `FB.docRef.set(snap, { merge:true })` to block dangerous saves and preserve existing revision guards.
- Added developer/diagnostic helpers `rememberDangerousSaveBlock`, `writeBlockedSaveLog`, `runDataSafetyPreflightSelfCheck`, and exposed several inspection helpers on `window` (e.g. `window.buildDataIntegritySummary`, `window.validateProtectedSavePreflight`) plus enhanced the Recovery diagnostics UI to show integrity summaries and last blocked-save details.
- Kept legacy compatibility: preserved existing `PROTECTED_STATE_FIELDS` and previous reduction detection while augmenting it with the new registry logic; added documentation files `docs/data-safety-implementation-status.md` and `docs/data-safety-recovery-plan.md` describing SAFE-03 and the broader recovery plan.

### Testing

- No CI or automated unit tests were executed as part of this change.
- Added an in-browser developer self-check `runDataSafetyPreflightSelfCheck()` that performs multiple in-memory fixture checks and returns a pass/fail summary for common dangerous-save scenarios, and this function is intended for automated/integrated checks by developers. 
- Save-path behavior is guarded at runtime by the new preflight and writes blocked-save diagnostics to `window.__lastDangerousSaveBlock` and attempt best-effort log writes to the existing `saveLogs` subcollection when a block occurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32b1835eb48325bd9226c77b04bbf7)