### PR TITLE
Isolate layout cloud saves

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1816,7 +1816,7 @@ function getSaveSchemaCoverageReport(options = {}){
   ];
 
   const staleWholeStateOverwriteRiskNotes = [
-    "Dashboard/cost/job layout changes call saveCloudDebounced(), which snapshots the whole app state rather than writing only layout keys.",
+    "Dashboard/cost/job layout changes must keep using saveLayoutCloudOnly() so layout movement writes only layout keys instead of snapshotting the whole app state.",
     "saveCloudInternal checks remote revision before set(..., { merge:true }), but the read-then-write sequence is not a Firestore transaction/compare-and-swap.",
     "Only totalHistory, dailyCutHours, and pumpEff have explicit remote merge protection before save; maintenanceOccurrencesV2, cutting jobs, task history, and purchase history rely on preflight blocking rather than append-only merging.",
     "loadFromCloud seeds defaults only when neither cloud nor local backup is meaningful, but a false non-meaningful read would be dangerous if not caught by recovery/preflight gates."
@@ -6033,6 +6033,205 @@ function saveCloudNow(){
   }else{
     return saveCloudInternal();
   }
+}
+
+const LAYOUT_SAVE_PROTECTED_KEYS = [
+  "cuttingJobs",
+  "completedCuttingJobs",
+  "tasksInterval",
+  "tasksAsReq",
+  "settingsFolders",
+  "inventory",
+  "inventoryFolders",
+  "inventoryMaterials",
+  "inventoryTransactions",
+  "receiptTrackerWeeks",
+  "weeklyCostReports",
+  "orderRequests",
+  "dailyCutHours",
+  "totalHistory",
+  "pumpEff",
+  "garnetCleanings",
+  "appConfig",
+  "cuttingJobDatabase",
+  "maintenanceTasksV2",
+  "maintenanceCalendarInstancesV2",
+  "maintenanceOccurrencesV2"
+];
+const LAYOUT_SAVE_AREA_CONFIG = {
+  dashboard: { stateKey: "dashboardLayout", cloudKey: "cloudDashboardLayout", loadedKey: "cloudDashboardLayoutLoaded" },
+  cost: { stateKey: "costLayout", cloudKey: "cloudCostLayout", loadedKey: "cloudCostLayoutLoaded" },
+  jobs: { stateKey: "jobLayout", cloudKey: "cloudJobLayout", loadedKey: "cloudJobLayoutLoaded" },
+  job: { stateKey: "jobLayout", cloudKey: "cloudJobLayout", loadedKey: "cloudJobLayoutLoaded", canonicalArea: "jobs" }
+};
+
+function buildLayoutSaveDebugReport(overrides = {}){
+  const payload = overrides.payload && typeof overrides.payload === "object" ? overrides.payload : {};
+  const payloadKeys = Object.keys(payload);
+  const protectedKeysIncludedInPayload = payloadKeys.filter(key => LAYOUT_SAVE_PROTECTED_KEYS.includes(key));
+  const layoutKey = overrides.layoutKey || payloadKeys.find(key => /Layout$/.test(key)) || "";
+  const remoteLayout = layoutKey && overrides.remoteData && typeof overrides.remoteData === "object" ? overrides.remoteData[layoutKey] : null;
+  return {
+    atISO: new Date().toISOString(),
+    lastLayoutSaveAction: overrides.action || "",
+    layoutArea: overrides.area || "",
+    firebasePath: overrides.firebasePath || "",
+    payloadKeys,
+    protectedKeysIncludedInPayload,
+    usedWholeAppSnapshot: Boolean(overrides.usedWholeAppSnapshot),
+    calledSaveCloudDebounced: Boolean(overrides.calledSaveCloudDebounced),
+    firestoreSetAttempted: Boolean(overrides.firestoreSetAttempted),
+    firestoreSetCompleted: Boolean(overrides.firestoreSetCompleted),
+    firestoreSetError: overrides.firestoreSetError || "",
+    lastCloudSaveBlock: (typeof window !== "undefined" && window.__lastCloudSaveBlock) ? window.__lastCloudSaveBlock : null,
+    lastDangerousSaveBlock: (typeof window !== "undefined" && window.__lastDangerousSaveBlock) ? window.__lastDangerousSaveBlock : null,
+    localStorageUpdated: Boolean(overrides.localStorageUpdated),
+    remoteLayoutVerified: Boolean(overrides.remoteLayoutVerified),
+    remoteLayoutShape: remoteLayout && typeof remoteLayout === "object"
+      ? { type: Array.isArray(remoteLayout) ? "array" : "object", keyCount: Object.keys(remoteLayout).length }
+      : { type: remoteLayout == null ? "missing" : typeof remoteLayout, keyCount: 0 }
+  };
+}
+
+async function saveLayoutCloudOnly(area, layout, options = {}){
+  const cfg = LAYOUT_SAVE_AREA_CONFIG[area] || null;
+  const canonicalArea = cfg?.canonicalArea || area;
+  const layoutClone = (typeof cloneStructured === "function")
+    ? (cloneStructured(layout || {}) || {})
+    : JSON.parse(JSON.stringify(layout || {}));
+  let payload = {};
+  let debug = buildLayoutSaveDebugReport({
+    action: "layout_save_started",
+    area: canonicalArea || area || "",
+    firebasePath: FB.docRef?.path || "",
+    payload,
+    layoutKey: cfg?.stateKey || "",
+    usedWholeAppSnapshot: false,
+    calledSaveCloudDebounced: false,
+    localStorageUpdated: Boolean(options.localStorageUpdated)
+  });
+  if (typeof window !== "undefined") window.__lastLayoutSaveIsolationReport = debug;
+  if (!cfg){
+    debug = { ...debug, lastLayoutSaveAction: "blocked_unknown_layout_area", firestoreSetError: `Unknown layout area: ${area}` };
+    if (typeof window !== "undefined") window.__lastLayoutSaveIsolationReport = debug;
+    console.warn("Layout save skipped: unknown layout area", area);
+    return false;
+  }
+  if (!FB.ready || !FB.docRef){
+    debug = { ...debug, lastLayoutSaveAction: "blocked_firebase_not_ready" };
+    if (typeof window !== "undefined") window.__lastLayoutSaveIsolationReport = debug;
+    return false;
+  }
+  if (!canWriteCloud(`layout save (${cfg.stateKey})`)){
+    debug = buildLayoutSaveDebugReport({ ...debug, action: "blocked_can_write_cloud", payload, layoutKey: cfg.stateKey, localStorageUpdated: Boolean(options.localStorageUpdated) });
+    if (typeof window !== "undefined") window.__lastLayoutSaveIsolationReport = debug;
+    return false;
+  }
+  if (isVercelPreviewRuntime()){
+    debug = { ...debug, lastLayoutSaveAction: "blocked_preview_readonly" };
+    if (typeof window !== "undefined") window.__lastLayoutSaveIsolationReport = debug;
+    return false;
+  }
+  try {
+    const remoteSnap = await FB.docRef.get();
+    const remoteData = remoteSnap && remoteSnap.exists ? (typeof remoteSnap.data === "function" ? remoteSnap.data() : remoteSnap.data) : null;
+    const revisionConflict = remoteData && typeof remoteData === "object"
+      ? detectRemoteRevisionConflict(remoteData)
+      : { blocked:false };
+    if (revisionConflict.blocked){
+      blockCloudSave("Layout save paused because cloud changed. Refresh before editing layout.", revisionConflict);
+      debug = buildLayoutSaveDebugReport({ ...debug, action: "blocked_remote_revision_conflict", payload, layoutKey: cfg.stateKey, remoteData, localStorageUpdated: Boolean(options.localStorageUpdated) });
+      if (typeof window !== "undefined") window.__lastLayoutSaveIsolationReport = debug;
+      return false;
+    }
+    const previousRev = Math.max(
+      Number(remoteData?.syncMeta?.rev || 0),
+      Number(window.__loadedCloudRevisionForSaveGuard || 0),
+      Number(lastAppliedCloudRevision || 0)
+    );
+    payload = {
+      [cfg.stateKey]: layoutClone,
+      syncMeta: {
+        rev: Math.max(Date.now(), previousRev + 1),
+        updatedAtISO: new Date().toISOString(),
+        updatedBy: getCloudSyncClientId(),
+        lastLayoutSaveArea: canonicalArea,
+        lastLayoutSaveKey: cfg.stateKey
+      }
+    };
+    debug = buildLayoutSaveDebugReport({
+      action: "firestore_set_attempted",
+      area: canonicalArea,
+      firebasePath: FB.docRef?.path || "",
+      payload,
+      layoutKey: cfg.stateKey,
+      usedWholeAppSnapshot: false,
+      calledSaveCloudDebounced: false,
+      firestoreSetAttempted: true,
+      localStorageUpdated: Boolean(options.localStorageUpdated),
+      remoteData
+    });
+    if (typeof window !== "undefined") window.__lastLayoutSaveIsolationReport = debug;
+    await FB.docRef.set(payload, { merge:true });
+    const verifiedSnap = await FB.docRef.get();
+    const verifiedData = verifiedSnap && verifiedSnap.exists ? (typeof verifiedSnap.data === "function" ? verifiedSnap.data() : verifiedSnap.data) : null;
+    const verifiedLayout = verifiedData && typeof verifiedData === "object" ? verifiedData[cfg.stateKey] : null;
+    const remoteLayoutVerified = typeof stableStringify === "function"
+      ? stableStringify(verifiedLayout || {}) === stableStringify(layoutClone || {})
+      : true;
+    if (typeof window !== "undefined"){
+      window.__loadedCloudRevisionForSaveGuard = Number(payload.syncMeta.rev || 0);
+      lastAppliedCloudRevision = Number(payload.syncMeta.rev || 0);
+      const baseline = (window.__lastLoadedCloudState && typeof window.__lastLoadedCloudState === "object")
+        ? (cloneStructured(window.__lastLoadedCloudState) || { ...window.__lastLoadedCloudState })
+        : {};
+      baseline[cfg.stateKey] = cloneStructured(layoutClone) || layoutClone;
+      baseline.syncMeta = { ...(baseline.syncMeta && typeof baseline.syncMeta === "object" ? baseline.syncMeta : {}), ...payload.syncMeta };
+      window.__lastLoadedCloudState = baseline;
+    }
+    debug = buildLayoutSaveDebugReport({
+      action: "firestore_set_completed",
+      area: canonicalArea,
+      firebasePath: FB.docRef?.path || "",
+      payload,
+      layoutKey: cfg.stateKey,
+      usedWholeAppSnapshot: false,
+      calledSaveCloudDebounced: false,
+      firestoreSetAttempted: true,
+      firestoreSetCompleted: true,
+      localStorageUpdated: Boolean(options.localStorageUpdated),
+      remoteLayoutVerified,
+      remoteData: verifiedData
+    });
+    if (typeof window !== "undefined") window.__lastLayoutSaveIsolationReport = debug;
+    return true;
+  } catch (err){
+    debug = buildLayoutSaveDebugReport({
+      action: "firestore_set_error",
+      area: canonicalArea,
+      firebasePath: FB.docRef?.path || "",
+      payload,
+      layoutKey: cfg.stateKey,
+      usedWholeAppSnapshot: false,
+      calledSaveCloudDebounced: false,
+      firestoreSetAttempted: Boolean(Object.keys(payload).length),
+      firestoreSetError: err?.message || String(err),
+      localStorageUpdated: Boolean(options.localStorageUpdated)
+    });
+    if (typeof window !== "undefined") window.__lastLayoutSaveIsolationReport = debug;
+    console.warn("Layout-only cloud save failed", err);
+    return false;
+  }
+}
+
+if (typeof window !== "undefined"){
+  window.saveLayoutCloudOnly = saveLayoutCloudOnly;
+  window.debugLayoutSaveIsolation = function debugLayoutSaveIsolation(){
+    if (!window.DEBUG_MODE) return { available:false, reason:"DEBUG_MODE is disabled. Open with ?debug=1." };
+    const report = window.__lastLayoutSaveIsolationReport || buildLayoutSaveDebugReport({ action:"no_layout_save_recorded" });
+    console.info("Layout save isolation report", report);
+    return report;
+  };
 }
 
 if (typeof window !== "undefined"){

--- a/js/core.js
+++ b/js/core.js
@@ -6085,12 +6085,40 @@ function buildLayoutSaveDebugReport(overrides = {}){
     firestoreSetError: overrides.firestoreSetError || "",
     lastCloudSaveBlock: (typeof window !== "undefined" && window.__lastCloudSaveBlock) ? window.__lastCloudSaveBlock : null,
     lastDangerousSaveBlock: (typeof window !== "undefined" && window.__lastDangerousSaveBlock) ? window.__lastDangerousSaveBlock : null,
+    persistFunctionCalled: Boolean(overrides.persistFunctionCalled),
+    layoutHasEntries: Boolean(overrides.layoutHasEntries),
+    cloudLoaded: Boolean(overrides.cloudLoaded),
+    layoutsEqualResult: Object.prototype.hasOwnProperty.call(overrides, "layoutsEqualResult") ? Boolean(overrides.layoutsEqualResult) : null,
+    changed: Object.prototype.hasOwnProperty.call(overrides, "changed") ? Boolean(overrides.changed) : null,
+    saveLayoutCloudOnlyCalled: Boolean(overrides.saveLayoutCloudOnlyCalled),
     localStorageUpdated: Boolean(overrides.localStorageUpdated),
     remoteLayoutVerified: Boolean(overrides.remoteLayoutVerified),
     remoteLayoutShape: remoteLayout && typeof remoteLayout === "object"
       ? { type: Array.isArray(remoteLayout) ? "array" : "object", keyCount: Object.keys(remoteLayout).length }
       : { type: remoteLayout == null ? "missing" : typeof remoteLayout, keyCount: 0 }
   };
+}
+
+function recordLayoutPersistAttempt(area, details = {}){
+  if (typeof window === "undefined") return null;
+  const previous = window.__lastLayoutSaveIsolationReport && typeof window.__lastLayoutSaveIsolationReport === "object"
+    ? window.__lastLayoutSaveIsolationReport
+    : {};
+  const payload = previous.payload && typeof previous.payload === "object" ? previous.payload : {};
+  const report = buildLayoutSaveDebugReport({
+    ...previous,
+    ...details,
+    action: details.action || "persist_attempt_recorded",
+    area,
+    firebasePath: FB.docRef?.path || previous.firebasePath || "",
+    payload,
+    usedWholeAppSnapshot: false,
+    calledSaveCloudDebounced: false,
+    persistFunctionCalled: true
+  });
+  window.__lastLayoutSaveIsolationReport = report;
+  if (window.DEBUG_MODE) console.info("Layout persist attempt", report);
+  return report;
 }
 
 async function saveLayoutCloudOnly(area, layout, options = {}){
@@ -6108,6 +6136,12 @@ async function saveLayoutCloudOnly(area, layout, options = {}){
     layoutKey: cfg?.stateKey || "",
     usedWholeAppSnapshot: false,
     calledSaveCloudDebounced: false,
+    persistFunctionCalled: Boolean(options.persistFunctionCalled),
+    layoutHasEntries: Boolean(options.layoutHasEntries),
+    cloudLoaded: Boolean(options.cloudLoaded),
+    layoutsEqualResult: options.layoutsEqualResult,
+    changed: options.changed,
+    saveLayoutCloudOnlyCalled: true,
     localStorageUpdated: Boolean(options.localStorageUpdated)
   });
   if (typeof window !== "undefined") window.__lastLayoutSaveIsolationReport = debug;
@@ -6123,7 +6157,7 @@ async function saveLayoutCloudOnly(area, layout, options = {}){
     return false;
   }
   if (!canWriteCloud(`layout save (${cfg.stateKey})`)){
-    debug = buildLayoutSaveDebugReport({ ...debug, action: "blocked_can_write_cloud", payload, layoutKey: cfg.stateKey, localStorageUpdated: Boolean(options.localStorageUpdated) });
+    debug = buildLayoutSaveDebugReport({ ...debug, action: "blocked_can_write_cloud", payload, layoutKey: cfg.stateKey, localStorageUpdated: Boolean(options.localStorageUpdated), saveLayoutCloudOnlyCalled: true });
     if (typeof window !== "undefined") window.__lastLayoutSaveIsolationReport = debug;
     return false;
   }
@@ -6168,6 +6202,12 @@ async function saveLayoutCloudOnly(area, layout, options = {}){
       usedWholeAppSnapshot: false,
       calledSaveCloudDebounced: false,
       firestoreSetAttempted: true,
+      persistFunctionCalled: Boolean(options.persistFunctionCalled),
+      layoutHasEntries: Boolean(options.layoutHasEntries),
+      cloudLoaded: Boolean(options.cloudLoaded),
+      layoutsEqualResult: options.layoutsEqualResult,
+      changed: options.changed,
+      saveLayoutCloudOnlyCalled: true,
       localStorageUpdated: Boolean(options.localStorageUpdated),
       remoteData
     });
@@ -6199,6 +6239,12 @@ async function saveLayoutCloudOnly(area, layout, options = {}){
       calledSaveCloudDebounced: false,
       firestoreSetAttempted: true,
       firestoreSetCompleted: true,
+      persistFunctionCalled: Boolean(options.persistFunctionCalled),
+      layoutHasEntries: Boolean(options.layoutHasEntries),
+      cloudLoaded: Boolean(options.cloudLoaded),
+      layoutsEqualResult: options.layoutsEqualResult,
+      changed: options.changed,
+      saveLayoutCloudOnlyCalled: true,
       localStorageUpdated: Boolean(options.localStorageUpdated),
       remoteLayoutVerified,
       remoteData: verifiedData
@@ -6216,6 +6262,12 @@ async function saveLayoutCloudOnly(area, layout, options = {}){
       calledSaveCloudDebounced: false,
       firestoreSetAttempted: Boolean(Object.keys(payload).length),
       firestoreSetError: err?.message || String(err),
+      persistFunctionCalled: Boolean(options.persistFunctionCalled),
+      layoutHasEntries: Boolean(options.layoutHasEntries),
+      cloudLoaded: Boolean(options.cloudLoaded),
+      layoutsEqualResult: options.layoutsEqualResult,
+      changed: options.changed,
+      saveLayoutCloudOnlyCalled: true,
       localStorageUpdated: Boolean(options.localStorageUpdated)
     });
     if (typeof window !== "undefined") window.__lastLayoutSaveIsolationReport = debug;
@@ -6226,6 +6278,7 @@ async function saveLayoutCloudOnly(area, layout, options = {}){
 
 if (typeof window !== "undefined"){
   window.saveLayoutCloudOnly = saveLayoutCloudOnly;
+  window.recordLayoutPersistAttempt = recordLayoutPersistAttempt;
   window.debugLayoutSaveIsolation = function debugLayoutSaveIsolation(){
     if (!window.DEBUG_MODE) return { available:false, reason:"DEBUG_MODE is disabled. Open with ?debug=1." };
     const report = window.__lastLayoutSaveIsolationReport || buildLayoutSaveDebugReport({ action:"no_layout_save_recorded" });

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -2659,9 +2659,9 @@ function persistDashboardLayout(state){
     setCloudLayout("dashboard", layoutClone);
   }
   if (!cloud.loaded) changed = true;
-  if (changed && typeof saveCloudDebounced === "function"){
-    console.info("Layout change persisted", { layout: "dashboardLayout", bytes: (typeof estimatePayloadBytes === "function" ? estimatePayloadBytes(layoutClone) : 0), saveTriggered: true });
-    try { saveCloudDebounced(); }
+  if (changed && typeof saveLayoutCloudOnly === "function"){
+    console.info("Layout change persisted", { layout: "dashboardLayout", bytes: (typeof estimatePayloadBytes === "function" ? estimatePayloadBytes(layoutClone) : 0), saveTriggered: true, savePath: "layout-only" });
+    try { saveLayoutCloudOnly("dashboard", layoutClone, { localStorageUpdated: true }); }
     catch (err) { console.warn("Unable to schedule cloud save for dashboard layout", err); }
   }
 }
@@ -3888,9 +3888,9 @@ function persistCostLayout(state){
     setCloudLayout("cost", layoutClone);
   }
   if (!cloud.loaded) changed = true;
-  if (changed && typeof saveCloudDebounced === "function"){
-    console.info("Cost layout saved", { bytes: (typeof estimatePayloadBytes === "function" ? estimatePayloadBytes(layoutClone) : 0), windowCount: Object.keys(layoutClone || {}).length, saveTriggered: true });
-    try { saveCloudDebounced(); }
+  if (changed && typeof saveLayoutCloudOnly === "function"){
+    console.info("Cost layout saved", { bytes: (typeof estimatePayloadBytes === "function" ? estimatePayloadBytes(layoutClone) : 0), windowCount: Object.keys(layoutClone || {}).length, saveTriggered: true, savePath: "layout-only" });
+    try { saveLayoutCloudOnly("cost", layoutClone, { localStorageUpdated: true }); }
     catch (err) { console.warn("Unable to schedule cloud save for cost layout", err); }
   }
 }
@@ -4404,9 +4404,9 @@ function persistJobLayout(state){
     setCloudLayout("jobs", layoutClone);
   }
   if (!cloud.loaded) changed = true;
-  if (changed && typeof saveCloudDebounced === "function"){
-    console.info("Layout change persisted", { layout: "jobLayout", bytes: (typeof estimatePayloadBytes === "function" ? estimatePayloadBytes(layoutClone) : 0), saveTriggered: true });
-    try { saveCloudDebounced(); }
+  if (changed && typeof saveLayoutCloudOnly === "function"){
+    console.info("Layout change persisted", { layout: "jobLayout", bytes: (typeof estimatePayloadBytes === "function" ? estimatePayloadBytes(layoutClone) : 0), saveTriggered: true, savePath: "layout-only" });
+    try { saveLayoutCloudOnly("jobs", layoutClone, { localStorageUpdated: true }); }
     catch (err) { console.warn("Unable to schedule cloud save for jobs layout", err); }
   }
 }

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -2637,7 +2637,9 @@ function persistDashboardLayout(state){
   const layoutSource = (state.layoutById && typeof state.layoutById === "object") ? state.layoutById : {};
   const layoutClone = cloneLayoutData(layoutSource);
   const hasLayout = layoutHasEntries(layoutClone);
+  const hadPendingLayoutChange = Boolean(state.layoutDirtyForCloud);
   const storage = dashboardLayoutStorage();
+  let localStorageUpdated = false;
   if (storage){
     try {
       if (hasLayout){
@@ -2645,6 +2647,7 @@ function persistDashboardLayout(state){
       }else{
         storage.removeItem(DASHBOARD_LAYOUT_STORAGE_KEY);
       }
+      localStorageUpdated = true;
     } catch (err){
       console.warn("Unable to persist dashboard layout", err);
     }
@@ -2654,14 +2657,27 @@ function persistDashboardLayout(state){
     state.root.classList.toggle("has-custom-layout", hasLayout);
   }
   const cloud = getCloudLayout("dashboard");
-  let changed = !cloud.loaded || !layoutsEqual(cloud.layout, layoutClone);
+  const layoutsEqualResult = layoutsEqual(cloud.layout, layoutClone);
+  let changed = !cloud.loaded || !layoutsEqualResult || hadPendingLayoutChange;
+  if (typeof recordLayoutPersistAttempt === "function"){
+    recordLayoutPersistAttempt("dashboard", {
+      action: "persistDashboardLayout_called",
+      layoutHasEntries: hasLayout,
+      localStorageUpdated,
+      cloudLoaded: cloud.loaded,
+      layoutsEqualResult,
+      changed,
+      saveLayoutCloudOnlyCalled: false
+    });
+  }
   if (!cloud.loaded || changed){
     setCloudLayout("dashboard", layoutClone);
   }
   if (!cloud.loaded) changed = true;
   if (changed && typeof saveLayoutCloudOnly === "function"){
     console.info("Layout change persisted", { layout: "dashboardLayout", bytes: (typeof estimatePayloadBytes === "function" ? estimatePayloadBytes(layoutClone) : 0), saveTriggered: true, savePath: "layout-only" });
-    try { saveLayoutCloudOnly("dashboard", layoutClone, { localStorageUpdated: true }); }
+    state.layoutDirtyForCloud = false;
+    try { saveLayoutCloudOnly("dashboard", layoutClone, { persistFunctionCalled: true, layoutHasEntries: hasLayout, localStorageUpdated, cloudLoaded: cloud.loaded, layoutsEqualResult, changed }); }
     catch (err) { console.warn("Unable to schedule cloud save for dashboard layout", err); }
   }
 }
@@ -3142,6 +3158,7 @@ function startDashboardWindowDrag(state, win, event){
     setDashboardWindowStyle(win, box);
     state.layoutById[id] = { ...(state.layoutById[id] || {}), ...box };
     state.activeLayoutById[id] = box;
+    state.layoutDirtyForCloud = true;
     updateDashboardRootSize(state, state.activeLayoutById);
   };
   const stop = ()=>{
@@ -3207,6 +3224,7 @@ function startDashboardWindowResize(state, win, direction, event){
     setDashboardWindowStyle(win, box);
     state.layoutById[id] = { ...(state.layoutById[id] || {}), ...box };
     state.activeLayoutById[id] = box;
+    state.layoutDirtyForCloud = true;
     updateDashboardRootSize(state, state.activeLayoutById);
     dispatchLayoutWindowResize("dashboard", id, win, box);
   };
@@ -3866,7 +3884,9 @@ function persistCostLayout(state){
   const layoutSource = (state.layoutById && typeof state.layoutById === "object") ? state.layoutById : {};
   const layoutClone = cloneLayoutData(layoutSource);
   const hasLayout = layoutHasEntries(layoutClone);
+  const hadPendingLayoutChange = Boolean(state.layoutDirtyForCloud);
   const storage = costLayoutStorage();
+  let localStorageUpdated = false;
   if (storage){
     try {
       if (hasLayout){
@@ -3874,6 +3894,7 @@ function persistCostLayout(state){
       }else{
         storage.removeItem(COST_LAYOUT_STORAGE_KEY);
       }
+      localStorageUpdated = true;
     } catch (err){
       console.warn("Unable to persist cost layout", err);
     }
@@ -3883,14 +3904,27 @@ function persistCostLayout(state){
     state.root.classList.toggle("has-custom-layout", hasLayout);
   }
   const cloud = getCloudLayout("cost");
-  let changed = !cloud.loaded || !layoutsEqual(cloud.layout, layoutClone);
+  const layoutsEqualResult = layoutsEqual(cloud.layout, layoutClone);
+  let changed = !cloud.loaded || !layoutsEqualResult || hadPendingLayoutChange;
+  if (typeof recordLayoutPersistAttempt === "function"){
+    recordLayoutPersistAttempt("cost", {
+      action: "persistCostLayout_called",
+      layoutHasEntries: hasLayout,
+      localStorageUpdated,
+      cloudLoaded: cloud.loaded,
+      layoutsEqualResult,
+      changed,
+      saveLayoutCloudOnlyCalled: false
+    });
+  }
   if (!cloud.loaded || changed){
     setCloudLayout("cost", layoutClone);
   }
   if (!cloud.loaded) changed = true;
   if (changed && typeof saveLayoutCloudOnly === "function"){
     console.info("Cost layout saved", { bytes: (typeof estimatePayloadBytes === "function" ? estimatePayloadBytes(layoutClone) : 0), windowCount: Object.keys(layoutClone || {}).length, saveTriggered: true, savePath: "layout-only" });
-    try { saveLayoutCloudOnly("cost", layoutClone, { localStorageUpdated: true }); }
+    state.layoutDirtyForCloud = false;
+    try { saveLayoutCloudOnly("cost", layoutClone, { persistFunctionCalled: true, layoutHasEntries: hasLayout, localStorageUpdated, cloudLoaded: cloud.loaded, layoutsEqualResult, changed }); }
     catch (err) { console.warn("Unable to schedule cloud save for cost layout", err); }
   }
 }
@@ -4126,6 +4160,7 @@ function startCostWindowDrag(state, win, event){
     setCostWindowStyle(win, box);
     state.layoutById[id] = { ...(state.layoutById[id] || {}), ...box };
     state.activeLayoutById[id] = box;
+    state.layoutDirtyForCloud = true;
     updateCostRootSize(state, state.activeLayoutById);
     scheduleCostLayoutRefresh(state);
   };
@@ -4192,6 +4227,7 @@ function startCostWindowResize(state, win, direction, event){
     setCostWindowStyle(win, box);
     state.layoutById[id] = { ...(state.layoutById[id] || {}), ...box };
     state.activeLayoutById[id] = box;
+    state.layoutDirtyForCloud = true;
     updateCostRootSize(state, state.activeLayoutById);
     scheduleCostLayoutRefresh(state);
     dispatchLayoutWindowResize("cost", id, win, box);
@@ -4382,7 +4418,9 @@ function persistJobLayout(state){
   const layoutSource = (state.layoutById && typeof state.layoutById === "object") ? state.layoutById : {};
   const layoutClone = cloneLayoutData(layoutSource);
   const hasLayout = layoutHasEntries(layoutClone);
+  const hadPendingLayoutChange = Boolean(state.layoutDirtyForCloud);
   const storage = jobLayoutStorage();
+  let localStorageUpdated = false;
   if (storage){
     try {
       if (hasLayout){
@@ -4390,6 +4428,7 @@ function persistJobLayout(state){
       }else{
         storage.removeItem(JOB_LAYOUT_STORAGE_KEY);
       }
+      localStorageUpdated = true;
     } catch (err){
       console.warn("Unable to persist jobs layout", err);
     }
@@ -4399,14 +4438,27 @@ function persistJobLayout(state){
     state.root.classList.toggle("has-custom-layout", hasLayout);
   }
   const cloud = getCloudLayout("jobs");
-  let changed = !cloud.loaded || !layoutsEqual(cloud.layout, layoutClone);
+  const layoutsEqualResult = layoutsEqual(cloud.layout, layoutClone);
+  let changed = !cloud.loaded || !layoutsEqualResult || hadPendingLayoutChange;
+  if (typeof recordLayoutPersistAttempt === "function"){
+    recordLayoutPersistAttempt("jobs", {
+      action: "persistJobLayout_called",
+      layoutHasEntries: hasLayout,
+      localStorageUpdated,
+      cloudLoaded: cloud.loaded,
+      layoutsEqualResult,
+      changed,
+      saveLayoutCloudOnlyCalled: false
+    });
+  }
   if (!cloud.loaded || changed){
     setCloudLayout("jobs", layoutClone);
   }
   if (!cloud.loaded) changed = true;
   if (changed && typeof saveLayoutCloudOnly === "function"){
     console.info("Layout change persisted", { layout: "jobLayout", bytes: (typeof estimatePayloadBytes === "function" ? estimatePayloadBytes(layoutClone) : 0), saveTriggered: true, savePath: "layout-only" });
-    try { saveLayoutCloudOnly("jobs", layoutClone, { localStorageUpdated: true }); }
+    state.layoutDirtyForCloud = false;
+    try { saveLayoutCloudOnly("jobs", layoutClone, { persistFunctionCalled: true, layoutHasEntries: hasLayout, localStorageUpdated, cloudLoaded: cloud.loaded, layoutsEqualResult, changed }); }
     catch (err) { console.warn("Unable to schedule cloud save for jobs layout", err); }
   }
 }
@@ -4638,6 +4690,7 @@ function startJobWindowDrag(state, win, event){
     setJobWindowStyle(win, box);
     state.layoutById[id] = { ...(state.layoutById[id] || {}), ...box };
     state.activeLayoutById[id] = box;
+    state.layoutDirtyForCloud = true;
     updateJobRootSize(state, state.activeLayoutById);
     scheduleJobLayoutRefresh(state);
   };
@@ -4704,6 +4757,7 @@ function startJobWindowResize(state, win, direction, event){
     setJobWindowStyle(win, box);
     state.layoutById[id] = { ...(state.layoutById[id] || {}), ...box };
     state.activeLayoutById[id] = box;
+    state.layoutDirtyForCloud = true;
     updateJobRootSize(state, state.activeLayoutById);
     scheduleJobLayoutRefresh(state);
     dispatchLayoutWindowResize("jobs", id, win, box);


### PR DESCRIPTION
### Motivation
- Prevent harmless dashboard/cost/job layout changes from triggering whole-app cloud saves that could overwrite protected business data. 
- Provide a safe, minimal cloud-write path for layout-only changes that preserves existing recovery/gate behavior and localStorage immediacy.

### Description
- Add `saveLayoutCloudOnly(area, layout, options)` in `js/core.js` which writes only the single layout key plus `syncMeta`, never calls `snapshotState()`, and uses existing write gates such as `canWriteCloud()` and revision checks. 
- Add `LAYOUT_SAVE_PROTECTED_KEYS` and `LAYOUT_SAVE_AREA_CONFIG` and a `buildLayoutSaveDebugReport()` helper, and expose `window.saveLayoutCloudOnly` and `window.debugLayoutSaveIsolation()` for DEBUG_MODE diagnostics. 
- Replace calls to `saveCloudDebounced()` in `persistDashboardLayout`, `persistCostLayout`, and `persistJobLayout` with `saveLayoutCloudOnly(...)`, while keeping immediate `localStorage` updates unchanged. 
- Preserve revision-conflict handling and do not change maintenance V2 creation/save logic or broad snapshot/save behavior for non-layout flows.

### Testing
- Checked for presence of `package.json` with `test -f package.json && cat package.json || echo "no package.json"` and confirmed there is no `package.json`. 
- Performed syntax checks with `node --check js/core.js`, `node --check js/calendar.js`, `node --check js/renderers.js`, and `node --check js/views.js`, all of which succeeded. 
- Ran a search for relevant layout/save symbols with `rg -n "persistDashboardLayout|persistCostLayout|persistJobLayout|dashboardLayout|costLayout|jobLayout|cloudDashboardLayout|cloudCostLayout|cloudJobLayout|saveCloudDebounced|saveCloudNow|saveCloudInternal|snapshotState|debugLayoutSaveIsolation|localStorage"` and verified updated call sites, which succeeded. 
- Ran `git diff --check` and basic commit operations to produce the PR changes, which succeeded; browser/manual Firebase preview tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57ab337a608325a9a5b08e53692e30)