### PR TITLE
Require confirmed cloud save for reviewed maintenance imports

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -5706,6 +5706,8 @@ function validateMaintenanceV2RepairRemoteBaseline(proof, remoteState){
 }
 
 const saveCloudInternal = debounce(async (saveOptions = {})=>{
+  let authoritativeStateWriteAttempted = false;
+  let authoritativeStateWriteCompleted = false;
   const explicitTrace = (typeof window !== "undefined" && window.__activeExplicitMaintenanceAddSaveTrace && typeof window.__activeExplicitMaintenanceAddSaveTrace === "object")
     ? window.__activeExplicitMaintenanceAddSaveTrace
     : null;
@@ -5900,7 +5902,9 @@ const saveCloudInternal = debounce(async (saveOptions = {})=>{
       explicitTrace.firestoreWritePayloadInstanceFound = Array.isArray(snap.maintenanceCalendarInstancesV2) && snap.maintenanceCalendarInstancesV2.some(entry => entry && String(entry.id || "") === String(explicitTrace.instanceId || ""));
       explicitTrace.firestoreWritePayloadOccurrenceFound = Array.isArray(snap.maintenanceOccurrencesV2) && snap.maintenanceOccurrencesV2.some(entry => entry && String(entry.id || "") === String(explicitTrace.occurrenceId || ""));
     }
+    authoritativeStateWriteAttempted = true;
     await FB.docRef.set(snap, { merge:true });
+    authoritativeStateWriteCompleted = true;
     if (explicitTrace) explicitTrace.firestoreSetCompleted = true;
     if (typeof window !== "undefined"){
       window.__loadedCloudRevisionForSaveGuard = Number(snap?.syncMeta?.rev || 0);
@@ -5938,14 +5942,27 @@ const saveCloudInternal = debounce(async (saveOptions = {})=>{
       explicitTrace.saveCloudInternalReturnValue = "completed";
       explicitTrace.saveCloudInternalReturnType = "resolved";
     }
+    const warnings = [];
     if (FB.workspaceDoc){
-      await updateWorkspaceMetadata({
-        workspaceId: WORKSPACE_ID,
-        lastTouchedAt: new Date().toISOString()
-      });
+      try {
+        await updateWorkspaceMetadata({
+          workspaceId: WORKSPACE_ID,
+          lastTouchedAt: new Date().toISOString()
+        });
+      } catch (metadataError){
+        const warning = `Authoritative state was saved, but workspace metadata was not updated: ${String(metadataError?.message || metadataError)}`;
+        warnings.push(warning);
+        console.warn(warning, metadataError);
+      }
     }
     window.__lastLoadedCloudState = { ...snap };
-    return { saved:true, path:FB.docRef?.path || `workspaces/${WORKSPACE_ID}/app/state` };
+    return {
+      saved:true,
+      stateWriteAttempted:true,
+      stateWriteCompleted:true,
+      path:FB.docRef?.path || `workspaces/${WORKSPACE_ID}/app/state`,
+      warnings
+    };
   }catch(e){
     if (explicitTrace){
       explicitTrace.firestoreSetError = e?.message || String(e);
@@ -5954,7 +5971,22 @@ const saveCloudInternal = debounce(async (saveOptions = {})=>{
       explicitTrace.hasPendingLocalChangesAfterInternal = Boolean(hasPendingLocalChanges);
     }
     console.error("Cloud save failed:", e);
-    return { saved:false, error:String(e?.message || e) };
+    if (authoritativeStateWriteCompleted){
+      return {
+        saved:true,
+        stateWriteAttempted:true,
+        stateWriteCompleted:true,
+        path:FB.docRef?.path || `workspaces/${WORKSPACE_ID}/app/state`,
+        warnings:[`Authoritative state was saved, but post-write bookkeeping failed: ${String(e?.message || e)}`]
+      };
+    }
+    return {
+      saved:false,
+      stateWriteAttempted:authoritativeStateWriteAttempted,
+      stateWriteCompleted:authoritativeStateWriteCompleted,
+      indeterminate:authoritativeStateWriteAttempted && !authoritativeStateWriteCompleted,
+      error:String(e?.message || e)
+    };
   }
 }, 1800);
 function recordDataFlowEvent(trigger = "save", nextSnapshot = null){

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -9470,12 +9470,77 @@ function createMaintenanceHistoryImportBackup(){
   return true;
 }
 
-function applyMaintenanceHistoryImportRows(previewRows){
-  const before = countMaintenanceHistoryImportProtectedState();
-  createMaintenanceHistoryImportBackup();
+function cloneMaintenanceHistoryImportValue(value){
+  if (typeof structuredClone === "function") return structuredClone(value);
+  return JSON.parse(JSON.stringify(value));
+}
+
+function maintenanceHistoryImportValueKey(value){
+  return JSON.stringify(value);
+}
+
+function captureMaintenanceHistoryImportManualHistory(){
+  return getMaintenanceHistoryImportTaskList().map(item => ({
+    mode:item.mode,
+    index:item.index,
+    task:item.task,
+    hadManualHistory:Object.prototype.hasOwnProperty.call(item.task, "manualHistory"),
+    manualHistory:cloneMaintenanceHistoryImportValue(item.task.manualHistory)
+  }));
+}
+
+function restoreMaintenanceHistoryImportManualHistory(snapshot){
+  (Array.isArray(snapshot) ? snapshot : []).forEach(item => {
+    if (item.hadManualHistory) item.task.manualHistory = cloneMaintenanceHistoryImportValue(item.manualHistory);
+    else delete item.task.manualHistory;
+  });
+  const mismatch = (Array.isArray(snapshot) ? snapshot : []).find(item => {
+    const hasProperty = Object.prototype.hasOwnProperty.call(item.task, "manualHistory");
+    return hasProperty !== item.hadManualHistory || maintenanceHistoryImportValueKey(item.task.manualHistory) !== maintenanceHistoryImportValueKey(item.manualHistory);
+  });
+  if (mismatch) throw new Error(`Rollback verification failed for ${mismatch.mode} task index ${mismatch.index}.`);
+}
+
+function verifyMaintenanceHistoryImportMutation(historySnapshot, touchedTasks, plannedIds){
+  const planned = new Set(plannedIds);
+  (Array.isArray(historySnapshot) ? historySnapshot : []).forEach(item => {
+    const beforeHistory = Array.isArray(item.manualHistory) ? item.manualHistory : [];
+    const afterHistory = Array.isArray(item.task.manualHistory) ? item.task.manualHistory : [];
+    const added = touchedTasks.get(item.task) || [];
+    if (!added.length){
+      if (maintenanceHistoryImportValueKey(item.task.manualHistory) !== maintenanceHistoryImportValueKey(item.manualHistory)){
+        throw new Error(`Unrelated manualHistory changed for ${item.mode} task index ${item.index}.`);
+      }
+      return;
+    }
+    if (afterHistory.length !== beforeHistory.length + added.length
+      || maintenanceHistoryImportValueKey(afterHistory.slice(0, beforeHistory.length)) !== maintenanceHistoryImportValueKey(beforeHistory)){
+      throw new Error(`Existing manualHistory was edited, removed, or reordered for ${item.mode} task index ${item.index}.`);
+    }
+    const actualAdded = afterHistory.slice(beforeHistory.length);
+    if (maintenanceHistoryImportValueKey(actualAdded) !== maintenanceHistoryImportValueKey(added)){
+      throw new Error(`Unexpected manualHistory entries were added for ${item.mode} task index ${item.index}.`);
+    }
+    if (actualAdded.some(entry => !planned.has(String(entry?.import_event_id || "")))){
+      throw new Error(`A new manualHistory entry did not have a planned import_event_id.`);
+    }
+  });
+}
+
+async function applyMaintenanceHistoryImportRows(previewRows){
+  const savePathDefault = typeof WORKSPACE_ID !== "undefined" ? `workspaces/${WORKSPACE_ID}/app/state` : "workspaces/{workspaceId}/app/state";
+  const result = {
+    importAttempted:true, importCompleted:false, saveAttempted:false, saveCompleted:false,
+    savePath:savePathDefault, saveError:"", saveWarnings:[], saveIndeterminate:false,
+    rolledBack:false, rollbackError:"", stats:null, before:null, after:null,
+    plannedImportEventIds:[], importedImportEventIds:[]
+  };
   const stats = { imported: 0, duplicate: 0, unresolved: 0, ambiguous: 0, excluded: 0, invalid: 0, failed: 0 };
-  const nowISO = new Date().toISOString();
-  (Array.isArray(previewRows) ? previewRows : []).forEach(item => {
+  result.stats = stats;
+  const submitted = Array.isArray(previewRows) ? previewRows : [];
+  const seen = new Set();
+  const validRows = [];
+  submitted.forEach(item => {
     if (!item || item.status !== "ready"){
       if (item?.status === "duplicate") stats.duplicate += 1;
       else if (item?.status === "unresolved") stats.unresolved += 1;
@@ -9484,52 +9549,111 @@ function applyMaintenanceHistoryImportRows(previewRows){
       else stats.invalid += 1;
       return;
     }
-    if (maintenanceHistoryImportHasDuplicate(item.import_event_id)){
-      stats.duplicate += 1;
-      return;
-    }
-    const task = item.match?.task;
-    if (!task || typeof task !== "object"){
-      stats.failed += 1;
-      return;
-    }
+    const raw = item.raw || item;
+    const eventId = String(raw?.import_event_id || "").trim();
+    const dateISO = String(raw?.scheduled_maintenance_date || "").trim();
+    const taskName = String(raw?.exact_website_task || "").trim();
+    const normalizedTask = normalizeMaintenanceImportTaskName(taskName);
+    if (!eventId || !isCanonicalMaintenanceImportDateISO(dateISO) || !taskName){ stats.invalid += 1; return; }
+    if (MAINTENANCE_HISTORY_IMPORT_EXCLUDED_TASKS.has(normalizedTask) || !MAINTENANCE_HISTORY_IMPORT_ALLOWED_TASKS.has(normalizedTask)){ stats.excluded += 1; return; }
+    const resolved = resolveMaintenanceHistoryImportTask(taskName);
+    if (resolved.status === "ambiguous"){ stats.ambiguous += 1; return; }
+    if (resolved.status !== "ready"){ stats.unresolved += 1; return; }
+    if (seen.has(eventId) || maintenanceHistoryImportHasDuplicate(eventId)){ stats.duplicate += 1; return; }
+    seen.add(eventId);
+    validRows.push({ raw, eventId, dateISO, taskName, match:resolved.match });
+  });
+  result.plannedImportEventIds = validRows.map(row => row.eventId);
+  if (!validRows.length){
+    result.saveError = "No currently valid ready rows were available to import.";
+    return result;
+  }
+  try {
+    createMaintenanceHistoryImportBackup();
+  } catch (backupError){
+    result.saveError = `Required backup failed: ${String(backupError?.message || backupError)}`;
+    return result;
+  }
+  const historySnapshot = captureMaintenanceHistoryImportManualHistory();
+  const before = countMaintenanceHistoryImportProtectedState();
+  result.before = before;
+  const touchedTasks = new Map();
+  const nowISO = new Date().toISOString();
+  validRows.forEach(item => {
+    const task = item.match.task;
     if (!Array.isArray(task.manualHistory)) task.manualHistory = [];
-    task.manualHistory.push({
-      dateISO: item.scheduled_maintenance_date,
+    const entry = {
+      dateISO: item.dateISO,
       status: "completed",
       source: "history_import",
       recordedAtISO: nowISO,
       hoursAtEntry: null,
       estimatedDailyHours: null,
-      import_event_id: item.import_event_id,
+      import_event_id: item.eventId,
       note: "Imported from reviewed purchase-proven maintenance history",
       provenance: {
-        import_event_id: item.import_event_id,
-        matchedTaskName: item.exact_website_task,
+        import_event_id: item.eventId,
+        matchedTaskName: item.taskName,
         matchedTaskId: String(task.id || ""),
         source: "reviewed_purchase_history",
-        sourcePurchaseDate: String(item.raw?.source_purchase_date || ""),
-        orderNumber: String(item.raw?.order_number || ""),
-        purchaseDescription: String(item.raw?.purchase_description || ""),
-        matchedPart: String(item.raw?.matched_part || ""),
-        quantityInstance: String(item.raw?.quantity_instance || ""),
-        quantitySource: String(item.raw?.quantity_source || ""),
-        confidence: String(item.raw?.confidence || ""),
-        notes: String(item.raw?.notes || "")
+        sourcePurchaseDate: String(item.raw.source_purchase_date || ""),
+        orderNumber: String(item.raw.order_number || ""),
+        purchaseDescription: String(item.raw.purchase_description || ""),
+        matchedPart: String(item.raw.matched_part || ""),
+        quantityInstance: String(item.raw.quantity_instance || ""),
+        quantitySource: String(item.raw.quantity_source || ""),
+        confidence: String(item.raw.confidence || ""),
+        notes: String(item.raw.notes || "")
       }
-    });
-    task.manualHistory.sort((a, b)=> String(a?.dateISO || "").localeCompare(String(b?.dateISO || "")) || String(a?.import_event_id || "").localeCompare(String(b?.import_event_id || "")));
+    };
+    task.manualHistory.push(entry);
+    if (!touchedTasks.has(task)) touchedTasks.set(task, []);
+    touchedTasks.get(task).push(entry);
     stats.imported += 1;
+    result.importedImportEventIds.push(item.eventId);
   });
   const after = countMaintenanceHistoryImportProtectedState();
+  result.after = after;
   const drops = findMaintenanceHistoryImportDrops(before, after);
-  if (drops.length) throw new Error(`Protected data count dropped unexpectedly: ${drops.join(", ")}`);
-  if (typeof saveTasks === "function") saveTasks();
-  if (typeof saveCloudNow === "function") saveCloudNow();
-  else if (typeof saveCloudDebounced === "function") saveCloudDebounced();
-  if (typeof renderCalendar === "function") renderCalendar();
-  if (typeof refreshDashboardWidgets === "function") refreshDashboardWidgets();
-  return { stats, before, after };
+  try {
+    if (drops.length) throw new Error(`Protected data count dropped unexpectedly: ${drops.join(", ")}`);
+    verifyMaintenanceHistoryImportMutation(historySnapshot, touchedTasks, result.plannedImportEventIds);
+  } catch (verificationError){
+    result.saveError = String(verificationError?.message || verificationError);
+    try { restoreMaintenanceHistoryImportManualHistory(historySnapshot); result.rolledBack = true; }
+    catch (rollbackError){ result.rollbackError = String(rollbackError?.message || rollbackError); }
+    return result;
+  }
+  if (typeof saveCloudNow !== "function"){
+    result.saveError = "Authoritative cloud save is unavailable.";
+    try { restoreMaintenanceHistoryImportManualHistory(historySnapshot); result.rolledBack = true; }
+    catch (rollbackError){ result.rollbackError = String(rollbackError?.message || rollbackError); }
+    return result;
+  }
+  result.saveAttempted = true;
+  let saveResult;
+  try {
+    saveResult = await saveCloudNow();
+  } catch (saveError){
+    saveResult = { saved:false, stateWriteAttempted:false, stateWriteCompleted:false, error:String(saveError?.message || saveError) };
+  }
+  result.savePath = String(saveResult?.path || savePathDefault);
+  result.saveCompleted = saveResult?.saved === true && saveResult?.stateWriteCompleted === true;
+  result.saveWarnings = Array.isArray(saveResult?.warnings) ? saveResult.warnings.slice() : [];
+  result.saveError = String(saveResult?.error || "");
+  result.saveIndeterminate = !result.saveCompleted && saveResult?.indeterminate === true;
+  if (result.saveCompleted){
+    result.importCompleted = true;
+    return result;
+  }
+  if (result.saveIndeterminate){
+    if (!result.saveError) result.saveError = "Cloud save completion is indeterminate; refresh and verify before retrying.";
+    return result;
+  }
+  if (!result.saveError) result.saveError = "Authoritative Firestore state write was not completed.";
+  try { restoreMaintenanceHistoryImportManualHistory(historySnapshot); result.rolledBack = true; }
+  catch (rollbackError){ result.rollbackError = String(rollbackError?.message || rollbackError); }
+  return result;
 }
 
 
@@ -9663,6 +9787,7 @@ function wireMaintenanceHistoryImportTool(root){
   const confirmInput = root?.querySelector?.("#maintenanceHistoryImportConfirm");
   const previewEl = root?.querySelector?.("#maintenanceHistoryImportPreview");
   const statusEl = root?.querySelector?.("#maintenanceHistoryImportStatus");
+  let importRunning = false;
   const setStatus = (message, isError = false)=> {
     if (!statusEl) return;
     statusEl.textContent = message || "";
@@ -9671,7 +9796,14 @@ function wireMaintenanceHistoryImportTool(root){
   const hasReadyPreviewRows = ()=> (Array.isArray(window.__maintenanceHistoryImportPreviewRows) ? window.__maintenanceHistoryImportPreviewRows : []).some(row => row.status === "ready");
   const confirmationIsExact = ()=> String(confirmInput?.value || "") === "IMPORT REVIEWED MAINTENANCE";
   const updateImportButtonState = ()=> {
-    if (importBtn) importBtn.disabled = !(hasReadyPreviewRows() && confirmationIsExact());
+    if (importBtn) importBtn.disabled = importRunning || !(hasReadyPreviewRows() && confirmationIsExact());
+  };
+  const setImportControlsLocked = locked => {
+    importRunning = Boolean(locked);
+    fileInput.disabled = importRunning;
+    previewBtn.disabled = importRunning;
+    confirmInput.disabled = importRunning;
+    updateImportButtonState();
   };
   if (!fileInput || !previewBtn || !importBtn || !confirmInput || !previewEl) return;
   updateImportButtonState();
@@ -9694,23 +9826,38 @@ function wireMaintenanceHistoryImportTool(root){
       setStatus(`Preview failed: ${err && err.message ? err.message : err}`, true);
     }
   });
-  importBtn.addEventListener("click", ()=> {
+  importBtn.addEventListener("click", async ()=> {
+    if (importRunning) return;
     const previewRows = Array.isArray(window.__maintenanceHistoryImportPreviewRows) ? window.__maintenanceHistoryImportPreviewRows : [];
     if (!previewRows.some(row => row.status === "ready")){ setStatus("No ready rows to import.", true); return; }
     if (String(confirmInput.value || "") !== "IMPORT REVIEWED MAINTENANCE"){
       setStatus('Type "IMPORT REVIEWED MAINTENANCE" to confirm the append-only import.', true);
       return;
     }
+    setImportControlsLocked(true);
+    setStatus("Saving reviewed maintenance history…");
     try {
-      const result = applyMaintenanceHistoryImportRows(previewRows);
+      const result = await applyMaintenanceHistoryImportRows(previewRows);
       const stats = result.stats || {};
-      setStatus(`Import complete. Imported ${stats.imported || 0}; duplicates ${stats.duplicate || 0}; unresolved ${stats.unresolved || 0}; ambiguous ${stats.ambiguous || 0}; excluded ${stats.excluded || 0}; invalid ${stats.invalid || 0}; failed ${stats.failed || 0}. Protected top-level counts did not drop.`);
-      const refreshed = buildMaintenanceHistoryImportPreview(previewRows.map(row => row.raw));
-      window.__maintenanceHistoryImportPreviewRows = refreshed;
-      renderMaintenanceHistoryImportPreview(previewEl, refreshed);
-      updateImportButtonState();
+      if (result.saveCompleted === true){
+        const warningText = result.saveWarnings?.length ? ` Warning: ${result.saveWarnings.join(" ")}` : "";
+        setStatus(`Import complete. Imported ${stats.imported || 0}. Confirmed cloud save completed at ${result.savePath}.${warningText}`);
+        const refreshed = buildMaintenanceHistoryImportPreview(previewRows.map(row => row.raw));
+        window.__maintenanceHistoryImportPreviewRows = refreshed;
+        renderMaintenanceHistoryImportPreview(previewEl, refreshed);
+        if (typeof renderCalendar === "function") renderCalendar();
+        if (typeof refreshDashboardWidgets === "function") refreshDashboardWidgets();
+      }else if (result.saveIndeterminate){
+        setStatus(`Import not confirmed: ${result.saveError || "Cloud state-write completion is indeterminate."} Do not retry until a refresh/read verifies the authoritative state.`, true);
+      }else if (result.rolledBack){
+        setStatus(`Nothing was saved. ${result.saveError || "The authoritative state write failed or was blocked."} Local changes were rolled back${result.rollbackError ? ` with an error: ${result.rollbackError}` : "."}`, true);
+      }else{
+        setStatus(`Import blocked: ${result.saveError || "Authoritative cloud save was not confirmed."}${result.rollbackError ? ` Rollback error: ${result.rollbackError}` : ""}`, true);
+      }
     } catch (err){
       setStatus(`Import blocked: ${err && err.message ? err.message : err}`, true);
+    } finally {
+      setImportControlsLocked(false);
     }
   });
 }

--- a/tests/maintenance-history-import.test.js
+++ b/tests/maintenance-history-import.test.js
@@ -1,0 +1,111 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const vm = require("node:vm");
+
+const rendererSource = fs.readFileSync("js/renderers.js", "utf8");
+const start = rendererSource.indexOf("function normalizeMaintenanceImportTaskName");
+const end = rendererSource.indexOf("function cleanupMi02cTinyMaintenanceImportRows");
+assert.ok(start >= 0 && end > start, "importer source section is available");
+
+function createHarness(saveCloudNow){
+  const window = {
+    tasksInterval:[{ id:"filter", name:"RO Micron Filter", manualHistory:[{ dateISO:"2024-01-01", status:"completed", note:"keep" }], completedDates:["2024-01-01"] }],
+    tasksAsReq:[], maintenanceTasksV2:[{ id:"v2-task" }],
+    maintenanceCalendarInstancesV2:[{ id:"v2-instance" }],
+    maintenanceOccurrencesV2:[], cuttingJobs:[{ id:"job" }], completedCuttingJobs:[],
+    settingsFolders:[{ id:"folder" }], inventory:[{ id:"stock" }], inventoryFolders:[],
+    inventoryMaterials:[], receiptTrackerWeeks:[], orderRequests:[], dailyCutHours:[], garnetCleanings:[]
+  };
+  const context = {
+    window, console, Date, Set, Map, JSON, Object, Array, String, Number, RegExp,
+    structuredClone, saveCloudNow,
+    exportJsonDownload:()=>true,
+    getCurrentAppStateForDiagnostics:()=>structuredClone(window)
+  };
+  vm.createContext(context);
+  vm.runInContext(rendererSource.slice(start, end) + "\nthis.api={applyMaintenanceHistoryImportRows,buildMaintenanceHistoryImportPreview,countMaintenanceHistoryImportProtectedState,findMaintenanceHistoryImportDrops};", context);
+  return { window, api:context.api };
+}
+
+function row(id="event-1", task="RO Micron Filter", date="2025-02-03"){
+  return { import_event_id:id, scheduled_maintenance_date:date, exact_website_task:task };
+}
+
+async function run(){
+  {
+    const h = createHarness(async()=>({ saved:true, stateWriteCompleted:true, path:"workspaces/test/app/state" }));
+    const beforeV2 = structuredClone([h.window.maintenanceTasksV2, h.window.maintenanceCalendarInstancesV2, h.window.maintenanceOccurrencesV2]);
+    const beforeDates = structuredClone(h.window.tasksInterval[0].completedDates);
+    const result = await h.api.applyMaintenanceHistoryImportRows(h.api.buildMaintenanceHistoryImportPreview([row()]));
+    assert.equal(result.importCompleted, true);
+    assert.equal(result.saveCompleted, true);
+    assert.deepEqual(Array.from(result.importedImportEventIds), ["event-1"]);
+    assert.deepEqual([h.window.maintenanceTasksV2, h.window.maintenanceCalendarInstancesV2, h.window.maintenanceOccurrencesV2], beforeV2, "V2 state is untouched");
+    assert.deepEqual(h.window.tasksInterval[0].completedDates, beforeDates, "completedDates is untouched");
+    assert.deepEqual(h.window.tasksInterval[0].manualHistory[0], { dateISO:"2024-01-01", status:"completed", note:"keep" }, "existing history remains byte-for-byte ordered");
+    const reimport = await h.api.applyMaintenanceHistoryImportRows(h.api.buildMaintenanceHistoryImportPreview([row()]));
+    assert.equal(reimport.stats.duplicate, 1);
+    assert.equal(reimport.saveAttempted, false, "successful IDs become duplicate/no-op");
+  }
+  for (const save of [
+    async()=>({ saved:false, stateWriteAttempted:false, stateWriteCompleted:false, error:"blocked" }),
+    async()=>{ throw new Error("before write"); }
+  ]){
+    const h = createHarness(save);
+    const original = structuredClone(h.window.tasksInterval[0].manualHistory);
+    const result = await h.api.applyMaintenanceHistoryImportRows(h.api.buildMaintenanceHistoryImportPreview([row()]));
+    assert.equal(result.saveCompleted, false);
+    assert.equal(result.rolledBack, true);
+    assert.deepEqual(h.window.tasksInterval[0].manualHistory, original, "failed save restores exact history");
+  }
+  {
+    const h = createHarness(async()=>({ saved:true, stateWriteCompleted:true, warnings:["metadata failed"] }));
+    const result = await h.api.applyMaintenanceHistoryImportRows(h.api.buildMaintenanceHistoryImportPreview([row()]));
+    assert.equal(result.saveCompleted, true);
+    assert.equal(result.rolledBack, false, "auxiliary warning does not roll back confirmed write");
+    assert.deepEqual(Array.from(result.saveWarnings), ["metadata failed"]);
+  }
+  {
+    const h = createHarness(async()=>({ saved:false, stateWriteAttempted:true, stateWriteCompleted:false, indeterminate:true, error:"unknown outcome" }));
+    const result = await h.api.applyMaintenanceHistoryImportRows(h.api.buildMaintenanceHistoryImportPreview([row()]));
+    assert.equal(result.saveIndeterminate, true);
+    assert.equal(result.rolledBack, false, "indeterminate writes are not retried or rolled back");
+  }
+  {
+    const h = createHarness(async()=>({ saved:true, stateWriteCompleted:true }));
+    h.window.maintenanceOccurrencesV2.push({ import_event_id:"existing-v2" });
+    const rows = [row("same"), row("same", "RO Micron Filter", "2025-02-04"), row("existing-v2")];
+    const preview = h.api.buildMaintenanceHistoryImportPreview(rows);
+    assert.deepEqual(Array.from(preview, item=>item.status), ["ready", "duplicate", "duplicate"]);
+    const result = await h.api.applyMaintenanceHistoryImportRows(preview);
+    assert.equal(result.stats.imported, 1);
+    assert.equal(result.stats.duplicate, 2);
+  }
+  {
+    const h = createHarness(async()=>({ saved:true, stateWriteCompleted:true }));
+    h.window.tasksInterval.push({ id:"second", name:"RO Micron Filter", manualHistory:[] });
+    const preview = h.api.buildMaintenanceHistoryImportPreview([
+      row("ambiguous"), row("excluded", "Mixing Tube Rotation"), row("invalid", "RO Micron Filter", "2025-02-30"), row("unresolved", "Pump Rebuild")
+    ]);
+    assert.deepEqual(Array.from(preview, item=>item.status), ["ambiguous", "excluded", "invalid date", "unresolved"]);
+    const result = await h.api.applyMaintenanceHistoryImportRows(preview);
+    assert.equal(result.saveAttempted, false);
+    assert.equal(result.stats.imported, 0);
+  }
+  {
+    const h = createHarness(async()=>({ saved:true, stateWriteCompleted:true }));
+    const before = h.api.countMaintenanceHistoryImportProtectedState();
+    h.window.inventory.length = 0;
+    const after = h.api.countMaintenanceHistoryImportProtectedState();
+    assert.deepEqual(Array.from(h.api.findMaintenanceHistoryImportDrops(before, after)), ["inventory"], "protected collection reduction is detected");
+  }
+  const wireSection = rendererSource.slice(rendererSource.indexOf("function wireMaintenanceHistoryImportTool"), rendererSource.indexOf("function renderSettings"));
+  assert.match(wireSection, /if \(importRunning\) return;/, "concurrent import attempts are ignored");
+  assert.match(wireSection, /finally\s*{[\s\S]*setImportControlsLocked\(false\)/, "controls restore in finally");
+  assert.match(wireSection, /if \(result\.saveCompleted === true\)[\s\S]*buildMaintenanceHistoryImportPreview/, "preview rebuild is success-only");
+  console.log("maintenance history importer deterministic tests passed");
+}
+
+run().catch(error => { console.error(error); process.exitCode = 1; });


### PR DESCRIPTION
### Motivation

- Ensure the Reviewed Maintenance History Import waits for an authoritative Firestore state write before reporting success and never reports “Import complete” until persistence is confirmed.
- If the authoritative write is blocked or fails prior to completion, restore the exact pre-import in-memory `manualHistory` values and clearly report the failure.
- Distinguish authoritative write completion from later noncritical bookkeeping (metadata/log) failures so confirmed writes are not rolled back.

### Description

- Update `saveCloudInternal` to record whether the authoritative `FB.docRef.set()` was attempted and completed, and to return a structured result that preserves `stateWriteCompleted: true` when the authoritative write succeeded even if post-write bookkeeping fails; metadata failures are returned as warnings. (`js/core.js`).
- Convert `applyMaintenanceHistoryImportRows()` into an async operation that revalidates every `ready` row immediately before mutation, requires a successful full-state backup, captures exact pre-import `manualHistory` snapshots (including whether the `manualHistory` property existed), builds a precise planned-import-ID list, applies only valid rows to legacy `manualHistory`, verifies only intended mutations occurred and protected counts did not drop, and then `await saveCloudNow()` on the authoritative path; on pre-write failure it restores the exact snapshots and verifies rollback. (`js/renderers.js`).
- Implement a small verification/rollback helper set: `captureMaintenanceHistoryImportManualHistory`, `restoreMaintenanceHistoryImportManualHistory`, `verifyMaintenanceHistoryImportMutation`, value-cloning helpers, and a structured import result including `importAttempted`, `importCompleted`, `saveAttempted`, `saveCompleted`, `savePath`, `saveError`, `rolledBack`, `rollbackError`, `stats`, `before`, `after`, `plannedImportEventIds`, and `importedImportEventIds`. (`js/renderers.js`).
- Make the importer UI handler asynchronous and await the import result, lock relevant controls during the save, display `Saving reviewed maintenance history…`, prevent concurrent imports/double clicks, rebuild the preview only after confirmed save, show errors/warnings for blocked/indeterminate outcomes, and always restore controls in `finally`. (`js/renderers.js`).
- Added deterministic mocked tests that exercise confirmed saves, blocked/thrown saves before the authoritative write, exact rollback verification, auxiliary-warning post-write behavior, indeterminate outcomes, duplicate detection, excluded/ambiguous/unresolved/invalid cases, protected-collection drop detection, V2 and `completedDates` immutability, re-import idempotency, and UI concurrency/success gating. (`tests/maintenance-history-import.test.js`).
- Exact files changed: `js/core.js`, `js/renderers.js`, and `tests/maintenance-history-import.test.js`.

Save-completion determination and rollback design

- Save completion is determined by a resolved `FB.docRef.set()` inside `saveCloudInternal`; the save API now explicitly returns `stateWriteAttempted` and `stateWriteCompleted` (both true when the authoritative write was confirmed). The importer treats `saved === true && stateWriteCompleted === true` as a confirmed cloud save.
- If `saveCloudNow()` returns a result that indicates the authoritative write was not completed (or the call rejects before the write), the importer treats the save as a definite failure and restores the captured pre-import `manualHistory` snapshots exactly (including removing `manualHistory` where it did not previously exist) and verifies byte-for-byte equality after rollback.
- If the authoritative write succeeded but later noncritical bookkeeping (workspace metadata / log writes) throws, the save is reported as successful (`saveCompleted: true`) and any bookkeeping failure is returned as a warning; the importer does not roll back confirmed writes.
- If the save result is genuinely indeterminate (the write was attempted but not confirmed), the importer returns `saveIndeterminate: true`, does not retry or roll back, and instructs operators to refresh/verify before attempting a re-import.

### Testing

- Ran repository/environment checks and automated tests locally against the modified code with deterministic mocks (no real Firestore or authenticated writes were performed):
  - ✅ `test ! -f package.json` — `package.json` is absent; npm commands were skipped.
  - ✅ `node --check js/core.js` — syntax check passed.
  - ✅ `node --check js/renderers.js` — syntax check passed.
  - ✅ `node --check tests/maintenance-history-import.test.js` — test file syntax passed.
  - ✅ `node tests/maintenance-history-import.test.js` — deterministic mocked importer tests passed (confirmed successful write, blocked throws before write with successful rollback, auxiliary metadata-warning behavior, indeterminate outcome handling, duplicate/invalid/excluded/unresolved/ambiguous handling, protected-collection reduction detection, no V2/completedDates mutation, idempotent re-import behavior, and UI concurrency gating).
  - ✅ `git diff --check` — no whitespace/patch errors.
  - ✅ `test "$(cat vercel.json)" = $'{\n  "cleanUrls": true\n}'` — `vercel.json` remains the required cleanUrls-only content and was not changed.

Testing caveats / not tested

- ⚠️ Authenticated browser and real Firestore writes were intentionally NOT executed; the tests use mocked `saveCloudNow` implementations and a JS `vm` harness so no real network or authenticated mutation occurred.
- ⚠️ The `make_pr` helper was not available in this environment so an automated PR creation tool was not invoked; a commit was created on branch `work` instead. No remote PR or Vercel preview URL was produced from this runtime.

If you want, I can open a GitHub PR with this title/body and attach the change; note that creating the remote PR and obtaining a Vercel preview requires repository remotes and the `make_pr` tool available in your environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79fad3d9948325a4bd1db7625e77fb)