### PR TITLE
MI-02K: Prevent Pump Rebuild duplicate resurrection and add audit/repair helpers

### DIFF
--- a/docs/mi-02k-pump-rebuild-safety.md
+++ b/docs/mi-02k-pump-rebuild-safety.md
@@ -1,0 +1,20 @@
+# MI-02K Pump Rebuild duplication safety
+
+The duplicate was resurrected because `renderCalendar()` called
+`restoreCriticalIntervalTasks()`. That helper searched trash by the deleted
+task's old ID/name and restored every matching critical task before it checked
+whether an equivalent active task already satisfied the requirement. Calendar
+rendering then scheduled recovered tasks and requested a debounced full-state
+cloud save. Thus an ordinary render could mutate `tasksInterval` and persist
+the mutation.
+
+MI-02K makes calendar rendering read-only and changes critical recovery to use
+normalized name plus scheduling configuration. An active 500-hour interval
+Pump Rebuild now satisfies recovery regardless of its generated ID. Recovery
+remains available when no equivalent active critical task exists.
+
+Task `mode` and `cat` are intentionally separate. `mode=interval` or
+`mode=asreq` controls scheduling behavior; `cat=root` means the task is placed
+at the settings-tree root. Old tasks can therefore legitimately have a
+scheduling mode while remaining in the root folder. Folder migration is out of
+scope until the Pump Rebuild state is stable.

--- a/index.html
+++ b/index.html
@@ -205,6 +205,7 @@
   <script src="js/computations.js"></script>
   <script src="js/opportunity.js"></script>
   <script src="js/pump.js"></script>
+  <script src="js/maintenance-duplication.js"></script>
   <script src="js/calendar.js"></script>
   <script src="js/views.js"></script>
   <script src="js/renderers.js"></script>

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -2950,7 +2950,14 @@ function restoreCriticalIntervalTasks(){
   if (restoreFromTrash((id,name)=> id.includes("mixing_tube_rotation") || name.includes("mixing tube rotation"))) changed = true;
   if (restoreFromTrash((id,name)=> id.includes("pump_tube_noz_filter") || (name.includes("mixing tube") && name.includes("replace")) || (name.includes("pump tube") && name.includes("nozzle filter")))) changed = true;
   if (restoreFromTrash((id,name)=> id.includes("jewel_nozzle_clean") || (name.includes("jew") && name.includes("orifice") && name.includes("nozzle")))) changed = true;
-  if (restoreFromTrash((id,name)=> id.includes("pump_rebuild") || (name.includes("pump") && name.includes("rebuild")))) changed = true;
+  const activePumpEquivalent = tasks.some(task => {
+    if (typeof window.normalizeMaintenanceTaskIdentity !== "function"){
+      return String(task?.name || "").trim().toLowerCase() === "pump rebuild" && String(task?.mode || "interval") === "interval" && Number(task?.interval) === 500;
+    }
+    return window.normalizeMaintenanceTaskIdentity(task).equivalentKey === "pump rebuild|interval|500";
+  });
+  // Recovery is by task identity/configuration, never by a deleted object's old ID.
+  if (!activePumpEquivalent && restoreFromTrash((id,name)=> id.includes("pump_rebuild") || (name.includes("pump") && name.includes("rebuild")))) changed = true;
   const matched = [];
   tasks.forEach(task => {
     if (!task) return;
@@ -3016,9 +3023,7 @@ function restoreCriticalIntervalTasks(){
 }
 
 function renderCalendar(){
-  if (restoreCriticalIntervalTasks()){
-    if (typeof saveCloudDebounced === "function") saveCloudDebounced();
-  }
+  // Rendering is read-only. Recovery runs only from explicit load/recovery flows.
   const container = $("#months");
   if (!container) return;
   let showAll = Boolean(window.__calendarShowAllMonths);

--- a/js/maintenance-duplication.js
+++ b/js/maintenance-duplication.js
@@ -1,0 +1,153 @@
+"use strict";
+
+// MI-02K: task folders are intentionally not normalized here.  Older tasks can
+// have mode=interval/asreq while cat=root because mode controls scheduling and
+// cat controls only the independently editable settings-tree placement.
+(function maintenanceDuplicationSafety(global){
+  const CANONICAL_ID = "pump_rebuild_msnpt6hi";
+  const DUPLICATE_ID = "pump_rebuild_msnpt6gs";
+  const IMPORT_IDS = ["OMAX-2067268-302701-01", "OMAX-2070032-302701-01"];
+
+  const clone = value => typeof structuredClone === "function" ? structuredClone(value) : JSON.parse(JSON.stringify(value));
+  const key = value => JSON.stringify(value);
+  const normalizeName = value => String(value || "").trim().toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+  const normalizeMode = task => String(task?.mode || "interval").trim().toLowerCase();
+  const taskIdentity = task => normalizeName(task?.name);
+  const taskConfiguration = task => `${normalizeMode(task)}|${Number(task?.interval) || 0}`;
+  const equivalentKey = task => `${taskIdentity(task)}|${taskConfiguration(task)}`;
+  const isPumpRebuild = task => taskIdentity(task) === "pump rebuild";
+  const isEquivalentPump = task => isPumpRebuild(task) && normalizeMode(task) === "interval" && Number(task?.interval) === 500;
+  const historyIds = task => (Array.isArray(task?.manualHistory) ? task.manualHistory : []).map(entry => String(entry?.import_event_id || entry?.importEventId || entry?.provenance?.import_event_id || entry?.provenance?.importEventId || "")).filter(Boolean);
+  const count = value => Array.isArray(value) ? value.length : 0;
+
+  function normalizeMaintenanceTaskIdentity(task){
+    return { identity:taskIdentity(task), mode:normalizeMode(task), interval:Number(task?.interval) || 0, configuration:taskConfiguration(task), equivalentKey:equivalentKey(task) };
+  }
+
+  let creationLock = null;
+  function createMaintenanceTaskOnce(actionToken, spec, create){
+    const token = String(actionToken || "");
+    const signature = equivalentKey(spec || {});
+    if (creationLock && creationLock.token === token) return { created:false, task:creationLock.task, reason:"same-action" };
+    const list = normalizeMode(spec) === "asreq" ? global.tasksAsReq : global.tasksInterval;
+    const sameOperationEquivalent = Array.isArray(list) && list.find(task => task && task.__creationActionToken === token && equivalentKey(task) === signature);
+    if (token && sameOperationEquivalent) return { created:false, task:sameOperationEquivalent, reason:"same-action-equivalent" };
+    creationLock = { token, task:null };
+    try {
+      const task = create();
+      if (task && token) Object.defineProperty(task, "__creationActionToken", { value:token, configurable:true, enumerable:false });
+      creationLock.task = task || null;
+      return { created:Boolean(task), task:task || null, reason:task ? "" : "not-created" };
+    } finally {
+      // Keep the action identity briefly after the synchronous handler returns;
+      // browsers may dispatch a second submit/click from the same double click.
+      setTimeout(()=> { if (creationLock?.token === token) creationLock = null; }, 1000);
+    }
+  }
+
+  function findReferences(value, wanted, path = "", found = []){
+    if (!value || typeof value !== "object") return found;
+    if (Array.isArray(value)) value.forEach((item, index)=>findReferences(item, wanted, `${path}[${index}]`, found));
+    else Object.entries(value).forEach(([field, child])=>{
+      const childPath = path ? `${path}.${field}` : field;
+      if (String(child) === wanted) found.push({ path:childPath, field, value:child });
+      else findReferences(child, wanted, childPath, found);
+    });
+    return found;
+  }
+
+  function auditPumpRebuildTaskDuplication(){
+    const tasks = (Array.isArray(global.tasksInterval) ? global.tasksInterval : []).filter(isPumpRebuild);
+    const inventory = Array.isArray(global.inventory) ? global.inventory : [];
+    const deleted = Array.isArray(global.deletedItems) ? global.deletedItems : [];
+    const records = tasks.map((task, index)=>({
+      collection:"tasksInterval", index, id:String(task.id || ""), name:String(task.name || ""),
+      normalized:normalizeMaintenanceTaskIdentity(task), manualHistory:count(task.manualHistory), completedDates:count(task.completedDates),
+      importedEventIds:historyIds(task), liveInventoryLinks:findReferences(inventory, String(task.id || ""), "inventory"),
+      deletedItemsLinks:findReferences(deleted, String(task.id || ""), "deletedItems")
+    }));
+    const groups = {};
+    records.forEach(record => { (groups[record.normalized.equivalentKey] ||= []).push(record.id); });
+    const canonical = tasks.find(task => String(task.id) === CANONICAL_ID);
+    const duplicate = tasks.find(task => String(task.id) === DUPLICATE_ID);
+    const liveCollections = ["inventory", "maintenanceCalendarInstancesV2", "maintenanceOccurrencesV2", "maintenanceTasksV2", "tasksAsReq"];
+    const unexpectedLiveReferences = liveCollections.flatMap(name => findReferences(global[name], DUPLICATE_ID, name));
+    (Array.isArray(global.tasksInterval) ? global.tasksInterval : []).forEach((task, index)=>{
+      if (String(task?.id || "") === DUPLICATE_ID) return;
+      findReferences(task, DUPLICATE_ID, `tasksInterval[${index}]`, unexpectedLiveReferences);
+    });
+    const removableCandidateIds = canonical && duplicate && isEquivalentPump(canonical) && isEquivalentPump(duplicate)
+      && count(duplicate.manualHistory) === 0 && count(duplicate.completedDates) === 0 && !unexpectedLiveReferences.length ? [DUPLICATE_ID] : [];
+    return { records, equivalentGroups:Object.entries(groups).map(([configuration, ids])=>({ configuration, ids })), removableCandidateIds,
+      liveReferences:unexpectedLiveReferences, deletedItemsLinks:findReferences(deleted, DUPLICATE_ID, "deletedItems"),
+      repairSafe:removableCandidateIds.length === 1 };
+  }
+
+  function stateForRepair(){
+    if (typeof snapshotState === "function") return snapshotState();
+    if (typeof getCurrentAppStateForDiagnostics === "function") return getCurrentAppStateForDiagnostics();
+    return null;
+  }
+
+  function setIntervalTasks(list){
+    global.tasksInterval = list;
+    if (typeof tasksInterval !== "undefined") tasksInterval = list;
+  }
+
+  async function repairExactPumpRebuildTaskDuplication(){
+    const result = { repaired:false, saveAttempted:false, saveMethod:"saveCloudNow", stateWriteAttempted:false, stateWriteCompleted:false,
+      saveCompleted:false, saveIndeterminate:false, saveError:"", saveWarnings:[], backupCreated:false, canonicalTaskId:CANONICAL_ID,
+      removedTaskId:DUPLICATE_ID, beforeCounts:null, afterCounts:null, preservedImportEventIds:[], refusedReason:"" };
+    const refuse = reason => { result.refusedReason = reason; return result; };
+    const current = stateForRepair();
+    const baseline = global.__lastLoadedCloudState;
+    if (!current || !baseline) return refuse("Current state or last authoritative Firestore baseline is unavailable.");
+    const comparisonCurrent = clone(current);
+    const comparisonBaseline = clone(baseline);
+    delete comparisonCurrent.saveMeta; delete comparisonBaseline.saveMeta;
+    const baselineMatches = typeof getTrackedStateSignature === "function"
+      ? getTrackedStateSignature(comparisonCurrent) === getTrackedStateSignature(comparisonBaseline)
+      : key(comparisonCurrent) === key(comparisonBaseline);
+    if (!baselineMatches) return refuse("Current state does not match the last authoritative Firestore baseline.");
+    const audit = auditPumpRebuildTaskDuplication();
+    if (!audit.repairSafe || key(audit.removableCandidateIds) !== key([DUPLICATE_ID])) return refuse("Exact duplicate preconditions or live-reference audit failed.");
+    const tasks = global.tasksInterval;
+    const canonical = tasks.find(task => String(task?.id) === CANONICAL_ID);
+    const duplicate = tasks.find(task => String(task?.id) === DUPLICATE_ID);
+    if (!canonical || !duplicate) return refuse("Both exact Pump Rebuild task IDs are required.");
+    if (key(historyIds(canonical)) !== key(IMPORT_IDS)) return refuse("Canonical imported Pump Rebuild history IDs are not exact.");
+    const canonicalHistory = clone(canonical.manualHistory);
+    const protectedBefore = clone(current);
+    try {
+      if (typeof exportJsonDownload !== "function" || !exportJsonDownload(`omax-pump-rebuild-duplicate-backup-${Date.now()}.json`, clone(current))) return refuse("Full-state backup download did not start.");
+      result.backupCreated = true;
+    } catch (error){ return refuse(`Full-state backup failed: ${String(error?.message || error)}`); }
+    result.beforeCounts = { tasksInterval:tasks.length, manualHistory:count(canonical.manualHistory) + count(duplicate.manualHistory), completedDates:count(canonical.completedDates) + count(duplicate.completedDates) };
+    setIntervalTasks(tasks.filter(task => String(task?.id) !== DUPLICATE_ID));
+    const afterState = stateForRepair();
+    const expected = clone(protectedBefore);
+    expected.tasksInterval = expected.tasksInterval.filter(task => String(task?.id) !== DUPLICATE_ID);
+    if (key(afterState) !== key(expected) || key(canonical.manualHistory) !== key(canonicalHistory)){
+      setIntervalTasks(tasks);
+      return refuse("Intended-only verification failed before save.");
+    }
+    result.afterCounts = { tasksInterval:global.tasksInterval.length, manualHistory:count(canonical.manualHistory), completedDates:count(canonical.completedDates) };
+    result.preservedImportEventIds = historyIds(canonical);
+    if (typeof saveCloudNow !== "function"){ setIntervalTasks(tasks); return refuse("Authoritative full-state save is unavailable."); }
+    result.saveAttempted = true;
+    try {
+      const saved = await saveCloudNow();
+      result.stateWriteAttempted = saved?.stateWriteAttempted === true;
+      result.stateWriteCompleted = saved?.stateWriteCompleted === true;
+      result.saveWarnings = Array.isArray(saved?.warnings) ? saved.warnings.slice() : [];
+      result.saveError = String(saved?.error || "");
+      result.saveIndeterminate = saved?.indeterminate === true;
+      result.saveCompleted = saved?.saved === true && result.stateWriteCompleted;
+      result.repaired = result.saveCompleted;
+      if (!result.saveCompleted && !result.saveIndeterminate) setIntervalTasks(tasks);
+    } catch (error){ result.saveError = String(error?.message || error); setIntervalTasks(tasks); }
+    return result;
+  }
+
+  Object.assign(global, { normalizeMaintenanceTaskIdentity, createMaintenanceTaskOnce, auditPumpRebuildTaskDuplication, repairExactPumpRebuildTaskDuplication });
+})(window);

--- a/js/renderers.js
+++ b/js/renderers.js
@@ -9480,13 +9480,16 @@ function maintenanceHistoryImportValueKey(value){
 }
 
 function captureMaintenanceHistoryImportManualHistory(){
-  return getMaintenanceHistoryImportTaskList().map(item => ({
+  const snapshot = getMaintenanceHistoryImportTaskList().map(item => ({
     mode:item.mode,
     index:item.index,
     task:item.task,
     hadManualHistory:Object.prototype.hasOwnProperty.call(item.task, "manualHistory"),
     manualHistory:cloneMaintenanceHistoryImportValue(item.task.manualHistory)
   }));
+  snapshot.intervalTaskRefs = (Array.isArray(window.tasksInterval) ? window.tasksInterval : []).slice();
+  snapshot.asReqTaskRefs = (Array.isArray(window.tasksAsReq) ? window.tasksAsReq : []).slice();
+  return snapshot;
 }
 
 function restoreMaintenanceHistoryImportManualHistory(snapshot){
@@ -9502,6 +9505,12 @@ function restoreMaintenanceHistoryImportManualHistory(snapshot){
 }
 
 function verifyMaintenanceHistoryImportMutation(historySnapshot, touchedTasks, plannedIds){
+  const sameTaskRefs = (current, before)=> Array.isArray(current) && Array.isArray(before)
+    && current.length === before.length && current.every((task, index)=>task === before[index]);
+  if (!sameTaskRefs(window.tasksInterval, historySnapshot?.intervalTaskRefs)
+    || !sameTaskRefs(window.tasksAsReq, historySnapshot?.asReqTaskRefs)){
+    throw new Error("Unexpected task collection mutation: additions, removals, or reordering are forbidden during history import.");
+  }
   const planned = new Set(plannedIds);
   (Array.isArray(historySnapshot) ? historySnapshot : []).forEach(item => {
     const beforeHistory = Array.isArray(item.manualHistory) ? item.manualHistory : [];
@@ -11561,6 +11570,11 @@ function renderSettings(){
     const name = (data.get("taskName")||"").toString().trim();
     const mode = (data.get("taskType")||"interval").toString();
     if (!name){ alert("Task name is required."); return; }
+    const submitButton = form.querySelector('[type="submit"]');
+    const actionToken = form.dataset.creationActionToken || (form.dataset.creationActionToken = `task_create_${Date.now()}_${Math.random().toString(36).slice(2)}`);
+    if (form.dataset.creationPending === "1") return;
+    form.dataset.creationPending = "1";
+    if (submitButton) submitButton.disabled = true;
     const rootId = (typeof window !== "undefined" && typeof window.ROOT_FOLDER_ID === "string") ? window.ROOT_FOLDER_ID : "root";
     const catRaw = (data.get("taskCategory")||"").toString().trim();
     const catId = catRaw ? catRaw : rootId;
@@ -11592,14 +11606,31 @@ function renderSettings(){
       const curHours = getCurrentMachineHours();
       const baselineHours = parseBaselineHours(data.get("taskLastServiced"));
       applyIntervalBaseline(task, { baselineHours, currentHours: curHours });
-      window.tasksInterval.unshift(task);
-      createdTask = task;
+      const creation = typeof window.createMaintenanceTaskOnce === "function"
+        ? window.createMaintenanceTaskOnce(actionToken, task, ()=>{ window.tasksInterval.unshift(task); return task; })
+        : { created:true, task:(window.tasksInterval.unshift(task), task) };
+      if (!creation.created){
+        delete form.dataset.creationPending;
+        if (submitButton) submitButton.disabled = false;
+        return;
+      }
+      createdTask = creation.task;
     }else{
       const condition = (data.get("taskCondition")||"").toString().trim() || "As required";
       const task = Object.assign(base, { mode:"asreq", condition, variant: "template", templateId: id });
-      (Array.isArray(window.tasksAsReq) ? window.tasksAsReq : (window.tasksAsReq = [])).unshift(task);
+      const creation = typeof window.createMaintenanceTaskOnce === "function"
+        ? window.createMaintenanceTaskOnce(actionToken, task, ()=>{
+            (Array.isArray(window.tasksAsReq) ? window.tasksAsReq : (window.tasksAsReq = [])).unshift(task);
+            return task;
+          })
+        : { created:true, task:((Array.isArray(window.tasksAsReq) ? window.tasksAsReq : (window.tasksAsReq = [])).unshift(task), task) };
+      if (!creation.created){
+        delete form.dataset.creationPending;
+        if (submitButton) submitButton.disabled = false;
+        return;
+      }
       tasksAsReq = window.tasksAsReq;
-      createdTask = task;
+      createdTask = creation.task;
     }
 
     if (createdTask){
@@ -11642,6 +11673,11 @@ function renderSettings(){
         if (typeof fn === "function") fn(createdTask);
       }, 60);
     }
+    delete form.dataset.creationPending;
+    if (submitButton) submitButton.disabled = false;
+    setTimeout(()=>{
+      if (form.dataset.creationActionToken === actionToken) delete form.dataset.creationActionToken;
+    }, 1000);
   });
 
   const pendingFocus = window.pendingMaintenanceFocus;
@@ -16619,8 +16655,19 @@ function computeCostModel(){
     return false;
   };
 
-  const intervalTasks = intervalTasksAll.filter(isTaskActive);
-  const asReqTasks = asReqTasksAll.filter(isTaskActive);
+  const dedupeEquivalentTasks = list => {
+    const seen = new Set();
+    return list.filter(task => {
+      const identity = typeof window.normalizeMaintenanceTaskIdentity === "function"
+        ? window.normalizeMaintenanceTaskIdentity(task).equivalentKey
+        : String(task?.id || "");
+      if (seen.has(identity)) return false;
+      seen.add(identity);
+      return true;
+    });
+  };
+  const intervalTasks = dedupeEquivalentTasks(intervalTasksAll.filter(isTaskActive));
+  const asReqTasks = dedupeEquivalentTasks(asReqTasksAll.filter(isTaskActive));
   const taskCostFromSettingsById = new Map();
   const registerTaskCostFromSettings = (task)=>{
     if (!task || task.id == null) return;

--- a/tests/maintenance-history-import.test.js
+++ b/tests/maintenance-history-import.test.js
@@ -25,7 +25,7 @@ function createHarness(saveCloudNow){
     getCurrentAppStateForDiagnostics:()=>structuredClone(window)
   };
   vm.createContext(context);
-  vm.runInContext(rendererSource.slice(start, end) + "\nthis.api={applyMaintenanceHistoryImportRows,buildMaintenanceHistoryImportPreview,countMaintenanceHistoryImportProtectedState,findMaintenanceHistoryImportDrops};", context);
+  vm.runInContext(rendererSource.slice(start, end) + "\nthis.api={applyMaintenanceHistoryImportRows,buildMaintenanceHistoryImportPreview,countMaintenanceHistoryImportProtectedState,findMaintenanceHistoryImportDrops,captureMaintenanceHistoryImportManualHistory,verifyMaintenanceHistoryImportMutation};", context);
   return { window, api:context.api };
 }
 
@@ -100,6 +100,12 @@ async function run(){
     h.window.inventory.length = 0;
     const after = h.api.countMaintenanceHistoryImportProtectedState();
     assert.deepEqual(Array.from(h.api.findMaintenanceHistoryImportDrops(before, after)), ["inventory"], "protected collection reduction is detected");
+  }
+  {
+    const h = createHarness(async()=>({ saved:true, stateWriteCompleted:true }));
+    const snapshot = h.api.captureMaintenanceHistoryImportManualHistory();
+    h.window.tasksInterval.push({ id:"unexpected", name:"Pump Rebuild", interval:500, mode:"interval", manualHistory:[], completedDates:[] });
+    assert.throws(()=>h.api.verifyMaintenanceHistoryImportMutation(snapshot, new Map(), []), /Unexpected task collection mutation/);
   }
   const wireSection = rendererSource.slice(rendererSource.indexOf("function wireMaintenanceHistoryImportTool"), rendererSource.indexOf("function renderSettings"));
   assert.match(wireSection, /if \(importRunning\) return;/, "concurrent import attempts are ignored");

--- a/tests/pump-rebuild-duplication.test.js
+++ b/tests/pump-rebuild-duplication.test.js
@@ -1,0 +1,55 @@
+"use strict";
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const vm = require("node:vm");
+
+const source = fs.readFileSync("js/maintenance-duplication.js", "utf8");
+function task(id, history=[]){ return { id, name:"Pump Rebuild", mode:"interval", cat:"root", interval:500, manualHistory:history, completedDates:[] }; }
+function harness(overrides={}){
+  const imported = id => ({ dateISO:"2025-01-01", import_event_id:id, payload:{ exact:id } });
+  const canonical = task("pump_rebuild_msnpt6hi", [imported("OMAX-2067268-302701-01"), imported("OMAX-2070032-302701-01")]);
+  const duplicate = task("pump_rebuild_msnpt6gs");
+  const window = Object.assign({ tasksInterval:[canonical, duplicate], tasksAsReq:[], inventory:[], deletedItems:[{ payload:{ name:"Pump Rebuild" }, linkedTaskId:duplicate.id }], maintenanceTasksV2:[], maintenanceCalendarInstancesV2:[], maintenanceOccurrencesV2:[] }, overrides);
+  const state = ()=>structuredClone({ tasksInterval:window.tasksInterval, tasksAsReq:window.tasksAsReq, inventory:window.inventory, deletedItems:window.deletedItems, maintenanceTasksV2:window.maintenanceTasksV2, maintenanceCalendarInstancesV2:window.maintenanceCalendarInstancesV2, maintenanceOccurrencesV2:window.maintenanceOccurrencesV2 });
+  window.__lastLoadedCloudState = state();
+  const context = { window, structuredClone, JSON, Date, setTimeout, snapshotState:state, exportJsonDownload:()=>true, saveCloudNow:async()=>({ saved:true, stateWriteAttempted:true, stateWriteCompleted:true }) };
+  vm.createContext(context); vm.runInContext(source, context);
+  return { window, context, canonical, duplicate, state };
+}
+(async()=>{
+  {
+    const h=harness({ tasksInterval:[] }); let calls=0;
+    const spec={ name:"Pump Rebuild", mode:"interval", interval:500 };
+    const add=()=>{ calls++; const made=task(`id${calls}`); h.window.tasksInterval.push(made); return made; };
+    const first=h.window.createMaintenanceTaskOnce("action-1", spec, add);
+    const second=h.window.createMaintenanceTaskOnce("action-1", spec, add);
+    assert.equal(first.created,true); assert.equal(second.created,false); assert.equal(calls,1); assert.equal(h.window.tasksInterval.length,1);
+    h.window.createMaintenanceTaskOnce("action-2", { ...spec, interval:750 }, add);
+    assert.equal(h.window.tasksInterval.length,2,"separately configured same-name task remains legitimate");
+  }
+  {
+    const h=harness(); const audit=h.window.auditPumpRebuildTaskDuplication();
+    assert.deepEqual(Array.from(audit.removableCandidateIds),["pump_rebuild_msnpt6gs"]); assert.equal(audit.repairSafe,true);
+    const beforeHistory=structuredClone(h.canonical.manualHistory); const beforeV2=structuredClone([h.window.maintenanceTasksV2,h.window.maintenanceCalendarInstancesV2,h.window.maintenanceOccurrencesV2]);
+    const result=await h.window.repairExactPumpRebuildTaskDuplication();
+    assert.equal(result.repaired,true); assert.deepEqual(h.window.tasksInterval.map(x=>x.id),["pump_rebuild_msnpt6hi"]);
+    assert.deepEqual(h.canonical.manualHistory,beforeHistory,"both imported events stay byte-for-byte");
+    assert.deepEqual([h.window.maintenanceTasksV2,h.window.maintenanceCalendarInstancesV2,h.window.maintenanceOccurrencesV2],beforeV2);
+    assert.deepEqual(h.window.deletedItems,[{ payload:{ name:"Pump Rebuild" }, linkedTaskId:"pump_rebuild_msnpt6gs" }],"trash lifecycle entry is not rewritten");
+  }
+  { const h=harness(); h.duplicate.manualHistory.push({dateISO:"2020-01-01"}); h.window.__lastLoadedCloudState=h.state(); assert.match((await h.window.repairExactPumpRebuildTaskDuplication()).refusedReason,/preconditions/); }
+  { const h=harness(); h.window.inventory.push({ linkedTaskId:h.duplicate.id }); h.window.__lastLoadedCloudState=h.state(); assert.match((await h.window.repairExactPumpRebuildTaskDuplication()).refusedReason,/live-reference/); }
+  { const h=harness(); h.window.inventory.push({id:"changed"}); assert.match((await h.window.repairExactPumpRebuildTaskDuplication()).refusedReason,/baseline/); }
+
+  const calendar=fs.readFileSync("js/calendar.js","utf8");
+  const restore=calendar.slice(calendar.indexOf("function restoreCriticalIntervalTasks"),calendar.indexOf("function renderCalendar"));
+  const ctask=task("pump_rebuild_msnpt6hi"); let restored=0;
+  const ctx={ window:{tasksInterval:[ctask],deletedItems:[{id:"trash",type:"task",payload:task("pump_rebuild_msnpt6gs")}],normalizeMaintenanceTaskIdentity:t=>({equivalentKey:`pump rebuild|${t.mode}|${t.interval}`})}, Set, String, Number, Array, isInstanceTask:()=>false,isTemplateTask:()=>false,restoreDeletedItem:()=>{restored++;return {ok:true};} };
+  vm.createContext(ctx); vm.runInContext(restore+"\nthis.restoreCriticalIntervalTasks=restoreCriticalIntervalTasks",ctx);
+  assert.equal(ctx.restoreCriticalIntervalTasks(),false); assert.equal(ctx.restoreCriticalIntervalTasks(),false); assert.equal(restored,0,"active equivalent prevents deleted-ID resurrection");
+  const renderHead=calendar.slice(calendar.indexOf("function renderCalendar"),calendar.indexOf("const container",calendar.indexOf("function renderCalendar")));
+  assert.doesNotMatch(renderHead,/restoreCriticalIntervalTasks|saveCloudDebounced/,"repeated rendering cannot mutate/restore/save tasks");
+  const renderer=fs.readFileSync("js/renderers.js","utf8");
+  assert.match(renderer,/const intervalTasks = dedupeEquivalentTasks\(intervalTasksAll\.filter\(isTaskActive\)\)/,"cost analysis collapses equivalent task identities");
+  console.log("pump rebuild duplication deterministic tests passed");
+})().catch(e=>{console.error(e);process.exitCode=1;});


### PR DESCRIPTION
### Motivation

- Fix an issue where a deleted Pump Rebuild task ID was resurrected during rendering/import because `restoreCriticalIntervalTasks()` restored by legacy IDs and `renderCalendar()` could trigger a hidden cloud save. 
- Ensure a single user action cannot create duplicate interval/as-required tasks and make task-creation idempotent across rapid/repeated UI events. 
- Provide safe, auditable, and narrowly scoped repair tooling for the exact Pump Rebuild duplicate case while preserving imported history and protected state invariants. 

### Description

- Add `js/maintenance-duplication.js` which implements normalized maintenance-task identity functions, a `createMaintenanceTaskOnce()` same-action idempotency guard, `auditPumpRebuildTaskDuplication()` read-only inspector, and `repairExactPumpRebuildTaskDuplication()` exact repair helper with full-state backup, baseline checks, targeted mutation, verification, and save reporting. 
- Narrow `restoreCriticalIntervalTasks()` in `js/calendar.js` so it treats Pump Rebuild recovery by normalized identity/configuration (name+mode+interval) and will not restore a deleted Pump Rebuild when an equivalent active 500-hour interval Pump Rebuild already exists, and stop invoking cloud save from render-time recovery. 
- Harden the task-creation UI in `js/renderers.js` by adding form-level `actionToken` and `creationPending` guards and calling `createMaintenanceTaskOnce()` to prevent duplicate creations from the same user action, including separate handling for `interval` and `asreq` tasks. 
- Strengthen the maintenance-history importer by snapshotting `tasksInterval`/`tasksAsReq` references and throwing on unexpected additions/removals/reordering during import, and deduplicate equivalent active tasks in the cost-analysis path to avoid duplicate cost rows. 
- Wire the new helper script into `index.html`, add deterministic tests `tests/pump-rebuild-duplication.test.js`, and document the rationale in `docs/mi-02k-pump-rebuild-safety.md`. 

### Testing

- Confirmed `package.json` is absent and no npm commands were run. 
- Performed syntax checks with `node --check` on the modified JS files (`js/calendar.js`, `js/renderers.js`, `js/maintenance-duplication.js`) and on the two test files, and all checks passed. 
- Ran deterministic unit tests: `tests/maintenance-history-import.test.js` and new `tests/pump-rebuild-duplication.test.js`, and both test suites passed. 
- Ran repository validations `git diff --check` and a conflict-marker scan, both of which passed and reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a41ff1be083258fc442319b0fd2d7)