### PR TITLE
Authorize exact Pump Rebuild inventory relink

### DIFF
--- a/js/maintenance-duplication.js
+++ b/js/maintenance-duplication.js
@@ -6,7 +6,9 @@
 (function maintenanceDuplicationSafety(global){
   const CANONICAL_ID = "pump_rebuild_msnpt6hi";
   const DUPLICATE_ID = "pump_rebuild_msnpt6gs";
+  const INVENTORY_ID = "inventory_msnpt6ic";
   const IMPORT_IDS = ["OMAX-2067268-302701-01", "OMAX-2070032-302701-01"];
+  const AUTHORITATIVE_INVENTORY = { id:INVENTORY_ID, name:"Pump Rebuild", linkedTaskId:DUPLICATE_ID, qty:0, qtyNew:0, price:null, pn:"", folderId:null };
 
   const clone = value => typeof structuredClone === "function" ? structuredClone(value) : JSON.parse(JSON.stringify(value));
   const key = value => JSON.stringify(value);
@@ -57,7 +59,8 @@
   }
 
   function auditPumpRebuildTaskDuplication(){
-    const tasks = (Array.isArray(global.tasksInterval) ? global.tasksInterval : []).filter(isPumpRebuild);
+    const intervalTasks = Array.isArray(global.tasksInterval) ? global.tasksInterval : [];
+    const tasks = intervalTasks.filter(isPumpRebuild);
     const inventory = Array.isArray(global.inventory) ? global.inventory : [];
     const deleted = Array.isArray(global.deletedItems) ? global.deletedItems : [];
     const records = tasks.map((task, index)=>({
@@ -68,19 +71,46 @@
     }));
     const groups = {};
     records.forEach(record => { (groups[record.normalized.equivalentKey] ||= []).push(record.id); });
-    const canonical = tasks.find(task => String(task.id) === CANONICAL_ID);
-    const duplicate = tasks.find(task => String(task.id) === DUPLICATE_ID);
+    const allLiveTasks = intervalTasks.concat(Array.isArray(global.tasksAsReq) ? global.tasksAsReq : []);
+    const canonicalMatches = allLiveTasks.filter(task => String(task?.id || "") === CANONICAL_ID);
+    const duplicateMatches = allLiveTasks.filter(task => String(task?.id || "") === DUPLICATE_ID);
+    const canonical = canonicalMatches[0];
+    const duplicate = duplicateMatches[0];
+    const matchingInventory = inventory.filter(item => String(item?.id || "") === INVENTORY_ID);
+    const inventoryRecord = matchingInventory[0];
     const liveCollections = ["inventory", "maintenanceCalendarInstancesV2", "maintenanceOccurrencesV2", "maintenanceTasksV2", "tasksAsReq"];
-    const unexpectedLiveReferences = liveCollections.flatMap(name => findReferences(global[name], DUPLICATE_ID, name));
-    (Array.isArray(global.tasksInterval) ? global.tasksInterval : []).forEach((task, index)=>{
+    const allLiveReferences = liveCollections.flatMap(name => findReferences(global[name], DUPLICATE_ID, name));
+    intervalTasks.forEach((task, index)=>{
       if (String(task?.id || "") === DUPLICATE_ID) return;
-      findReferences(task, DUPLICATE_ID, `tasksInterval[${index}]`, unexpectedLiveReferences);
+      findReferences(task, DUPLICATE_ID, `tasksInterval[${index}]`, allLiveReferences);
     });
-    const removableCandidateIds = canonical && duplicate && isEquivalentPump(canonical) && isEquivalentPump(duplicate)
-      && count(duplicate.manualHistory) === 0 && count(duplicate.completedDates) === 0 && !unexpectedLiveReferences.length ? [DUPLICATE_ID] : [];
+    const intendedReferencePath = matchingInventory.length === 1 ? `inventory[${inventory.indexOf(inventoryRecord)}].linkedTaskId` : "";
+    const unexpectedLiveReferences = allLiveReferences.filter(reference => reference.path !== intendedReferencePath);
+    const current = stateForRepair();
+    const baseline = global.__lastLoadedCloudState;
+    const currentComparison = current ? clone(current) : null;
+    const baselineComparison = baseline ? clone(baseline) : null;
+    if (currentComparison) delete currentComparison.saveMeta;
+    if (baselineComparison) delete baselineComparison.saveMeta;
+    const baselineMatches = Boolean(currentComparison && baselineComparison && key(currentComparison) === key(baselineComparison));
+    const refusalReasons = [];
+    if (canonicalMatches.length !== 1 || duplicateMatches.length !== 1) refusalReasons.push("Both exact task IDs must exist exactly once.");
+    if (!canonical || !duplicate || !isEquivalentPump(canonical) || !isEquivalentPump(duplicate)) refusalReasons.push("Both exact tasks must be equivalent 500-hour interval Pump Rebuild tasks.");
+    if (String(canonical?.inventoryId || "") !== INVENTORY_ID || String(duplicate?.inventoryId || "") !== INVENTORY_ID) refusalReasons.push("Both tasks must point to the exact shared inventory ID.");
+    if (count(canonical?.manualHistory) !== 2 || count(canonical?.completedDates) !== 0 || key(historyIds(canonical)) !== key(IMPORT_IDS)) refusalReasons.push("Canonical task history does not contain exactly the two protected imports.");
+    if (count(duplicate?.manualHistory) !== 0 || count(duplicate?.completedDates) !== 0) refusalReasons.push("Duplicate task is not empty.");
+    if (matchingInventory.length !== 1) refusalReasons.push("Exactly one matching live inventory record is required.");
+    if (!inventoryRecord || key(inventoryRecord) !== key(AUTHORITATIVE_INVENTORY)) refusalReasons.push("Shared inventory record differs from the authoritative configuration.");
+    if (unexpectedLiveReferences.length) refusalReasons.push("Unexpected additional live references target the duplicate task.");
+    if (!baselineMatches) refusalReasons.push("Current state does not match the latest authoritative Firestore-loaded baseline.");
+    const inventoryRelinkRequired = Boolean(inventoryRecord && inventoryRecord.linkedTaskId === DUPLICATE_ID);
+    const inventoryRelinkSafe = inventoryRelinkRequired && matchingInventory.length === 1 && !unexpectedLiveReferences.length && key(inventoryRecord) === key(AUTHORITATIVE_INVENTORY);
+    const inventoryRelinkPlan = inventoryRelinkSafe ? { inventoryId:INVENTORY_ID, fromTaskId:DUPLICATE_ID, toTaskId:CANONICAL_ID } : null;
+    const removableCandidateIds = refusalReasons.length === 0 ? [DUPLICATE_ID] : [];
     return { records, equivalentGroups:Object.entries(groups).map(([configuration, ids])=>({ configuration, ids })), removableCandidateIds,
-      liveReferences:unexpectedLiveReferences, deletedItemsLinks:findReferences(deleted, DUPLICATE_ID, "deletedItems"),
-      repairSafe:removableCandidateIds.length === 1 };
+      inventoryRelinkRequired, inventoryRelinkSafe, inventoryRelinkPlan, refusalReasons,
+      liveReferences:allLiveReferences, unexpectedLiveReferences, deletedItemsLinks:findReferences(deleted, DUPLICATE_ID, "deletedItems"),
+      repairSafe:removableCandidateIds.length === 1 && inventoryRelinkSafe };
   }
 
   function stateForRepair(){
@@ -94,24 +124,26 @@
     if (typeof tasksInterval !== "undefined") tasksInterval = list;
   }
 
+  function setInventory(list){
+    global.inventory = list;
+    if (typeof inventory !== "undefined") inventory = list;
+  }
+
   async function repairExactPumpRebuildTaskDuplication(){
     const result = { repaired:false, saveAttempted:false, saveMethod:"saveCloudNow", stateWriteAttempted:false, stateWriteCompleted:false,
       saveCompleted:false, saveIndeterminate:false, saveError:"", saveWarnings:[], backupCreated:false, canonicalTaskId:CANONICAL_ID,
-      removedTaskId:DUPLICATE_ID, beforeCounts:null, afterCounts:null, preservedImportEventIds:[], refusedReason:"" };
+      removedTaskId:DUPLICATE_ID, beforeCounts:null, afterCounts:null, preservedImportEventIds:[], refusedReason:"",
+      inventoryRelinkRequired:false, inventoryRelinkCompleted:false, relinkedInventoryIds:[], beforeInventoryLink:null, afterInventoryLink:null };
     const refuse = reason => { result.refusedReason = reason; return result; };
     const current = stateForRepair();
     const baseline = global.__lastLoadedCloudState;
     if (!current || !baseline) return refuse("Current state or last authoritative Firestore baseline is unavailable.");
-    const comparisonCurrent = clone(current);
-    const comparisonBaseline = clone(baseline);
-    delete comparisonCurrent.saveMeta; delete comparisonBaseline.saveMeta;
-    const baselineMatches = typeof getTrackedStateSignature === "function"
-      ? getTrackedStateSignature(comparisonCurrent) === getTrackedStateSignature(comparisonBaseline)
-      : key(comparisonCurrent) === key(comparisonBaseline);
-    if (!baselineMatches) return refuse("Current state does not match the last authoritative Firestore baseline.");
     const audit = auditPumpRebuildTaskDuplication();
     if (!audit.repairSafe || key(audit.removableCandidateIds) !== key([DUPLICATE_ID])) return refuse("Exact duplicate preconditions or live-reference audit failed.");
+    const authorization = { used:false, state:key(current), plan:key(audit.inventoryRelinkPlan) };
+    result.inventoryRelinkRequired = audit.inventoryRelinkRequired;
     const tasks = global.tasksInterval;
+    const inventoryBefore = global.inventory;
     const canonical = tasks.find(task => String(task?.id) === CANONICAL_ID);
     const duplicate = tasks.find(task => String(task?.id) === DUPLICATE_ID);
     if (!canonical || !duplicate) return refuse("Both exact Pump Rebuild task IDs are required.");
@@ -122,18 +154,34 @@
       if (typeof exportJsonDownload !== "function" || !exportJsonDownload(`omax-pump-rebuild-duplicate-backup-${Date.now()}.json`, clone(current))) return refuse("Full-state backup download did not start.");
       result.backupCreated = true;
     } catch (error){ return refuse(`Full-state backup failed: ${String(error?.message || error)}`); }
+    const revalidation = auditPumpRebuildTaskDuplication();
+    const revalidatedState = stateForRepair();
+    if (authorization.used || !revalidation.repairSafe || key(revalidation.inventoryRelinkPlan) !== authorization.plan || key(revalidatedState) !== authorization.state) return refuse("Exact repair authorization became stale before mutation.");
+    authorization.used = true;
     result.beforeCounts = { tasksInterval:tasks.length, manualHistory:count(canonical.manualHistory) + count(duplicate.manualHistory), completedDates:count(canonical.completedDates) + count(duplicate.completedDates) };
+    const inventoryIndex = inventoryBefore.findIndex(item => String(item?.id || "") === INVENTORY_ID);
+    const originalInventoryRecord = inventoryBefore[inventoryIndex];
+    const relinkedInventoryRecord = { ...originalInventoryRecord, linkedTaskId:CANONICAL_ID };
+    const inventoryAfter = inventoryBefore.slice();
+    inventoryAfter[inventoryIndex] = relinkedInventoryRecord;
+    result.beforeInventoryLink = originalInventoryRecord.linkedTaskId;
+    result.afterInventoryLink = relinkedInventoryRecord.linkedTaskId;
     setIntervalTasks(tasks.filter(task => String(task?.id) !== DUPLICATE_ID));
+    setInventory(inventoryAfter);
     const afterState = stateForRepair();
     const expected = clone(protectedBefore);
     expected.tasksInterval = expected.tasksInterval.filter(task => String(task?.id) !== DUPLICATE_ID);
+    expected.inventory[inventoryIndex] = { ...expected.inventory[inventoryIndex], linkedTaskId:CANONICAL_ID };
     if (key(afterState) !== key(expected) || key(canonical.manualHistory) !== key(canonicalHistory)){
       setIntervalTasks(tasks);
+      setInventory(inventoryBefore);
       return refuse("Intended-only verification failed before save.");
     }
     result.afterCounts = { tasksInterval:global.tasksInterval.length, manualHistory:count(canonical.manualHistory), completedDates:count(canonical.completedDates) };
     result.preservedImportEventIds = historyIds(canonical);
-    if (typeof saveCloudNow !== "function"){ setIntervalTasks(tasks); return refuse("Authoritative full-state save is unavailable."); }
+    result.inventoryRelinkCompleted = true;
+    result.relinkedInventoryIds = [INVENTORY_ID];
+    if (typeof saveCloudNow !== "function"){ setIntervalTasks(tasks); setInventory(inventoryBefore); result.inventoryRelinkCompleted=false; result.relinkedInventoryIds=[]; return refuse("Authoritative full-state save is unavailable."); }
     result.saveAttempted = true;
     try {
       const saved = await saveCloudNow();
@@ -144,8 +192,13 @@
       result.saveIndeterminate = saved?.indeterminate === true;
       result.saveCompleted = saved?.saved === true && result.stateWriteCompleted;
       result.repaired = result.saveCompleted;
-      if (!result.saveCompleted && !result.saveIndeterminate) setIntervalTasks(tasks);
-    } catch (error){ result.saveError = String(error?.message || error); setIntervalTasks(tasks); }
+      if (!result.saveCompleted && !result.saveIndeterminate && !result.stateWriteAttempted){ setIntervalTasks(tasks); setInventory(inventoryBefore); result.inventoryRelinkCompleted=false; result.relinkedInventoryIds=[]; }
+    } catch (error){
+      result.saveError = String(error?.message || error);
+      result.saveIndeterminate = error?.indeterminate === true;
+      result.stateWriteAttempted = error?.stateWriteAttempted === true;
+      if (!result.saveIndeterminate && !result.stateWriteAttempted){ setIntervalTasks(tasks); setInventory(inventoryBefore); result.inventoryRelinkCompleted=false; result.relinkedInventoryIds=[]; }
+    }
     return result;
   }
 

--- a/tests/pump-rebuild-duplication.test.js
+++ b/tests/pump-rebuild-duplication.test.js
@@ -4,17 +4,18 @@ const fs = require("node:fs");
 const vm = require("node:vm");
 
 const source = fs.readFileSync("js/maintenance-duplication.js", "utf8");
-function task(id, history=[]){ return { id, name:"Pump Rebuild", mode:"interval", cat:"root", interval:500, manualHistory:history, completedDates:[] }; }
+function task(id, history=[]){ return { id, name:"Pump Rebuild", mode:"interval", cat:"root", inventoryId:"inventory_msnpt6ic", interval:500, manualHistory:history, completedDates:[] }; }
 function harness(overrides={}){
   const imported = id => ({ dateISO:"2025-01-01", import_event_id:id, payload:{ exact:id } });
   const canonical = task("pump_rebuild_msnpt6hi", [imported("OMAX-2067268-302701-01"), imported("OMAX-2070032-302701-01")]);
   const duplicate = task("pump_rebuild_msnpt6gs");
-  const window = Object.assign({ tasksInterval:[canonical, duplicate], tasksAsReq:[], inventory:[], deletedItems:[{ payload:{ name:"Pump Rebuild" }, linkedTaskId:duplicate.id }], maintenanceTasksV2:[], maintenanceCalendarInstancesV2:[], maintenanceOccurrencesV2:[] }, overrides);
+  const sharedInventory={ id:"inventory_msnpt6ic", name:"Pump Rebuild", linkedTaskId:duplicate.id, qty:0, qtyNew:0, price:null, pn:"", folderId:null };
+  const window = Object.assign({ tasksInterval:[canonical, duplicate], tasksAsReq:[], inventory:[{id:"first",name:"Other"},sharedInventory,{id:"last",name:"Other 2"}], deletedItems:[{ payload:{ name:"Pump Rebuild" }, linkedTaskId:duplicate.id }], maintenanceTasksV2:[], maintenanceCalendarInstancesV2:[], maintenanceOccurrencesV2:[] }, overrides);
   const state = ()=>structuredClone({ tasksInterval:window.tasksInterval, tasksAsReq:window.tasksAsReq, inventory:window.inventory, deletedItems:window.deletedItems, maintenanceTasksV2:window.maintenanceTasksV2, maintenanceCalendarInstancesV2:window.maintenanceCalendarInstancesV2, maintenanceOccurrencesV2:window.maintenanceOccurrencesV2 });
   window.__lastLoadedCloudState = state();
   const context = { window, structuredClone, JSON, Date, setTimeout, snapshotState:state, exportJsonDownload:()=>true, saveCloudNow:async()=>({ saved:true, stateWriteAttempted:true, stateWriteCompleted:true }) };
   vm.createContext(context); vm.runInContext(source, context);
-  return { window, context, canonical, duplicate, state };
+  return { window, context, canonical, duplicate, sharedInventory, state };
 }
 (async()=>{
   {
@@ -30,16 +31,52 @@ function harness(overrides={}){
   {
     const h=harness(); const audit=h.window.auditPumpRebuildTaskDuplication();
     assert.deepEqual(Array.from(audit.removableCandidateIds),["pump_rebuild_msnpt6gs"]); assert.equal(audit.repairSafe,true);
+    assert.equal(audit.inventoryRelinkRequired,true); assert.equal(audit.inventoryRelinkSafe,true);
+    assert.deepEqual({...audit.inventoryRelinkPlan},{inventoryId:"inventory_msnpt6ic",fromTaskId:"pump_rebuild_msnpt6gs",toTaskId:"pump_rebuild_msnpt6hi"});
+    const beforeTasks=structuredClone(h.window.tasksInterval); const beforeInventory=structuredClone(h.window.inventory); const beforeDeleted=structuredClone(h.window.deletedItems);
     const beforeHistory=structuredClone(h.canonical.manualHistory); const beforeV2=structuredClone([h.window.maintenanceTasksV2,h.window.maintenanceCalendarInstancesV2,h.window.maintenanceOccurrencesV2]);
     const result=await h.window.repairExactPumpRebuildTaskDuplication();
     assert.equal(result.repaired,true); assert.deepEqual(h.window.tasksInterval.map(x=>x.id),["pump_rebuild_msnpt6hi"]);
+    assert.deepEqual(h.window.tasksInterval[0],beforeTasks[0],"canonical task remains byte-equivalent");
     assert.deepEqual(h.canonical.manualHistory,beforeHistory,"both imported events stay byte-for-byte");
+    assert.deepEqual(Array.from(result.preservedImportEventIds),["OMAX-2067268-302701-01","OMAX-2070032-302701-01"]);
+    assert.equal(result.inventoryRelinkRequired,true); assert.equal(result.inventoryRelinkCompleted,true);
+    assert.deepEqual(Array.from(result.relinkedInventoryIds),["inventory_msnpt6ic"]); assert.equal(result.beforeInventoryLink,"pump_rebuild_msnpt6gs"); assert.equal(result.afterInventoryLink,"pump_rebuild_msnpt6hi");
+    assert.equal(h.window.inventory.length,beforeInventory.length); assert.deepEqual(h.window.inventory.map(x=>x.id),beforeInventory.map(x=>x.id),"inventory order is unchanged");
+    assert.deepEqual(h.window.inventory[0],beforeInventory[0]); assert.deepEqual(h.window.inventory[2],beforeInventory[2]);
+    assert.equal(JSON.stringify(h.window.inventory[1]),JSON.stringify({...beforeInventory[1],linkedTaskId:"pump_rebuild_msnpt6hi"}),"only inventory link changes");
     assert.deepEqual([h.window.maintenanceTasksV2,h.window.maintenanceCalendarInstancesV2,h.window.maintenanceOccurrencesV2],beforeV2);
-    assert.deepEqual(h.window.deletedItems,[{ payload:{ name:"Pump Rebuild" }, linkedTaskId:"pump_rebuild_msnpt6gs" }],"trash lifecycle entry is not rewritten");
+    assert.deepEqual(h.window.deletedItems,beforeDeleted,"trash lifecycle entry is not rewritten");
+  }
+  {
+    const h=harness(); const first={id:"first-task",name:"Other",interval:100}; const last={id:"last-task",name:"Other 2",interval:200};
+    h.window.tasksInterval.splice(0,0,first); h.window.tasksInterval.push(last); h.window.__lastLoadedCloudState=h.state();
+    await h.window.repairExactPumpRebuildTaskDuplication();
+    assert.deepEqual(h.window.tasksInterval.map(item=>item.id),["first-task","pump_rebuild_msnpt6hi","last-task"],"every retained task keeps its ordering");
   }
   { const h=harness(); h.duplicate.manualHistory.push({dateISO:"2020-01-01"}); h.window.__lastLoadedCloudState=h.state(); assert.match((await h.window.repairExactPumpRebuildTaskDuplication()).refusedReason,/preconditions/); }
-  { const h=harness(); h.window.inventory.push({ linkedTaskId:h.duplicate.id }); h.window.__lastLoadedCloudState=h.state(); assert.match((await h.window.repairExactPumpRebuildTaskDuplication()).refusedReason,/live-reference/); }
-  { const h=harness(); h.window.inventory.push({id:"changed"}); assert.match((await h.window.repairExactPumpRebuildTaskDuplication()).refusedReason,/baseline/); }
+  { const h=harness(); h.window.inventory.push({ id:"another", linkedTaskId:h.duplicate.id }); h.window.__lastLoadedCloudState=h.state(); const audit=h.window.auditPumpRebuildTaskDuplication(); assert.equal(audit.repairSafe,false); assert.match(audit.refusalReasons.join(" "),/additional live references/); }
+  { const h=harness(); h.canonical.inventoryId="different"; h.window.__lastLoadedCloudState=h.state(); assert.equal(h.window.auditPumpRebuildTaskDuplication().repairSafe,false,"different inventory ID blocks repair"); }
+  { const h=harness(); h.window.inventory.push(structuredClone(h.sharedInventory)); h.window.__lastLoadedCloudState=h.state(); assert.equal(h.window.auditPumpRebuildTaskDuplication().repairSafe,false,"multiple inventory records block repair"); }
+  { const h=harness(); h.window.inventory[1].qty=1; h.window.__lastLoadedCloudState=h.state(); assert.match(h.window.auditPumpRebuildTaskDuplication().refusalReasons.join(" "),/authoritative configuration/); }
+  { const h=harness(); h.window.inventory.push({id:"changed"}); assert.match((await h.window.repairExactPumpRebuildTaskDuplication()).refusedReason,/preconditions/); }
+  {
+    const h=harness(); const beforeTasks=h.state().tasksInterval; const beforeInventory=h.state().inventory;
+    h.context.saveCloudNow=async()=>({saved:false,stateWriteAttempted:false,stateWriteCompleted:false,error:"pre-write"});
+    const result=await h.window.repairExactPumpRebuildTaskDuplication();
+    assert.equal(result.repaired,false); assert.deepEqual(h.window.tasksInterval,beforeTasks); assert.deepEqual(h.window.inventory,beforeInventory,"definite pre-write failure restores inventory");
+  }
+  {
+    const h=harness(); let saves=0; h.context.saveCloudNow=async()=>{ saves++; return {saved:false,stateWriteAttempted:true,stateWriteCompleted:false,indeterminate:true}; };
+    const result=await h.window.repairExactPumpRebuildTaskDuplication();
+    assert.equal(saves,1,"indeterminate write is never retried"); assert.equal(result.saveIndeterminate,true);
+    assert.equal(h.window.tasksInterval.length,1,"indeterminate write is not rolled back"); assert.equal(h.window.inventory[1].linkedTaskId,"pump_rebuild_msnpt6hi");
+  }
+  {
+    const h=harness(); h.context.exportJsonDownload=()=>{ h.window.inventory[1].qty=9; return true; };
+    const result=await h.window.repairExactPumpRebuildTaskDuplication();
+    assert.match(result.refusedReason,/authorization became stale/); assert.equal(result.saveAttempted,false,"authorization cannot be reused after state changes");
+  }
 
   const calendar=fs.readFileSync("js/calendar.js","utf8");
   const restore=calendar.slice(calendar.indexOf("function restoreCriticalIntervalTasks"),calendar.indexOf("function renderCalendar"));


### PR DESCRIPTION
### Motivation

- Tighten MI-02K Pump Rebuild duplication handling so the helper can safely relink a single authoritative inventory record from the empty duplicate to the canonical task while preserving protected imported history and deleted-items evidence.

### Description

- Extend `auditPumpRebuildTaskDuplication` to detect the exact shared-inventory configuration and to report `inventoryRelinkRequired`, `inventoryRelinkSafe`, `inventoryRelinkPlan`, `removableCandidateIds`, and `refusalReasons` while validating canonical/duplicate existence, task equivalence, imported event IDs, and baseline parity. (`js/maintenance-duplication.js`)
- Implement `repairExactPumpRebuildTaskDuplication` authorization and mutation flow to generate a single-use authorization, download a full-state backup, revalidate the plan, relink only `inventory_msnpt6ic.linkedTaskId` to the canonical task, remove only the duplicate from `tasksInterval`, verify intended-only changes before calling `saveCloudNow()`, and preserve canonical task history and `deletedItems` byte-for-byte. (`js/maintenance-duplication.js`)
- Add precise rollback behavior that restores both `tasksInterval` and `inventory` on a definite pre-write failure and that does not retry or roll back indeterminate writes, and expose structured relink results (`inventoryRelinkCompleted`, `relinkedInventoryIds`, `beforeInventoryLink`, `afterInventoryLink`, `preservedImportEventIds`). (`js/maintenance-duplication.js`)
- Add deterministic tests covering the successful relink path, audit plan reporting, inventory/order preservation, canonical-history preservation, deleted-items preservation, refusal conditions for unexpected references or changed inventory, multiple-inventory blocking, baseline mismatches, definite save failure rollback, indeterminate-write behavior, and single-use authorization. (`tests/pump-rebuild-duplication.test.js`)
- Leave `vercel.json` unchanged (kept exact `{ "cleanUrls": true }`).

### Testing

- Ran `node --check` on the changed files and the test file and they passed. (checked `js/maintenance-duplication.js` and `tests/pump-rebuild-duplication.test.js`)
- Ran the deterministic test suite with `node tests/pump-rebuild-duplication.test.js` and the pump rebuild duplication tests passed.
- Ran repository checks including `git diff --check`, a conflict-marker scan, and `git status --short` and they reported no conflicts and a clean working tree after the focused changes.
- No browser automation, Firestore writes, or production data operations were performed during testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b2ab73a008325abffcf008d3236db)