### PR TITLE
MI-02K: Fix false Pump Rebuild repair refusal against matching cloud state

### DIFF
--- a/js/maintenance-duplication.js
+++ b/js/maintenance-duplication.js
@@ -8,7 +8,8 @@
   const DUPLICATE_ID = "pump_rebuild_msnpt6gs";
   const INVENTORY_ID = "inventory_msnpt6ic";
   const IMPORT_IDS = ["OMAX-2067268-302701-01", "OMAX-2070032-302701-01"];
-  const AUTHORITATIVE_INVENTORY = { id:INVENTORY_ID, name:"Pump Rebuild", linkedTaskId:DUPLICATE_ID, qty:0, qtyNew:0, price:null, pn:"", folderId:null };
+  const REQUIRED_INVENTORY_CONFIGURATION = { id:INVENTORY_ID, name:"Pump Rebuild", linkedTaskId:DUPLICATE_ID, qty:0, qtyNew:0, qtyOld:0, price:null, pn:"", folderId:null, unit:"pcs", link:"", note:"" };
+  const BASELINE_FIELDS = ["tasksInterval", "inventory", "tasksAsReq", "deletedItems", "maintenanceTasksV2", "maintenanceCalendarInstancesV2", "maintenanceOccurrencesV2"];
 
   const clone = value => typeof structuredClone === "function" ? structuredClone(value) : JSON.parse(JSON.stringify(value));
   const key = value => JSON.stringify(value);
@@ -21,6 +22,26 @@
   const isEquivalentPump = task => isPumpRebuild(task) && normalizeMode(task) === "interval" && Number(task?.interval) === 500;
   const historyIds = task => (Array.isArray(task?.manualHistory) ? task.manualHistory : []).map(entry => String(entry?.import_event_id || entry?.importEventId || entry?.provenance?.import_event_id || entry?.provenance?.importEventId || "")).filter(Boolean);
   const count = value => Array.isArray(value) ? value.length : 0;
+
+  // Compare JSON data structurally rather than relying on insertion order in
+  // JSON.stringify. Paths are retained so a refusal identifies what changed.
+  function mismatchPaths(actual, expected, path = "", found = []){
+    if (Object.is(actual, expected)) return found;
+    if (Array.isArray(actual) || Array.isArray(expected)){
+      if (!Array.isArray(actual) || !Array.isArray(expected)){ found.push(path || "$"); return found; }
+      if (actual.length !== expected.length) found.push(`${path}.length`);
+      for (let index = 0; index < Math.max(actual.length, expected.length); index++)
+        mismatchPaths(actual[index], expected[index], `${path}[${index}]`, found);
+      return found;
+    }
+    if (actual && expected && typeof actual === "object" && typeof expected === "object"){
+      [...new Set([...Object.keys(actual), ...Object.keys(expected)])].sort().forEach(field =>
+        mismatchPaths(actual[field], expected[field], path ? `${path}.${field}` : field, found));
+      return found;
+    }
+    found.push(path || "$");
+    return found;
+  }
 
   function normalizeMaintenanceTaskIdentity(task){
     return { identity:taskIdentity(task), mode:normalizeMode(task), interval:Number(task?.interval) || 0, configuration:taskConfiguration(task), equivalentKey:equivalentKey(task) };
@@ -88,11 +109,28 @@
     const unexpectedLiveReferences = allLiveReferences.filter(reference => reference.path !== intendedReferencePath);
     const current = stateForRepair();
     const baseline = global.__lastLoadedCloudState;
-    const currentComparison = current ? clone(current) : null;
-    const baselineComparison = baseline ? clone(baseline) : null;
-    if (currentComparison) delete currentComparison.saveMeta;
-    if (baselineComparison) delete baselineComparison.saveMeta;
-    const baselineMatches = Boolean(currentComparison && baselineComparison && key(currentComparison) === key(baselineComparison));
+    const baselineMismatchPaths = [];
+    if (!current || !baseline) baselineMismatchPaths.push("baseline");
+    else BASELINE_FIELDS.forEach(field => mismatchPaths(current[field], baseline[field], field, baselineMismatchPaths));
+    const tasksIntervalMismatchPaths = current && baseline ? mismatchPaths(current.tasksInterval, baseline.tasksInterval, "tasksInterval") : ["tasksInterval"];
+    const inventoryBaselineMismatchPaths = current && baseline ? mismatchPaths(current.inventory, baseline.inventory, "inventory") : ["inventory"];
+    const tasksIntervalBaselineMatched = tasksIntervalMismatchPaths.length === 0;
+    const inventoryBaselineMatched = inventoryBaselineMismatchPaths.length === 0;
+    const baselineMatches = baselineMismatchPaths.length === 0;
+    const baselineInventoryMatches = Array.isArray(baseline?.inventory) ? baseline.inventory.filter(item => String(item?.id || "") === INVENTORY_ID) : [];
+    const authoritativeInventoryRecord = baselineInventoryMatches[0];
+    const authoritativeInventoryIndex = Array.isArray(baseline?.inventory) ? baseline.inventory.indexOf(authoritativeInventoryRecord) : -1;
+    // The baseline position provides a diagnostic candidate when the ID itself
+    // was changed, without authorizing it as the required live record.
+    const configurationCandidates = inventory.filter(item => item?.name === "Pump Rebuild" && item?.linkedTaskId === DUPLICATE_ID);
+    const inventoryConfigurationRecord = inventoryRecord || (authoritativeInventoryIndex >= 0 ? inventory[authoritativeInventoryIndex] : null) || (configurationCandidates.length === 1 ? configurationCandidates[0] : null);
+    const inventoryConfigurationMismatchPaths = [];
+    if (inventoryConfigurationRecord) Object.entries(REQUIRED_INVENTORY_CONFIGURATION).forEach(([field, expected]) =>
+      mismatchPaths(inventoryConfigurationRecord[field], expected, `inventory.${field}`, inventoryConfigurationMismatchPaths));
+    else inventoryConfigurationMismatchPaths.push("inventory");
+    const authoritativeRecordMismatchPaths = inventoryConfigurationRecord && authoritativeInventoryRecord
+      ? mismatchPaths(inventoryConfigurationRecord, authoritativeInventoryRecord, "inventory", []) : ["inventory"];
+    const authoritativeBaselineMatched = baselineInventoryMatches.length === 1 && inventoryConfigurationMismatchPaths.length === 0 && authoritativeRecordMismatchPaths.length === 0;
     const refusalReasons = [];
     if (canonicalMatches.length !== 1 || duplicateMatches.length !== 1) refusalReasons.push("Both exact task IDs must exist exactly once.");
     if (!canonical || !duplicate || !isEquivalentPump(canonical) || !isEquivalentPump(duplicate)) refusalReasons.push("Both exact tasks must be equivalent 500-hour interval Pump Rebuild tasks.");
@@ -100,15 +138,17 @@
     if (count(canonical?.manualHistory) !== 2 || count(canonical?.completedDates) !== 0 || key(historyIds(canonical)) !== key(IMPORT_IDS)) refusalReasons.push("Canonical task history does not contain exactly the two protected imports.");
     if (count(duplicate?.manualHistory) !== 0 || count(duplicate?.completedDates) !== 0) refusalReasons.push("Duplicate task is not empty.");
     if (matchingInventory.length !== 1) refusalReasons.push("Exactly one matching live inventory record is required.");
-    if (!inventoryRecord || key(inventoryRecord) !== key(AUTHORITATIVE_INVENTORY)) refusalReasons.push("Shared inventory record differs from the authoritative configuration.");
+    if (inventoryConfigurationMismatchPaths.length || baselineInventoryMatches.length !== 1) refusalReasons.push("Shared inventory record differs from the authoritative configuration.");
+    if (authoritativeRecordMismatchPaths.length) refusalReasons.push("Shared inventory record differs from the authoritative cloud-loaded record.");
     if (unexpectedLiveReferences.length) refusalReasons.push("Unexpected additional live references target the duplicate task.");
     if (!baselineMatches) refusalReasons.push("Current state does not match the latest authoritative Firestore-loaded baseline.");
     const inventoryRelinkRequired = Boolean(inventoryRecord && inventoryRecord.linkedTaskId === DUPLICATE_ID);
-    const inventoryRelinkSafe = inventoryRelinkRequired && matchingInventory.length === 1 && !unexpectedLiveReferences.length && key(inventoryRecord) === key(AUTHORITATIVE_INVENTORY);
+    const inventoryRelinkSafe = inventoryRelinkRequired && matchingInventory.length === 1 && !unexpectedLiveReferences.length && authoritativeBaselineMatched;
     const inventoryRelinkPlan = inventoryRelinkSafe ? { inventoryId:INVENTORY_ID, fromTaskId:DUPLICATE_ID, toTaskId:CANONICAL_ID } : null;
     const removableCandidateIds = refusalReasons.length === 0 ? [DUPLICATE_ID] : [];
     return { records, equivalentGroups:Object.entries(groups).map(([configuration, ids])=>({ configuration, ids })), removableCandidateIds,
       inventoryRelinkRequired, inventoryRelinkSafe, inventoryRelinkPlan, refusalReasons,
+      authoritativeBaselineMatched, tasksIntervalBaselineMatched, inventoryBaselineMatched, baselineMismatchPaths, inventoryConfigurationMismatchPaths,
       liveReferences:allLiveReferences, unexpectedLiveReferences, deletedItemsLinks:findReferences(deleted, DUPLICATE_ID, "deletedItems"),
       repairSafe:removableCandidateIds.length === 1 && inventoryRelinkSafe };
   }

--- a/tests/pump-rebuild-duplication.test.js
+++ b/tests/pump-rebuild-duplication.test.js
@@ -9,7 +9,7 @@ function harness(overrides={}){
   const imported = id => ({ dateISO:"2025-01-01", import_event_id:id, payload:{ exact:id } });
   const canonical = task("pump_rebuild_msnpt6hi", [imported("OMAX-2067268-302701-01"), imported("OMAX-2070032-302701-01")]);
   const duplicate = task("pump_rebuild_msnpt6gs");
-  const sharedInventory={ id:"inventory_msnpt6ic", name:"Pump Rebuild", linkedTaskId:duplicate.id, qty:0, qtyNew:0, price:null, pn:"", folderId:null };
+  const sharedInventory={ folderId:null, id:"inventory_msnpt6ic", link:"", linkedTaskId:duplicate.id, name:"Pump Rebuild", note:"", pn:"", price:null, qty:0, qtyNew:0, qtyOld:0, unit:"pcs" };
   const window = Object.assign({ tasksInterval:[canonical, duplicate], tasksAsReq:[], inventory:[{id:"first",name:"Other"},sharedInventory,{id:"last",name:"Other 2"}], deletedItems:[{ payload:{ name:"Pump Rebuild" }, linkedTaskId:duplicate.id }], maintenanceTasksV2:[], maintenanceCalendarInstancesV2:[], maintenanceOccurrencesV2:[] }, overrides);
   const state = ()=>structuredClone({ tasksInterval:window.tasksInterval, tasksAsReq:window.tasksAsReq, inventory:window.inventory, deletedItems:window.deletedItems, maintenanceTasksV2:window.maintenanceTasksV2, maintenanceCalendarInstancesV2:window.maintenanceCalendarInstancesV2, maintenanceOccurrencesV2:window.maintenanceOccurrencesV2 });
   window.__lastLoadedCloudState = state();
@@ -32,6 +32,8 @@ function harness(overrides={}){
     const h=harness(); const audit=h.window.auditPumpRebuildTaskDuplication();
     assert.deepEqual(Array.from(audit.removableCandidateIds),["pump_rebuild_msnpt6gs"]); assert.equal(audit.repairSafe,true);
     assert.equal(audit.inventoryRelinkRequired,true); assert.equal(audit.inventoryRelinkSafe,true);
+    assert.equal(audit.authoritativeBaselineMatched,true); assert.equal(audit.tasksIntervalBaselineMatched,true); assert.equal(audit.inventoryBaselineMatched,true);
+    assert.deepEqual(Array.from(audit.baselineMismatchPaths),[]); assert.deepEqual(Array.from(audit.inventoryConfigurationMismatchPaths),[]);
     assert.deepEqual({...audit.inventoryRelinkPlan},{inventoryId:"inventory_msnpt6ic",fromTaskId:"pump_rebuild_msnpt6gs",toTaskId:"pump_rebuild_msnpt6hi"});
     const beforeTasks=structuredClone(h.window.tasksInterval); const beforeInventory=structuredClone(h.window.inventory); const beforeDeleted=structuredClone(h.window.deletedItems);
     const beforeHistory=structuredClone(h.canonical.manualHistory); const beforeV2=structuredClone([h.window.maintenanceTasksV2,h.window.maintenanceCalendarInstancesV2,h.window.maintenanceOccurrencesV2]);
@@ -58,7 +60,16 @@ function harness(overrides={}){
   { const h=harness(); h.window.inventory.push({ id:"another", linkedTaskId:h.duplicate.id }); h.window.__lastLoadedCloudState=h.state(); const audit=h.window.auditPumpRebuildTaskDuplication(); assert.equal(audit.repairSafe,false); assert.match(audit.refusalReasons.join(" "),/additional live references/); }
   { const h=harness(); h.canonical.inventoryId="different"; h.window.__lastLoadedCloudState=h.state(); assert.equal(h.window.auditPumpRebuildTaskDuplication().repairSafe,false,"different inventory ID blocks repair"); }
   { const h=harness(); h.window.inventory.push(structuredClone(h.sharedInventory)); h.window.__lastLoadedCloudState=h.state(); assert.equal(h.window.auditPumpRebuildTaskDuplication().repairSafe,false,"multiple inventory records block repair"); }
-  { const h=harness(); h.window.inventory[1].qty=1; h.window.__lastLoadedCloudState=h.state(); assert.match(h.window.auditPumpRebuildTaskDuplication().refusalReasons.join(" "),/authoritative configuration/); }
+  { const h=harness(); h.window.inventory[1].qty=1; h.window.__lastLoadedCloudState=h.state(); const audit=h.window.auditPumpRebuildTaskDuplication(); assert.match(audit.refusalReasons.join(" "),/authoritative configuration/); assert.deepEqual(Array.from(audit.inventoryConfigurationMismatchPaths),["inventory.qty"]); }
+  {
+    const criticalFields={id:"wrong",name:"Wrong",linkedTaskId:"wrong",qty:1,qtyNew:1,qtyOld:1,price:1,pn:"x",folderId:"x",unit:"ea",link:"x",note:"x"};
+    for (const [field,value] of Object.entries(criticalFields)){ const h=harness(); h.window.inventory[1][field]=value; h.window.__lastLoadedCloudState=h.state(); assert.ok(h.window.auditPumpRebuildTaskDuplication().inventoryConfigurationMismatchPaths.includes(`inventory.${field}`),`${field} is diagnosed`); }
+  }
+  { const h=harness(); h.window.inventory[1].extraLegitimateField="cloud-value"; h.window.__lastLoadedCloudState=h.state(); assert.equal(h.window.auditPumpRebuildTaskDuplication().repairSafe,true,"cloud-matched extra fields are retained and accepted"); }
+  { const h=harness(); h.window.__lastLoadedCloudState.inventory[1]=Object.fromEntries(Object.entries(h.window.__lastLoadedCloudState.inventory[1]).reverse()); const audit=h.window.auditPumpRebuildTaskDuplication(); assert.equal(audit.inventoryBaselineMatched,true,"object insertion order is not a data mismatch"); assert.equal(audit.repairSafe,true); }
+  { const h=harness(); h.window.inventory[1].note="changed"; const audit=h.window.auditPumpRebuildTaskDuplication(); assert.equal(audit.inventoryBaselineMatched,false); assert.ok(audit.baselineMismatchPaths.includes("inventory[1].note")); }
+  { const h=harness(); h.window.inventory[1].nonTarget="changed"; const audit=h.window.auditPumpRebuildTaskDuplication(); assert.equal(audit.authoritativeBaselineMatched,false); assert.ok(audit.baselineMismatchPaths.includes("inventory[1].nonTarget")); }
+  { const h=harness(); h.window.tasksInterval[0].cat="changed"; const audit=h.window.auditPumpRebuildTaskDuplication(); assert.equal(audit.tasksIntervalBaselineMatched,false); assert.ok(audit.baselineMismatchPaths.includes("tasksInterval[0].cat")); }
   { const h=harness(); h.window.inventory.push({id:"changed"}); assert.match((await h.window.repairExactPumpRebuildTaskDuplication()).refusedReason,/preconditions/); }
   {
     const h=harness(); const beforeTasks=h.state().tasksInterval; const beforeInventory=h.state().inventory;


### PR DESCRIPTION
### Motivation
- Prevent spurious repair refusals when the live Pump Rebuild inventory record contains legitimate extra fields or when object property insertion order differs from the cloud-loaded baseline.
- Use the authoritative cloud-loaded inventory as the byte-equivalent baseline and require explicit safety-critical inventory fields before enabling relink/remove repairs.
- Produce actionable diagnostics that show exact mismatch paths for baseline and inventory configuration differences instead of only generic refusal messages.

### Description
- Replaced the insertion-order-sensitive `JSON.stringify` equality check with a recursive structural comparator `mismatchPaths` and a `BASELINE_FIELDS` list to compare protected collections (`tasksInterval`, `inventory`, `tasksAsReq`, `deletedItems`, `maintenanceTasksV2`, `maintenanceCalendarInstancesV2`, `maintenanceOccurrencesV2`).
- Introduced `REQUIRED_INVENTORY_CONFIGURATION` containing all safety-critical inventory fields and changed inventory validation to: require those fields explicitly, verify the live record matches the cloud-loaded authoritative record byte-for-byte, and accept additional legitimate fields only if they match the cloud baseline.
- Changed relink authorization to depend on a new `authoritativeBaselineMatched` signal and added diagnostic audit fields returned by `auditPumpRebuildTaskDuplication`: `authoritativeBaselineMatched`, `tasksIntervalBaselineMatched`, `inventoryBaselineMatched`, `baselineMismatchPaths`, and `inventoryConfigurationMismatchPaths`.
- Updated the deterministic test harness to reproduce the full production-shaped inventory record and added targeted tests that assert correct acceptance of extra legitimate fields, detection of safety-critical mismatches, object property-order tolerance, and that identical current/cloud task and inventory arrays pass.

### Testing
- Ran `node --check js/maintenance-duplication.js` and `node --check tests/pump-rebuild-duplication.test.js` and both checks succeeded.
- Executed `node tests/pump-rebuild-duplication.test.js` and the deterministic test suite passed with the message `pump rebuild duplication deterministic tests passed`.
- Ran repository sanity checks: `git diff --check` and a conflict-marker scan (no conflict markers found), and they passed.
- Note: PR creation tooling (`make_pr`) was not available in this environment, so a remote pull request could not be opened here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ce7290b908325882af6a1b7715564)