### PR TITLE
CFR-02: Add cutting-file content firewall, Storage initialization, and read-only diagnostics

### DIFF
--- a/docs/cfr-02-file-content-firewall-and-storage-foundation.md
+++ b/docs/cfr-02-file-content-firewall-and-storage-foundation.md
@@ -1,0 +1,70 @@
+# CFR-02 — Cutting-file content firewall and Storage foundation
+
+**Status:** safety foundation only. Cloud Storage uploads, downloads, listing, deletion, migration, and cutting-job import remain disabled.
+
+## Implementation
+
+`index.html` loads Firebase Storage 8.10.1 and the standalone `js/cuttingFileContentFirewall.js` module. `initFirebase()` reuses the existing Firebase app and authenticated session and initializes only the Storage service for `gs://omax-maintenance.firebasestorage.app`. Initialization calls no Storage reference or object method. Failure is retained as diagnostic information and does not change Firestore state loading, adoption, or routing.
+
+`snapshotState()` no longer silently removes attachment content before inspection. The pure scanner examines live values recursively before JSON serialization or state compaction. `saveCloudInternal()` scans that raw complete snapshot, retains all existing size, revision, schema, protected-state, and dangerous-reduction checks, and sends the final merged state through `writeAuthoritativeStateSnapshot()`. Initial seed, legacy workspace-root migration, and clear/reset state writes also use this shared final boundary. No direct `FB.docRef.set()` state write remains.
+
+The shared writer returns this shape when blocked:
+
+```js
+{
+  saved: false,
+  blocked: true,
+  error: "Embedded cutting-file content was blocked from authoritative state.",
+  errorCode: "embedded_cutting_file_content_blocked",
+  stateWriteAttempted: false,
+  stateWriteCompleted: false,
+  findings: [ /* paths and metadata only; never content */ ]
+}
+```
+
+It does not mutate, strip, truncate, retry, save a partial state, or update the authoritative cloud baseline.
+
+## Detection rules and thresholds
+
+Every finding contains a deterministic `$`-based object path, reason/type, measurable approximate byte size, root collection, and `blocksAuthoritativeSave: true`. Object keys are traversed and findings are sorted lexically for stable results. Cycles are safely ignored after their first visit.
+
+The scanner blocks:
+
+- `File`, `Blob`, `ArrayBuffer`, `SharedArrayBuffer`, `DataView`, all typed-array views, and recognized binary-like browser objects;
+- every `data:` or `blob:` URL;
+- base64-like strings at **4,096 characters or greater**;
+- known raw/content/payload fields at **512 characters or greater**, including content fields in cutting-file or preview context;
+- DXF/ORD/OMX signatures at **256 characters or greater**;
+- SVG, HTML, canvas, or image markup at **16,384 characters or greater**.
+
+Tests cover the base64 lower boundary and markup threshold. Ordinary bounded filenames, extensions, MIME types, hashes, `gs://` object references, HTTPS references, local relative paths/root signatures, notes, dimensions, and parser metadata are allowed. Threshold matching is inclusive. These heuristics intentionally favor blocking and operator review over silent data loss; they do not prove a file format is valid.
+
+## Read-only browser diagnostics
+
+`auditCuttingFileContentExposure()` scans the current `snapshotState()`, active and completed job roots, `deletedItems`, the last loaded cloud baseline, `cutting_job_files_v1`, `cutting_job_onedrive_preview_cache_v1`, and `omax_local_state_backup_v1`. It groups path-only findings by source, reports inaccessible caches and local-only contamination, and performs no cleanup or save.
+
+`getCloudCutFileStorageDiagnostics()` reports URL/hostname and Vercel-host detection, project/bucket/workspace/document routing, existing sign-in UID when available, Storage SDK/service status, production-project targeting, and a current firewall summary. It explicitly reports uploads/downloads disabled and Storage rules untested. It exposes no token, credential, complete user record, or embedded content.
+
+## Known limitations
+
+- Diagnostics are static client observations, not proof of Firebase Console configuration, deployed rules, bucket access, or cross-device behavior.
+- Local cache inspection is best effort; unavailable or unparsable storage is reported without modification.
+- The firewall detects content patterns and binary values; it is not a CAD parser, antivirus scanner, MIME validator, or strict metadata schema.
+- Existing contaminated cloud state can still load and display. A later authoritative save remains blocked until a separately authorized remediation/migration is designed.
+- Storage rules remain deny-all and were not exercised by this implementation.
+
+## Manual Vercel-preview checks
+
+Use this branch's PR preview without editing data:
+
+1. Confirm Vercel uses Framework Preset **Other**, empty Build and Install commands, and output directory `.`.
+2. Open the preview and run `getCloudCutFileStorageDiagnostics()`; confirm preview hostname detection, project `omax-maintenance`, bucket `omax-maintenance.firebasestorage.app`, workspace `github-prod`, state path `workspaces/github-prod/app/state`, and both transfer flags `false`.
+3. Run `auditCuttingFileContentExposure()` and export only its metadata result for review; confirm no content appears in the result.
+4. Confirm existing contaminated records, if any, still render without cleanup or migration.
+5. In browser developer tools, confirm page load and both diagnostics make no Storage network request and no Firestore write.
+6. If an isolated, operator-approved non-production mock can be used later, verify a contaminated save returns the structured firewall block and makes no state `set()` call. Do **not** test this by changing production state.
+7. Do not claim Storage rules are tested; CFR-02 deliberately performs no Storage request.
+
+## CFR-02 / CFR-03 boundary
+
+CFR-02 provides initialization, prevention, and observation only. CFR-03 must separately design and authorize Storage security rules, bounded metadata schemas, upload/download/delete workflows, job documents and log subcollections, migration/backfill, imports, retry/idempotency, preview object validation, retention, and deployment isolation. None of those operations is enabled here, and public/test-mode Storage rules must not be used.

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-firestore.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-storage.js"></script>
   <script src="https://alcdn.msauth.net/browser/2.39.0/js/msal-browser.min.js"></script>
   <script src="https://js.live.net/v8.0/OneDrive.js"></script>
   <script>/* prevent bfcache for easier debug refresh */ window.onpageshow = e=>{ if(e.persisted) location.reload(); };</script>
@@ -197,6 +198,7 @@
   </div>
 
   <!-- Your app code (split into focused modules; order matters) -->
+  <script src="js/cuttingFileContentFirewall.js"></script>
   <script src="js/core.js"></script>
   <script src="js/auth/msalClient.js"></script>
   <script src="js/onedrive/graph.js"></script>

--- a/js/core.js
+++ b/js/core.js
@@ -589,6 +589,9 @@ let FB = {
   app: null,
   auth: null,
   db: null,
+  storage: null,
+  storageInitializationAttempted: false,
+  storageInitializationError: "",
   user: null,
   docRef: null,
   workspaceRef: null,
@@ -605,6 +608,7 @@ let hasPendingLocalChanges = false;
 let lastLocalMutationAt = 0;
 const CLOUD_SYNC_CLIENT_KEY = "cloud_sync_client_id_v1";
 const LOCAL_STATE_BACKUP_KEY = "omax_local_state_backup_v1";
+const CUT_FILE_STORAGE_BUCKET = "omax-maintenance.firebasestorage.app";
 
 
 const FIRESTORE_WARN_BYTES = 850000;
@@ -1782,13 +1786,13 @@ function getSaveSchemaCoverageReport(options = {}){
   const sanitizerRiskPaths = [
     {
       path: "cuttingJobs.files.*",
-      risk: "stripJobFileDataUrls removes embedded file/data-url/content fields before save; job metadata and manualLogs are expected to remain.",
-      source: "stripJobFileDataUrls"
+      risk: "The CFR-02 firewall blocks embedded file/data-url/content fields before an authoritative write; it does not remove them.",
+      source: "scanAuthoritativeCutFileContent"
     },
     {
       path: "completedCuttingJobs.files.*",
-      risk: "stripJobFileDataUrls removes embedded file/data-url/content fields before save; completed job metadata and manualLogs are expected to remain.",
-      source: "stripJobFileDataUrls"
+      risk: "The CFR-02 firewall blocks embedded file/data-url/content fields before an authoritative write; it does not remove them.",
+      source: "scanAuthoritativeCutFileContent"
     },
     {
       path: "cuttingJobs / completedCuttingJobs",
@@ -2490,6 +2494,17 @@ async function initFirebase(){
   FB.app  = existingApp || firebase.initializeApp(window.FIREBASE_CONFIG);
   FB.auth = firebase.auth();
   FB.db   = firebase.firestore();
+  FB.storageInitializationAttempted = true;
+  try {
+    FB.storage = typeof firebase.storage === "function"
+      ? FB.app.storage(`gs://${CUT_FILE_STORAGE_BUCKET}`)
+      : null;
+    FB.storageInitializationError = FB.storage ? "" : "Firebase Storage SDK is unavailable.";
+  } catch (err) {
+    FB.storage = null;
+    FB.storageInitializationError = String(err?.message || err || "Storage initialization failed.");
+    console.warn("Firebase Storage service initialization failed; state loading will continue without Storage.", err);
+  }
   applyFirestoreSettings(FB.db);
 
   // Persist login across refreshes
@@ -2824,6 +2839,9 @@ if (!Array.isArray(window.deletedItems)) window.deletedItems = [];
 
 function cloneStructured(value){
   if (value == null) return value;
+  if (typeof structuredClone === "function"){
+    try { return structuredClone(value); } catch (_){ }
+  }
   try {
     return JSON.parse(JSON.stringify(value));
   } catch (err) {
@@ -3988,32 +4006,14 @@ function applyJobFileCacheToJobs(jobs, cache){
   });
 }
 
-function stripJobFileDataUrls(jobs, tracker = null){
-  if (!Array.isArray(jobs)) return [];
-  return jobs.map(job => {
-    if (!job || typeof job !== "object") return job;
-    const files = Array.isArray(job.files)
-      ? job.files.map(file => {
-          if (!file || typeof file !== "object") return file;
-          const rest = {};
-          for (const [k,v] of Object.entries(file)){
-            if (typeof v === "string" && isLikelyEmbeddedFileContent(k, v)){ if (tracker) tracker.count += 1; continue; }
-            rest[k] = v;
-          }
-          return rest;
-        })
-      : [];
-    return { ...job, files };
-  });
-}
-
-function snapshotState(){
+function snapshotState(options = {}){
   refreshGlobalCollections();
-  const strippedTracker = { count: 0 };
-  const jobFileCache = readJobFileCache();
-  syncJobFileCacheFromJobs(cuttingJobs, jobFileCache);
-  syncJobFileCacheFromJobs(completedCuttingJobs, jobFileCache);
-  writeJobFileCache(jobFileCache);
+  if (!options.skipLocalFileCacheSync){
+    const jobFileCache = readJobFileCache();
+    syncJobFileCacheFromJobs(cuttingJobs, jobFileCache);
+    syncJobFileCacheFromJobs(completedCuttingJobs, jobFileCache);
+    writeJobFileCache(jobFileCache);
+  }
   const safePumpEff = (typeof window.pumpEff !== "undefined") ? window.pumpEff : null;
   const foldersSnapshot = snapshotSettingsFolders();
   const trashSnapshot = deletedItems.map(entry => ({
@@ -4054,8 +4054,8 @@ function snapshotState(){
     inventoryTransactions: inventoryTransactionsSource.map(entry => (entry && typeof entry === "object" ? { ...entry } : entry)),
     inventorySection: String(window.inventorySection || "items") === "material" ? "material" : "items",
     cuttingJobDatabase: cloneStructured(cuttingJobDatabaseSource) || {},
-    cuttingJobs: stripJobFileDataUrls(cuttingJobs, strippedTracker),
-    completedCuttingJobs: stripJobFileDataUrls(completedCuttingJobs, strippedTracker),
+    cuttingJobs: cloneStructured(cuttingJobs),
+    completedCuttingJobs: cloneStructured(completedCuttingJobs),
     orderRequests,
     receiptTrackerWeeks: Array.isArray(window.receiptTrackerWeeks)
       ? window.receiptTrackerWeeks.map(entry => ({ ...entry }))
@@ -4101,9 +4101,100 @@ function snapshotState(){
       updatedBy: getCloudSyncClientId()
     }
   };
-  if (typeof window !== "undefined") window.__lastStrippedHeavyFields = strippedTracker.count;
   return result;
 }
+
+function scanAuthoritativeCutFileContent(state, rootPath = "$"){
+  const scanner = window.CuttingFileContentFirewall?.scanCuttingFileContent;
+  if (typeof scanner !== "function"){
+    return { scannedRootPath:rootPath, contaminated:true, blockingFindingCount:1, findings:[{
+      path:rootPath, reason:"firewall_unavailable", detectedType:"FirewallAvailability",
+      approximateSize:null, sizeUnit:null, parentRootCollection:"$", blocksAuthoritativeSave:true
+    }] };
+  }
+  return scanner(state, { rootPath });
+}
+
+async function writeAuthoritativeStateSnapshot(state, setOptions = { merge:true }){
+  const writer = window.CuttingFileContentFirewall?.writeAuthoritativeState;
+  if (typeof writer !== "function"){
+    return { saved:false, blocked:true, error:"Cutting-file content firewall is unavailable.", errorCode:"cutting_file_firewall_unavailable", stateWriteAttempted:false, stateWriteCompleted:false, findings:scanAuthoritativeCutFileContent(state).findings };
+  }
+  return writer(FB.docRef, state, setOptions);
+}
+
+function inspectLocalJsonCache(key, rootPath, unavailable){
+  try {
+    if (!window.localStorage) { unavailable.push(key); return null; }
+    const raw = window.localStorage.getItem(key);
+    if (raw == null) return null;
+    try { return { value:JSON.parse(raw), rootPath }; }
+    catch (_) { return { value:raw, rootPath }; }
+  } catch (_) { unavailable.push(key); return null; }
+}
+
+function auditCuttingFileContentExposure(){
+  const unavailableCaches = [];
+  const sources = [
+    { name:"currentSnapshot", value:snapshotState({ skipLocalFileCacheSync:true }), rootPath:"$.currentSnapshot", localOnly:false },
+    { name:"cuttingJobs", value:window.cuttingJobs, rootPath:"$.cuttingJobs", localOnly:false },
+    { name:"completedCuttingJobs", value:window.completedCuttingJobs, rootPath:"$.completedCuttingJobs", localOnly:false },
+    { name:"deletedItems", value:window.deletedItems, rootPath:"$.deletedItems", localOnly:false },
+    { name:"lastLoadedAuthoritativeCloudBaseline", value:window.__lastLoadedCloudState, rootPath:"$.lastLoadedAuthoritativeCloudBaseline", localOnly:false }
+  ];
+  [
+    [JOB_FILE_CACHE_KEY, "jobFileCache"],
+    ["cutting_job_onedrive_preview_cache_v1", "oneDrivePreviewCache"],
+    [LOCAL_STATE_BACKUP_KEY, "localStateBackup"]
+  ].forEach(([key,name])=>{
+    const inspected = inspectLocalJsonCache(key, `$.${name}`, unavailableCaches);
+    if (inspected) sources.push({ name, value:inspected.value, rootPath:inspected.rootPath, localOnly:true });
+  });
+  const findingsBySource = {};
+  let blockingFindingCount = 0;
+  let localCacheFindingCount = 0;
+  let authoritativeSnapshotWouldPass = false;
+  sources.forEach(source=>{
+    const result = scanAuthoritativeCutFileContent(source.value, source.rootPath);
+    findingsBySource[source.name] = result.findings;
+    blockingFindingCount += result.blockingFindingCount;
+    if (source.localOnly) localCacheFindingCount += result.blockingFindingCount;
+    if (source.name === "currentSnapshot") authoritativeSnapshotWouldPass = !result.contaminated;
+  });
+  return {
+    generatedAtISO:new Date().toISOString(),
+    contaminated:blockingFindingCount > 0,
+    blockingFindingCount,
+    findingsBySource,
+    authoritativeSnapshotWouldPass,
+    findingExistsOnlyInLocalCache:localCacheFindingCount > 0 && blockingFindingCount === localCacheFindingCount,
+    localCacheFindingCount,
+    cachesThatCouldNotBeInspected:unavailableCaches.sort(),
+    automaticCleanupActions:[]
+  };
+}
+
+function getCloudCutFileStorageDiagnostics(){
+  const location = typeof window.location === "object" ? window.location : { hostname:"", href:"" };
+  const currentFirewall = scanAuthoritativeCutFileContent(snapshotState({ skipLocalFileCacheSync:true }), "$.currentSnapshot");
+  const projectId = String(FB.app?.options?.projectId || window.FIREBASE_CONFIG?.projectId || "");
+  return {
+    generatedAtISO:new Date().toISOString(), hostname:String(location.hostname || ""), url:String(location.href || ""),
+    isVercelPreviewHostname:/\.vercel\.app$/i.test(String(location.hostname || "")),
+    firebaseProjectId:projectId, configuredStorageBucket:CUT_FILE_STORAGE_BUCKET,
+    storageSdkAvailable:typeof window.firebase?.storage === "function",
+    storageServiceInitializationAttempted:Boolean(FB.storageInitializationAttempted),
+    storageServiceInitialized:Boolean(FB.storage), storageInitializationError:FB.storageInitializationError || "",
+    signedIn:Boolean(FB.user), uid:FB.user?.uid || null, workspaceId:WORKSPACE_ID,
+    authoritativeFirestoreDocumentPath:FB.docRef?.path || `workspaces/${WORKSPACE_ID}/app/state`,
+    pointsToProductionFirebase:projectId === "omax-maintenance", uploadsEnabled:false, downloadsEnabled:false,
+    storageRulesActuallyTested:false, firewallAvailable:typeof window.CuttingFileContentFirewall?.scanCuttingFileContent === "function",
+    currentSnapshotFirewallSummary:{ contaminated:currentFirewall.contaminated, blockingFindingCount:currentFirewall.blockingFindingCount, wouldPass:!currentFirewall.contaminated }
+  };
+}
+
+window.auditCuttingFileContentExposure = auditCuttingFileContentExposure;
+window.getCloudCutFileStorageDiagnostics = getCloudCutFileStorageDiagnostics;
 
 /* ======================== HISTORY ========================= */
 const HISTORY_LIMIT = 50;
@@ -5739,6 +5830,24 @@ const saveCloudInternal = debounce(async (saveOptions = {})=>{
   }
   try{
     const rawSnap = snapshotState();
+    const rawFirewall = scanAuthoritativeCutFileContent(rawSnap);
+    if (rawFirewall.contaminated){
+      hasPendingLocalChanges = true;
+      const blocked = {
+        saved:false, blocked:true,
+        error:"Embedded cutting-file content was blocked from authoritative state.",
+        errorCode:"embedded_cutting_file_content_blocked",
+        stateWriteAttempted:false, stateWriteCompleted:false,
+        findings:rawFirewall.findings
+      };
+      if (explicitTrace){
+        explicitTrace.saveCloudInternalReturnValue = blocked.errorCode;
+        explicitTrace.saveCloudInternalReturnType = "early_return";
+        explicitTrace.firestoreSetAttempted = false;
+      }
+      console.error("Cloud save blocked by cutting-file content firewall.", blocked);
+      return blocked;
+    }
     if (explicitTrace){
       const rawInstances = Array.isArray(rawSnap?.maintenanceCalendarInstancesV2) ? rawSnap.maintenanceCalendarInstancesV2 : [];
       const rawOccurrences = Array.isArray(rawSnap?.maintenanceOccurrencesV2) ? rawSnap.maintenanceOccurrencesV2 : [];
@@ -5896,15 +6005,19 @@ const saveCloudInternal = debounce(async (saveOptions = {})=>{
     const writeRev = Number(snap?.syncMeta?.rev || 0);
     snap.saveMeta = { lastSavedAt: new Date().toISOString(), lastSaveStatus: "saved", lastSaveError: "", lastSaveSizeBytes: sizeBytes };
     if (explicitTrace){
-      explicitTrace.firestoreSetAttempted = true;
       explicitTrace.firestoreWritePayloadInstancesCount = Array.isArray(snap.maintenanceCalendarInstancesV2) ? snap.maintenanceCalendarInstancesV2.length : 0;
       explicitTrace.firestoreWritePayloadOccurrencesCount = Array.isArray(snap.maintenanceOccurrencesV2) ? snap.maintenanceOccurrencesV2.length : 0;
       explicitTrace.firestoreWritePayloadInstanceFound = Array.isArray(snap.maintenanceCalendarInstancesV2) && snap.maintenanceCalendarInstancesV2.some(entry => entry && String(entry.id || "") === String(explicitTrace.instanceId || ""));
       explicitTrace.firestoreWritePayloadOccurrenceFound = Array.isArray(snap.maintenanceOccurrencesV2) && snap.maintenanceOccurrencesV2.some(entry => entry && String(entry.id || "") === String(explicitTrace.occurrenceId || ""));
     }
-    authoritativeStateWriteAttempted = true;
-    await FB.docRef.set(snap, { merge:true });
-    authoritativeStateWriteCompleted = true;
+    const writeResult = await writeAuthoritativeStateSnapshot(snap, { merge:true });
+    authoritativeStateWriteAttempted = writeResult.stateWriteAttempted;
+    authoritativeStateWriteCompleted = writeResult.stateWriteCompleted;
+    if (explicitTrace) explicitTrace.firestoreSetAttempted = writeResult.stateWriteAttempted;
+    if (!writeResult.saved){
+      hasPendingLocalChanges = true;
+      return writeResult;
+    }
     if (explicitTrace) explicitTrace.firestoreSetCompleted = true;
     if (typeof window !== "undefined"){
       window.__loadedCloudRevisionForSaveGuard = Number(snap?.syncMeta?.rev || 0);
@@ -6319,6 +6432,8 @@ async function loadFromCloud(){
       if (typeof resetHistoryToCurrent === "function") resetHistoryToCurrent();
       showLocalBackupConflictWarning({ cloudRev:0, backupRev:loadedRev, backupOnly:true });
     }else{
+      const previousLoadedCloudState = window.__lastLoadedCloudState;
+      const previousLoadedCloudRevision = window.__loadedCloudRevisionForSaveGuard;
       const pe = (typeof window.pumpEff === "object" && window.pumpEff)
         ? window.pumpEff
         : (window.pumpEff = { baselineRPM:null, baselineDateISO:null, entries:[], notes:[] });
@@ -6367,7 +6482,14 @@ async function loadFromCloud(){
         console.warn("Recovery Mode: seed/default Firestore write skipped.");
       } else {
         setCloudLoadGate({ loadComplete:true, adoptComplete:true });
-        await FB.docRef.set(seeded, { merge:true });
+        const seedWrite = await writeAuthoritativeStateSnapshot(seeded, { merge:true });
+        if (!seedWrite.saved){
+          console.error("Initial authoritative state write blocked by cutting-file content firewall.", seedWrite);
+          window.__lastLoadedCloudState = previousLoadedCloudState;
+          window.__loadedCloudRevisionForSaveGuard = previousLoadedCloudRevision;
+          hasPendingLocalChanges = true;
+          return seedWrite;
+        }
         hasPendingLocalChanges = false;
         if (FB.workspaceDoc){
           await updateWorkspaceMetadata({
@@ -6405,7 +6527,11 @@ async function migrateLegacyWorkspaceDoc(){
     delete stateData.createdAt;
     delete stateData.lastStateMigrationAt;
     delete stateData.lastStateDocPath;
-    await FB.docRef.set(stateData, { merge:true });
+    const migrationWrite = await writeAuthoritativeStateSnapshot(stateData, { merge:true });
+    if (!migrationWrite.saved){
+      console.error("Legacy authoritative state migration blocked by cutting-file content firewall.", migrationWrite);
+      return null;
+    }
     const meta = {
       workspaceId: WORKSPACE_ID,
       lastStateMigrationAt: new Date().toISOString(),
@@ -6683,7 +6809,8 @@ async function clearAllAppData(){
   try {
     if (FB.ready && FB.docRef) {
       if (!canWriteCloud("clearAllAppData")) return defaults;
-      await FB.docRef.set(snapshotState());
+      const clearWrite = await writeAuthoritativeStateSnapshot(snapshotState(), null);
+      if (!clearWrite.saved) console.error("Cleared authoritative state write blocked by cutting-file content firewall.", clearWrite);
     } else {
       saveCloudDebounced();
     }

--- a/js/cuttingFileContentFirewall.js
+++ b/js/cuttingFileContentFirewall.js
@@ -1,0 +1,133 @@
+(function(root, factory){
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  if (root) root.CuttingFileContentFirewall = api;
+})(typeof globalThis !== "undefined" ? globalThis : this, function(){
+  "use strict";
+
+  const THRESHOLDS = Object.freeze({
+    largeBase64Characters: 4096,
+    oversizedMarkupCharacters: 16384,
+    knownContentFieldCharacters: 512,
+    rawCadCharacters: 256
+  });
+  const CONTENT_FIELDS = /^(?:dataurl|filedata|filecontent|rawcontent|rawdata|binarydata|bytes|bytearray|arraybuffer|payloadbase64|base64|imagecontent|previewcontent|generatedpreview|svgmarkup|htmlmarkup|canvasdata)$/i;
+  const CONTENT_CONTEXT_FIELDS = /^(?:content|payload|body|source|text|markup)$/i;
+  const FILE_CONTEXT = /(?:files?|attachments?|preview|cutting|dxf|ord|omx|image|canvas)/i;
+  const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+  const SIMPLE_KEY_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+  function pathFor(parent, key, isIndex){
+    if (isIndex) return `${parent}[${key}]`;
+    const name = String(key);
+    return SIMPLE_KEY_RE.test(name) ? `${parent}.${name}` : `${parent}[${JSON.stringify(name)}]`;
+  }
+
+  function rootCollection(path){
+    const match = String(path).match(/^\$\.([^.[\]]+)/);
+    return match ? match[1] : "$";
+  }
+
+  function approximateUtf8Bytes(value){
+    if (typeof TextEncoder === "function") return new TextEncoder().encode(value).byteLength;
+    return unescape(encodeURIComponent(value)).length;
+  }
+
+  function scanCuttingFileContent(value, options = {}){
+    const rootPath = typeof options.rootPath === "string" && options.rootPath ? options.rootPath : "$";
+    const findings = [];
+    const seen = new WeakSet();
+    const add = (path, reason, type, size, detail)=>{
+      findings.push({
+        path,
+        reason,
+        detectedType: type,
+        approximateSize: Number.isFinite(size) ? size : null,
+        sizeUnit: Number.isFinite(size) ? "bytes" : null,
+        parentRootCollection: rootCollection(path),
+        blocksAuthoritativeSave: true,
+        ...(detail ? { detail } : {})
+      });
+    };
+    const visit = (current, path, keyName, ancestors)=>{
+      if (current == null) return;
+      if (typeof current === "string"){
+        const trimmed = current.trim();
+        const bytes = approximateUtf8Bytes(current);
+        if (/^data:/i.test(trimmed)) return add(path, "data_url", "DataURL", bytes);
+        if (/^blob:/i.test(trimmed)) return add(path, "blob_url", "BlobURL", bytes);
+        const compact = trimmed.replace(/\s+/g, "");
+        if (compact.length >= THRESHOLDS.largeBase64Characters && compact.length % 4 === 0 && BASE64_RE.test(compact))
+          return add(path, "suspicious_large_base64", "Base64String", bytes);
+        const key = String(keyName || "");
+        const context = ancestors.concat(key).join(".");
+        if ((CONTENT_FIELDS.test(key) || (CONTENT_CONTEXT_FIELDS.test(key) && FILE_CONTEXT.test(context))) && current.length >= THRESHOLDS.knownContentFieldCharacters)
+          return add(path, "known_embedded_content_field", "String", bytes);
+        if (current.length >= THRESHOLDS.rawCadCharacters && (/(?:^|\n)\s*SECTION\s*(?:\n|$)/i.test(current) && /(?:^|\n)\s*ENTITIES\s*(?:\n|$)/i.test(current)))
+          return add(path, "embedded_raw_dxf_content", "DXFText", bytes);
+        if (current.length >= THRESHOLDS.rawCadCharacters && (/\[(?:0|HEADER|PART|VARIABLES)\]/i.test(current) && /(?:OMX|ORD|Quality|Traverse|Pierce)/i.test(current)))
+          return add(path, "embedded_raw_ord_omx_content", "CADText", bytes);
+        if (current.length >= THRESHOLDS.oversizedMarkupCharacters && /<(?:svg|html|canvas|img)\b/i.test(current))
+          return add(path, "oversized_preview_or_markup", "MarkupString", bytes);
+        return;
+      }
+      if ((typeof File === "function" && current instanceof File) || Object.prototype.toString.call(current) === "[object File]")
+        return add(path, "browser_file_object", "File", Number(current.size));
+      if ((typeof Blob === "function" && current instanceof Blob) || Object.prototype.toString.call(current) === "[object Blob]")
+        return add(path, "browser_blob_object", "Blob", Number(current.size));
+      if (typeof ArrayBuffer === "function" && current instanceof ArrayBuffer)
+        return add(path, "array_buffer", "ArrayBuffer", current.byteLength);
+      if (typeof SharedArrayBuffer === "function" && current instanceof SharedArrayBuffer)
+        return add(path, "shared_array_buffer", "SharedArrayBuffer", current.byteLength);
+      if (typeof ArrayBuffer === "function" && ArrayBuffer.isView(current)){
+        const type = Object.prototype.toString.call(current).slice(8, -1);
+        return add(path, current instanceof DataView ? "data_view" : "typed_array", type, current.byteLength);
+      }
+      const tag = Object.prototype.toString.call(current);
+      if (/\[object (?:ImageData|ImageBitmap|OffscreenCanvas|HTMLCanvasElement|FileSystemFileHandle)\]/.test(tag))
+        return add(path, "binary_like_browser_object", tag.slice(8, -1), Number(current.width) * Number(current.height) * 4);
+      if ((typeof current !== "object" && typeof current !== "function") || seen.has(current)) return;
+      seen.add(current);
+      if (Array.isArray(current)){
+        current.forEach((item, index)=>visit(item, pathFor(path, index, true), String(index), ancestors.concat(String(keyName || ""))));
+      } else {
+        Object.keys(current).sort().forEach(key=>visit(current[key], pathFor(path, key, false), key, ancestors.concat(String(keyName || ""))));
+      }
+    };
+    visit(value, rootPath, "", []);
+    findings.sort((a,b)=>a.path.localeCompare(b.path) || a.reason.localeCompare(b.reason) || a.detectedType.localeCompare(b.detectedType));
+    return {
+      scannedRootPath: rootPath,
+      contaminated: findings.length > 0,
+      blockingFindingCount: findings.length,
+      findings
+    };
+  }
+
+  async function writeAuthoritativeState(docRef, state, setOptions){
+    const firewall = scanCuttingFileContent(state);
+    if (firewall.contaminated){
+      return {
+        saved: false,
+        blocked: true,
+        error: "Embedded cutting-file content was blocked from authoritative state.",
+        errorCode: "embedded_cutting_file_content_blocked",
+        stateWriteAttempted: false,
+        stateWriteCompleted: false,
+        findings: firewall.findings
+      };
+    }
+    try {
+      if (setOptions === null) await docRef.set(state);
+      else await docRef.set(state, setOptions);
+    } catch (err) {
+      return {
+        saved:false, blocked:false, stateWriteAttempted:true, stateWriteCompleted:false,
+        indeterminate:true, findings:[], error:String(err?.message || err)
+      };
+    }
+    return { saved:true, blocked:false, stateWriteAttempted:true, stateWriteCompleted:true, findings:[] };
+  }
+
+  return Object.freeze({ THRESHOLDS, scanCuttingFileContent, writeAuthoritativeState });
+});

--- a/tests/cfr02-content-firewall.test.js
+++ b/tests/cfr02-content-firewall.test.js
@@ -1,0 +1,92 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { THRESHOLDS, scanCuttingFileContent, writeAuthoritativeState } = require("../js/cuttingFileContentFirewall.js");
+
+const tests = [];
+const test = (name, fn)=>tests.push({ name, fn });
+const cleanMetadata = { cuttingJobs:[{ id:"job-1", name:"plate.dxf", type:"application/dxf", size:1200, checksum:"a".repeat(64), storagePath:"workspaces/github-prod/cutting-files/job-1/plate.dxf", downloadUrl:"https://example.test/plate.dxf", relativePath:"jobs/plate.dxf", localRootSignature:"root:abc", notes:"normal note" }], completedCuttingJobs:[], deletedItems:[] };
+
+test("clean bounded cutting-job metadata and references pass", ()=>assert.equal(scanCuttingFileContent(cleanMetadata).contaminated, false));
+test("File and Blob values are detected before serialization", ()=>{
+  const fakeFile = { size:7, [Symbol.toStringTag]:"File" };
+  const result = scanCuttingFileContent({ fakeFile, blob:new Blob(["abc"]) });
+  assert.deepEqual(result.findings.map(x=>x.reason), ["browser_blob_object", "browser_file_object"]);
+});
+test("ArrayBuffer, DataView, and typed arrays are blocked", ()=>{
+  const buffer = new ArrayBuffer(8);
+  assert.deepEqual(scanCuttingFileContent({ buffer, dataView:new DataView(buffer), typed:new Uint8Array(buffer) }).findings.map(x=>x.reason), ["array_buffer", "data_view", "typed_array"]);
+});
+test("nested forbidden content has exact stable path", ()=>assert.equal(scanCuttingFileContent({ cuttingJobs:[{ files:[{ preview:{ content:"data:image/png;base64,AA==" } }] }] }).findings[0].path, "$.cuttingJobs[0].files[0].preview.content"));
+test("data and blob URLs are blocked", ()=>assert.deepEqual(scanCuttingFileContent({ a:"data:text/plain,hi", b:"blob:https://example.test/id" }).findings.map(x=>x.reason), ["data_url", "blob_url"]));
+test("large base64 boundary blocks and short metadata passes", ()=>{
+  assert.equal(scanCuttingFileContent({ checksum:"A".repeat(64), payload:"A".repeat(THRESHOLDS.largeBase64Characters - 4) }).contaminated, false);
+  assert.equal(scanCuttingFileContent({ payload:"A".repeat(THRESHOLDS.largeBase64Characters) }).findings[0].reason, "suspicious_large_base64");
+});
+for (const root of ["cuttingJobs", "completedCuttingJobs", "deletedItems"]){
+  test(`embedded content in ${root} is blocked`, ()=>assert.equal(scanCuttingFileContent({ [root]:[{ dataUrl:"data:image/png;base64,AA==" }] }).findings[0].path, `$.${root}[0].dataUrl`));
+}
+test("known preview and raw content fields are blocked", ()=>{
+  const result = scanCuttingFileContent({ previewContent:"x".repeat(THRESHOLDS.knownContentFieldCharacters), rawContent:"0\nSECTION\n2\nENTITIES\n" + "x".repeat(300) });
+  assert.equal(result.blockingFindingCount, 2);
+});
+test("findings include root, size, and blocking metadata", ()=>{
+  const finding = scanCuttingFileContent({ completedCuttingJobs:[{ previewUrl:"data:image/png;base64,AA==" }] }).findings[0];
+  assert.equal(finding.parentRootCollection, "completedCuttingJobs");
+  assert.equal(finding.blocksAuthoritativeSave, true);
+  assert.equal(Number.isFinite(finding.approximateSize), true);
+});
+test("oversized markup boundary behavior is deterministic", ()=>{
+  assert.equal(scanCuttingFileContent({ note:"<svg>" + "x".repeat(THRESHOLDS.oversizedMarkupCharacters) }).findings[0].reason, "oversized_preview_or_markup");
+});
+test("findings are sorted deterministically", ()=>{
+  const input = { z:"blob:x", a:"data:text/plain,x" };
+  assert.deepEqual(scanCuttingFileContent(input).findings.map(x=>x.path), ["$.a", "$.z"]);
+  assert.deepEqual(scanCuttingFileContent(input), scanCuttingFileContent(input));
+});
+test("scanner does not mutate input", ()=>{
+  const input = structuredClone(cleanMetadata); const before = JSON.stringify(input);
+  scanCuttingFileContent(input); assert.equal(JSON.stringify(input), before);
+});
+test("blocked write never invokes set and reports flags", async ()=>{
+  let calls = 0; const result = await writeAuthoritativeState({ set:async()=>{ calls++; } }, { cuttingJobs:[{ content:"x".repeat(600) }] });
+  assert.equal(calls, 0); assert.equal(result.errorCode, "embedded_cutting_file_content_blocked");
+  assert.equal(result.stateWriteAttempted, false); assert.equal(result.stateWriteCompleted, false);
+});
+test("clean write reaches Firestore mock", async ()=>{
+  let calls = 0; const result = await writeAuthoritativeState({ set:async()=>{ calls++; } }, cleanMetadata, { merge:true });
+  assert.equal(calls, 1); assert.equal(result.saved, true); assert.equal(result.stateWriteCompleted, true);
+});
+test("failed clean write reports an attempted but incomplete write", async ()=>{
+  const result = await writeAuthoritativeState({ set:async()=>{ throw new Error("mock failure"); } }, cleanMetadata);
+  assert.equal(result.stateWriteAttempted, true); assert.equal(result.stateWriteCompleted, false); assert.equal(result.indeterminate, true);
+});
+test("core keeps protected preflight before the shared writer", ()=>{
+  const core = fs.readFileSync(path.join(__dirname, "../js/core.js"), "utf8");
+  assert.ok(core.indexOf("validateProtectedSavePreflight({") < core.indexOf("writeAuthoritativeStateSnapshot(snap"));
+});
+test("Storage initialization contains no object operation", ()=>{
+  const core = fs.readFileSync(path.join(__dirname, "../js/core.js"), "utf8");
+  const init = core.slice(core.indexOf("async function initFirebase"), core.indexOf("// Persist login"));
+  assert.match(init, /FB\.app\.storage\(`gs:\/\//);
+  assert.doesNotMatch(init, /\.ref\(|\.put\(|\.getDownloadURL\(|\.list|\.delete\(/);
+});
+test("diagnostics are read-only and helpers are exposed", ()=>{
+  const core = fs.readFileSync(path.join(__dirname, "../js/core.js"), "utf8");
+  const audit = core.slice(core.indexOf("function auditCuttingFileContentExposure"), core.indexOf("window.getCloudCutFileStorageDiagnostics") + 50);
+  assert.match(audit, /window\.auditCuttingFileContentExposure/);
+  assert.match(audit, /skipLocalFileCacheSync:true/);
+  assert.doesNotMatch(audit, /docRef\.set|writeAuthoritativeStateSnapshot|saveCloud/);
+});
+test("all state-document writes use shared firewall writer", ()=>{
+  const core = fs.readFileSync(path.join(__dirname, "../js/core.js"), "utf8");
+  assert.doesNotMatch(core, /FB\.docRef\.set\s*\(/);
+  assert.equal((core.match(/writeAuthoritativeStateSnapshot\(/g) || []).length >= 5, true);
+});
+
+(async()=>{
+  for (const { name, fn } of tests){ await fn(); process.stdout.write(`ok - ${name}\n`); }
+  process.stdout.write(`1..${tests.length}\n`);
+})().catch(err=>{ console.error(err); process.exitCode = 1; });


### PR DESCRIPTION
### Motivation

- Prevent embedded cutting-file contents (DXF/ORD/OMX, data/blob URLs, base64, browser File/Blob/ArrayBuffer/typed arrays, oversized previews) from entering the authoritative Firestore app/state snapshot.
- Initialize Firebase Cloud Storage safely (v8 compat) and expose Storage availability through diagnostics without performing any Storage operations.
- Provide read-only browser diagnostics and an audit helper to inspect current state and caches without mutating or saving data.

### Description

- Add a deterministic, pure, non-mutating scanner module `js/cuttingFileContentFirewall.js` that recursively inspects live snapshot values and returns stable, ordered findings with path, reason/type, approximate size, parent/root collection, and a blocking flag; thresholds are documented and frozen in-code.
- Load Firebase Storage v8 SDK in `index.html` and load the firewall module before app code, and initialize Storage through the existing `FB.app` in `js/core.js` using the configured bucket `gs://omax-maintenance.firebasestorage.app`, while explicitly performing no uploads/downloads/list/delete operations.  `vercel.json` was inspected and left unchanged. 
- Add shared authoritative-write enforcement in `js/core.js`: `scanAuthoritativeCutFileContent()` and `writeAuthoritativeStateSnapshot()` run the firewall on the final live snapshot immediately before any authoritative `set()` (normal saves, initial seed, legacy migration, and clear/reset paths are routed through this boundary), returning a structured blocked-save result (including `errorCode: "embedded_cutting_file_content_blocked"` and findings). 
- Preserve existing protected-state, revision, and size preflight checks; expose read-only helpers `auditCuttingFileContentExposure()` and `getCloudCutFileStorageDiagnostics()`; add a focused Node test harness `tests/cfr02-content-firewall.test.js` and implementation doc `docs/cfr-02-file-content-firewall-and-storage-foundation.md` describing thresholds, enforcement, diagnostics, and limitations.

### Testing

- Ran `node tests/cfr02-content-firewall.test.js` and all 21 focused CFR-02 assertions passed (output: `1..21`).
- Ran `node tests/maintenance-history-import.test.js` and `node tests/pump-rebuild-duplication.test.js` and both existing deterministic test suites passed.
- Performed static checks with `node --check js/cuttingFileContentFirewall.js`, `node --check js/core.js`, and `node --check tests/cfr02-content-firewall.test.js`, all of which returned success (no syntax errors).
- Verified no direct authoritative writes remain by running `rg -n 'FB\.docRef\.set\s*\(' js` which returned no matches, and confirmed the shared boundary `writeAuthoritativeStateSnapshot` is used for save/seed/migrate/clear paths. 
- Ran repository-quality checks `git diff --check` (no issues) and `rg -n '^(<<<<<<<|=======|>>>>>>>)' --glob '!docs/cfr-01-cloud-cut-file-storage-audit.md' .` (no conflict markers).
- Confirmed `vercel.json` content remains exactly `{ "cleanUrls": true }` and that Storage operations and Cloud Storage rules were intentionally not exercised (no network Storage tests performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7de819257483258f11844a553316b3)