### PR TITLE
CFR-03: Add default-deny Storage rules and isolated CFR-03 storage round-trip test helper

### DIFF
--- a/docs/cfr-03-secure-storage-round-trip.md
+++ b/docs/cfr-03-secure-storage-round-trip.md
@@ -28,6 +28,8 @@ One controlled Vercel test previously confirmed upload and metadata verification
 
 The old result also reported a combined protected-state fingerprint mismatch but did not retain root-level comparisons or paths. It is therefore impossible to identify the historical differing root honestly. `cutting_job_files_v1` was separately measured and matched. The exact uploaded object was manually deleted, Firebase Storage was confirmed empty, and deployed rules were restored to deny-all.
 
+A later authenticated controlled round trip completed upload, metadata verification, XHR download with HTTP 200, exact-content verification, deletion, and absence verification without an indeterminate operation or Firestore write. Every protected business root and `cutting_job_files_v1` matched. Only the browser-local backup changed at `$.localStateBackup.value`. The previous result model included that independently writable cache among business roots, so it incorrectly set `protectedStateMatched` false and `appStateMutationDetected` true.
+
 ## Corrected state machine
 
 `runCfr03StorageRoundTripTest(options)` remains manually gated by exact confirmation `CFR03 STORAGE TEST`. With deny-all rules deployed it will fail at upload; it does not provide production file capability. Internally it now tracks these explicit stages:
@@ -51,9 +53,15 @@ Once upload completion is confirmed, success or any later determinate failure tr
 
 ## Protected-state comparison
 
-Before and after the asynchronous test, the helper captures the same protected roots without calling `snapshotState()`, save/sync code, or a localStorage writer. Canonicalization preserves array order, sorts object keys recursively, represents explicit `undefined`, distinguishes missing properties, and represents ancestor cycles deterministically. Only the named transient containers `saveMeta`, `syncMeta`, `diagnostic`, `diagnostics`, `cfr03Diagnostics`, and `lastCfr03TestResult` are excluded.
+Before and after the asynchronous test, the helper captures the same protected business roots without calling `snapshotState()`, save/sync code, or a localStorage writer. Canonicalization preserves array order, sorts object keys recursively, represents explicit `undefined`, distinguishes missing properties, and represents ancestor cycles deterministically. Only the named transient containers `saveMeta`, `syncMeta`, `diagnostic`, `diagnostics`, `cfr03Diagnostics`, and `lastCfr03TestResult` are excluded.
 
-Results contain exact `protectedStateMismatchPaths`, per-root `protectedStateRootResults`, and separate `localJobFileCacheMismatchPaths`. `appStateMutationDetected` is based only on protected-root differences; `cutting_job_files_v1` remains a separate byte-equivalence comparison. The local backup is a protected root and is read without mutation.
+The result deliberately separates three observations:
+
+- **Protected business state:** `protectedStateMatched`, `protectedStateMismatchPaths`, and per-root `protectedStateRootResults`. `appStateMutationDetected` is based only on these roots.
+- **Browser-local full-state backup:** `localStateBackupMatched`, `localStateBackupMismatchPaths`, and `localStateBackupDriftObserved`. Backup drift remains visible but cannot alone mark business state as mutated.
+- **Browser-local cutting-file cache:** `localJobFileCacheMatched` and `localJobFileCacheMismatchPaths`, compared separately and without changing its existing entries.
+
+The local backup can change independently while the helper awaits Storage operations. The normal debounced `saveCloudInternal()` pipeline calls `persistLocalStateBackup()` before its Firestore write and also when an oversized state blocks the Firestore write. An already scheduled save or unrelated application interaction can therefore rewrite `omax_local_state_backup_v1` during the round trip even when the CFR-03 helper caused no state or Firestore mutation. The helper does not pause, disable, rewrite, or force this backup comparison to pass; it reads the raw localStorage value before and after and reports actual drift.
 
 ## CORS limitation
 

--- a/docs/cfr-03-secure-storage-round-trip.md
+++ b/docs/cfr-03-secure-storage-round-trip.md
@@ -1,79 +1,78 @@
-# CFR-03 — Secure Storage rules and isolated round-trip test
+# CFR-03A — Secure Storage round-trip correction and deny-all lock
 
-**Status:** reviewed rules and a manually triggered test helper only. Production cutting-file uploads and downloads remain disabled. No live Storage or Firestore operation was performed during implementation.
+**Status:** repository and deployed Cloud Storage rules are deny-all. Production uploads and downloads remain disabled. This correction performed no live Storage operation, rules deployment, CORS change, Firestore write, migration, repair, or cleanup.
 
-## Authorization model and production blocker
+## Authorization model and blocker
 
-The browser uses Firebase v8 email/password authentication. A missing account may be created by the sign-in flow. After authentication, client code assigns every user the constant workspace `github-prod` and routes Firestore to `workspaces/github-prod/app/state`. This proves identity and client routing only; it does not prove workspace membership.
+The browser uses Firebase v8 email/password authentication and routes authenticated sessions to the client constant `github-prod` and Firestore document `workspaces/github-prod/app/state`. Authentication and client routing do not prove workspace membership. The repository contains no authoritative membership document, role, or custom claim that Storage rules can verify. Production workspace authorization is not ready; authentication alone must never authorize production files.
 
-The repository has no authoritative workspace-membership record, role, custom claim check, or checked-in Firestore rule that Storage rules can use. Client workspace IDs, metadata, email addresses, filenames, and UI state are not authorization. Production workspace authorization is therefore **not ready**. CFR-04 must define and administratively provision an authoritative membership mechanism before any production cutting-file rule can be considered.
-
-## Rules boundary
-
-`firebase.json` identifies `storage.rules`; it adds no Hosting behavior. The rules are default deny and expose only:
+`firebase.json` points to the repository's `storage.rules` and adds no Hosting configuration. The committed rules are permanently locked to the following default-deny policy:
 
 ```text
-workspaces/{workspaceId}/cfr03-tests/{uid}/{testId}/cfr03-test.json
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}
 ```
 
-The workspace is a safe 1–64 character segment, the UID is a safe 1–128 character segment and must exactly equal `request.auth.uid`, and the test ID is exactly 32 lowercase hexadecimal characters. Creates require a previously absent object, non-empty content no larger than **2,048 bytes**, and exact `application/json` content type. Only that UID may get or delete the exact object. There is no update/overwrite or list permission. JSON cannot be served as arbitrary HTML or executable content under these rules.
+Thus the CFR-03 namespace and all production-like paths—including `workspaces/{workspaceId}/cutting-jobs/**`, `cutting-jobs/**`, `completed-cutting-jobs/**`, `previews/**`, `uploads/**`, and `originals/**`—are denied.
 
-The final catch-all denies all other reads and writes. This includes, without relying on name-specific exceptions:
+## Controlled-test finding and cleanup confirmation
 
-- `workspaces/{workspaceId}/cutting-jobs/**`
-- `cutting-jobs/**`
-- `completed-cutting-jobs/**`
-- `previews/**`
-- `uploads/**`
-- `originals/**`
+One controlled Vercel test previously confirmed upload and metadata verification for an 84-byte test object, then failed while downloading: `downloadAttempted` was true, `downloadCompleted` was false, and the browser reported `Failed to fetch`. The old helper first obtained a Firebase v8 download URL and then used browser `fetch()`. Its Fetch rejection carried no internal stage tag, so the outer fallback incorrectly returned `failedStage: "preflight"` even though upload and metadata had succeeded.
 
-The CFR-03 namespace does not establish workspace membership. It is deliberately useful only as a same-UID capability probe; production paths remain denied.
+The old result also reported a combined protected-state fingerprint mismatch but did not retain root-level comparisons or paths. It is therefore impossible to identify the historical differing root honestly. `cutting_job_files_v1` was separately measured and matched. The exact uploaded object was manually deleted, Firebase Storage was confirmed empty, and deployed rules were restored to deny-all.
 
-## Manual helper and state machine
+## Corrected state machine
 
-The page exposes only `runCfr03StorageRoundTripTest(options)`. It does nothing to Storage unless `options.confirmation` exactly equals `CFR03 STORAGE TEST`. It then performs one non-retrying pass:
+`runCfr03StorageRoundTripTest(options)` remains manually gated by exact confirmation `CFR03 STORAGE TEST`. With deny-all rules deployed it will fail at upload; it does not provide production file capability. Internally it now tracks these explicit stages:
 
-1. Validate signed-in UID, exact project `omax-maintenance`, bucket `omax-maintenance.firebasestorage.app`, existing workspace `github-prod`, Storage availability, and safe segments.
-2. Generate a 128-bit test ID with `crypto.getRandomValues`. There is no insecure randomness fallback.
-3. Build in memory a compact JSON object containing only `testId` and `timestamp`.
-4. Upload once to the exact test path. Rules enforce create-only behavior; a collision fails rather than overwrites.
-5. Await completion, then verify metadata path, byte size, content type, UID, workspace, and test ID.
-6. Obtain the exact object's download URL, read it with a no-store fetch, and compare the returned text byte-for-text with the generated JSON.
-7. Delete the same reference once, await it, and confirm `getMetadata()` returns `storage/object-not-found`.
+1. `validation`
+2. `upload`
+3. `metadata`
+4. `download_url`
+5. `download_content`
+6. `content_verification`
+7. `cleanup_delete`
+8. `cleanup_absence_verification`
 
-No upload, delete, or indeterminate operation is automatically retried. A failure after a completed upload returns a warning that the exact object may remain. The helper does not list objects or expose a general-purpose upload API.
+The generated payload still contains only a random 128-bit test ID and timestamp. The helper never exposes a general-purpose upload/download API, returns a download URL, logs a token, writes Firestore, calls a cloud-save function, or mutates local storage.
 
-## Structured result and state protection
+After `getDownloadURL()`, the small object is read with an internal Firebase-v8-compatible `XMLHttpRequest`: GET only, no credentials, a 10-second timeout, exact 2xx status handling, exact text comparison, and no retry. Results report URL creation, method, error type, HTTP status when present, and honest CORS/network suspicion without returning the URL.
 
-Every return includes `generatedAtISO`, confirmation/configuration/identity fields, the test path and ID, attempted/completed/verified flags for upload, metadata, download, content, deletion, and absence, plus `operationIndeterminate`, `failedStage`, a bounded error, and warnings. `firestoreWriteAttempted` is always false.
+### Cleanup behavior
 
-Before any validation, the helper fingerprints all protected application roots named by CFR-03 plus the raw local backup. It separately fingerprints the raw `cutting_job_files_v1` value. Canonical comparison ignores only transient diagnostic/save/sync timestamps; it does not call `snapshotState()`, write localStorage, or hydrate/normalize state. After the operation it reports `protectedStateMatched`, `localJobFileCacheMatched`, and `appStateMutationDetected`. It never calls a Firestore reference, `saveCloudNow()`, `saveCloudDebounced()`, or a cutting-job/cache helper.
+Once upload completion is confirmed, success or any later determinate failure triggers exactly one deletion of the known object reference, followed by exactly one metadata absence check. Cleanup results are reported independently. If upload is indeterminate, no deletion is attempted because object existence is unknown. If deletion or absence verification is indeterminate, it is not retried; `possibleOrphanPath` contains only the exact generated path and `manualCleanupRequired` is true.
 
-Diagnostics retain the CFR-02 fields and add the expected rule version, disabled production flags, helper/namespace information, the absent membership mechanism and blocker, and a bounded summary of the last result in the current page session. Diagnostics do not claim repository rules are deployed. A successful authenticated round trip proves only that the tested operations behaved as observed; operator review must still confirm the published ruleset.
+## Protected-state comparison
 
-## Publication procedure (operator action only)
+Before and after the asynchronous test, the helper captures the same protected roots without calling `snapshotState()`, save/sync code, or a localStorage writer. Canonicalization preserves array order, sorts object keys recursively, represents explicit `undefined`, distinguishes missing properties, and represents ancestor cycles deterministically. Only the named transient containers `saveMeta`, `syncMeta`, `diagnostic`, `diagnostics`, `cfr03Diagnostics`, and `lastCfr03TestResult` are excluded.
 
-Do not publish from an unreviewed development environment. After review, use one of these operator-controlled methods:
+Results contain exact `protectedStateMismatchPaths`, per-root `protectedStateRootResults`, and separate `localJobFileCacheMismatchPaths`. `appStateMutationDetected` is based only on protected-root differences; `cutting_job_files_v1` remains a separate byte-equivalence comparison. The local backup is a protected root and is read without mutation.
 
-1. **Firebase Console:** open project `omax-maintenance` → Storage → Rules; compare the complete console editor content with repository `storage.rules`; publish it; record the rules release/version and reviewer.
-2. **Existing configured Firebase CLI:** from the reviewed commit, first verify the selected project is exactly `omax-maintenance` (`firebase use`), review `firebase.json` and `storage.rules`, then run `firebase deploy --only storage --project omax-maintenance`. Do not install CLI tooling solely for CFR-03.
+## CORS limitation
 
-Rollback means republishing a reviewed deny-all Storage ruleset. Rules rollback cannot remove an object left by an interrupted/indeterminate test. Such an object must not be guessed, bulk-listed, or automatically cleaned up: preserve the returned exact `objectPath`, investigate the operation, and perform a separate explicitly authorized exact-path cleanup. The payload contains no business data.
+A browser network error has no HTTP response visible to JavaScript and can be caused by CORS or another network boundary, so `corsFailureSuspected` and `networkFailureSuspected` are suspicions, not diagnoses. Code alone cannot configure bucket CORS, and CORS is not authorization; Storage rules remain the authorization boundary.
 
-## Manual Vercel test procedure
+If an operator authorizes another controlled test, the minimal bucket CORS policy should permit only `GET` from each **explicit trusted origin** used for that test (for example the exact production origin and exact selected Vercel preview origin), expose only the needed `Content-Type` response header, and use a short cache duration such as 300 seconds. Never use `*`. Bucket CORS must be reviewed and applied separately by an operator, then removed or retained only under an approved infrastructure policy; this repository does not change it.
 
-Use this CFR-03 PR's preview throughout corrections. Vercel must use Framework Preset **Other**, empty Build and Install commands, output directory `.`, and the repository's clean-URLs-only configuration.
+## Next operator-only Vercel test
 
-1. Publish the reviewed Storage rules through an operator-controlled procedure above.
-2. Open the PR preview, sign in with the intended Firebase Auth test user, and run `getCloudCutFileStorageDiagnostics()`. Confirm project, bucket, workspace, initialized Storage, disabled production flags, blocker, and namespace. Do not interpret this read-only output as deployed-rules proof.
-3. Capture read-only application and browser-local cache audit results. Do not edit or clear the 47 local data URLs.
-4. Manually run `await runCfr03StorageRoundTripTest({ confirmation: "CFR03 STORAGE TEST" })` once.
-5. Require `uploadCompleted`, `metadataVerified`, `downloadCompleted`, `contentVerified`, `deleteCompleted`, `absenceVerified`, `protectedStateMatched`, and `localJobFileCacheMatched` to be true; require `firestoreWriteAttempted` and `appStateMutationDetected` to be false.
-6. If `operationIndeterminate` is true or a warning says an object may remain, do not rerun. Preserve the exact result for operator investigation.
-7. In browser network tools, confirm there was no Firestore write and no request to a production cutting-file path.
+Do not run this procedure until a separate operator approval exists. Reuse the existing CFR-03 PR and preview; Vercel remains Framework Preset **Other**, empty Build and Install commands, output directory `.`, and clean URLs only.
 
-Implementation tests use mocks only. No authenticated write, emulator rules test, production round trip, import, repair, migration, cleanup, or deletion was run while developing CFR-03.
+1. Record the exact trusted preview origin and verify project `omax-maintenance`, bucket `omax-maintenance.firebasestorage.app`, and workspace `github-prod`.
+2. Separately review an **operator-only temporary** test ruleset. It must use a placeholder replaced at deployment time with the one intended test UID (never committed), fix the workspace to `github-prod`, target the exact bucket, permit only a short-expiring isolated CFR-03 path, require that exact UID, create-only JSON, a maximum of 2,048 bytes, exact metadata, owner-only get/delete, and default-deny everything else. Authentication alone is insufficient for production workspace authorization.
+3. If required, separately apply the minimal explicit-origin GET CORS policy described above. Do not use a wildcard origin.
+4. Publish the temporary rules only for the scheduled test window. Run read-only diagnostics and confirm production flags remain false.
+5. Run the helper once with exact confirmation. Require verified upload, metadata, download/content, cleanup deletion/absence, protected roots, and local cache; require no Firestore write or app-state mutation.
+6. On any indeterminate result, do not retry. Preserve the exact structured result and investigate only `possibleOrphanPath` under a separate cleanup authorization.
+7. Immediately restore the exact committed deny-all rules, confirm the rules release, and remove temporary CORS if it was approved only for the test.
 
 ## CFR-04 boundary
 
-CFR-04 may design authoritative workspace membership and, only after review and provisioning, production cutting-file authorization. CFR-03 does not implement production uploads/downloads, previews, per-job Firestore documents, cutting-job or pump-log imports, migrations, or local-cache cleanup.
+CFR-04 may design an authoritative workspace-membership mechanism and only then consider production cutting-file rules. CFR-03A does not implement production uploads/downloads, previews, per-job Firestore documents, imports, migrations, or local-cache cleanup.

--- a/docs/cfr-03-secure-storage-round-trip.md
+++ b/docs/cfr-03-secure-storage-round-trip.md
@@ -1,0 +1,79 @@
+# CFR-03 — Secure Storage rules and isolated round-trip test
+
+**Status:** reviewed rules and a manually triggered test helper only. Production cutting-file uploads and downloads remain disabled. No live Storage or Firestore operation was performed during implementation.
+
+## Authorization model and production blocker
+
+The browser uses Firebase v8 email/password authentication. A missing account may be created by the sign-in flow. After authentication, client code assigns every user the constant workspace `github-prod` and routes Firestore to `workspaces/github-prod/app/state`. This proves identity and client routing only; it does not prove workspace membership.
+
+The repository has no authoritative workspace-membership record, role, custom claim check, or checked-in Firestore rule that Storage rules can use. Client workspace IDs, metadata, email addresses, filenames, and UI state are not authorization. Production workspace authorization is therefore **not ready**. CFR-04 must define and administratively provision an authoritative membership mechanism before any production cutting-file rule can be considered.
+
+## Rules boundary
+
+`firebase.json` identifies `storage.rules`; it adds no Hosting behavior. The rules are default deny and expose only:
+
+```text
+workspaces/{workspaceId}/cfr03-tests/{uid}/{testId}/cfr03-test.json
+```
+
+The workspace is a safe 1–64 character segment, the UID is a safe 1–128 character segment and must exactly equal `request.auth.uid`, and the test ID is exactly 32 lowercase hexadecimal characters. Creates require a previously absent object, non-empty content no larger than **2,048 bytes**, and exact `application/json` content type. Only that UID may get or delete the exact object. There is no update/overwrite or list permission. JSON cannot be served as arbitrary HTML or executable content under these rules.
+
+The final catch-all denies all other reads and writes. This includes, without relying on name-specific exceptions:
+
+- `workspaces/{workspaceId}/cutting-jobs/**`
+- `cutting-jobs/**`
+- `completed-cutting-jobs/**`
+- `previews/**`
+- `uploads/**`
+- `originals/**`
+
+The CFR-03 namespace does not establish workspace membership. It is deliberately useful only as a same-UID capability probe; production paths remain denied.
+
+## Manual helper and state machine
+
+The page exposes only `runCfr03StorageRoundTripTest(options)`. It does nothing to Storage unless `options.confirmation` exactly equals `CFR03 STORAGE TEST`. It then performs one non-retrying pass:
+
+1. Validate signed-in UID, exact project `omax-maintenance`, bucket `omax-maintenance.firebasestorage.app`, existing workspace `github-prod`, Storage availability, and safe segments.
+2. Generate a 128-bit test ID with `crypto.getRandomValues`. There is no insecure randomness fallback.
+3. Build in memory a compact JSON object containing only `testId` and `timestamp`.
+4. Upload once to the exact test path. Rules enforce create-only behavior; a collision fails rather than overwrites.
+5. Await completion, then verify metadata path, byte size, content type, UID, workspace, and test ID.
+6. Obtain the exact object's download URL, read it with a no-store fetch, and compare the returned text byte-for-text with the generated JSON.
+7. Delete the same reference once, await it, and confirm `getMetadata()` returns `storage/object-not-found`.
+
+No upload, delete, or indeterminate operation is automatically retried. A failure after a completed upload returns a warning that the exact object may remain. The helper does not list objects or expose a general-purpose upload API.
+
+## Structured result and state protection
+
+Every return includes `generatedAtISO`, confirmation/configuration/identity fields, the test path and ID, attempted/completed/verified flags for upload, metadata, download, content, deletion, and absence, plus `operationIndeterminate`, `failedStage`, a bounded error, and warnings. `firestoreWriteAttempted` is always false.
+
+Before any validation, the helper fingerprints all protected application roots named by CFR-03 plus the raw local backup. It separately fingerprints the raw `cutting_job_files_v1` value. Canonical comparison ignores only transient diagnostic/save/sync timestamps; it does not call `snapshotState()`, write localStorage, or hydrate/normalize state. After the operation it reports `protectedStateMatched`, `localJobFileCacheMatched`, and `appStateMutationDetected`. It never calls a Firestore reference, `saveCloudNow()`, `saveCloudDebounced()`, or a cutting-job/cache helper.
+
+Diagnostics retain the CFR-02 fields and add the expected rule version, disabled production flags, helper/namespace information, the absent membership mechanism and blocker, and a bounded summary of the last result in the current page session. Diagnostics do not claim repository rules are deployed. A successful authenticated round trip proves only that the tested operations behaved as observed; operator review must still confirm the published ruleset.
+
+## Publication procedure (operator action only)
+
+Do not publish from an unreviewed development environment. After review, use one of these operator-controlled methods:
+
+1. **Firebase Console:** open project `omax-maintenance` → Storage → Rules; compare the complete console editor content with repository `storage.rules`; publish it; record the rules release/version and reviewer.
+2. **Existing configured Firebase CLI:** from the reviewed commit, first verify the selected project is exactly `omax-maintenance` (`firebase use`), review `firebase.json` and `storage.rules`, then run `firebase deploy --only storage --project omax-maintenance`. Do not install CLI tooling solely for CFR-03.
+
+Rollback means republishing a reviewed deny-all Storage ruleset. Rules rollback cannot remove an object left by an interrupted/indeterminate test. Such an object must not be guessed, bulk-listed, or automatically cleaned up: preserve the returned exact `objectPath`, investigate the operation, and perform a separate explicitly authorized exact-path cleanup. The payload contains no business data.
+
+## Manual Vercel test procedure
+
+Use this CFR-03 PR's preview throughout corrections. Vercel must use Framework Preset **Other**, empty Build and Install commands, output directory `.`, and the repository's clean-URLs-only configuration.
+
+1. Publish the reviewed Storage rules through an operator-controlled procedure above.
+2. Open the PR preview, sign in with the intended Firebase Auth test user, and run `getCloudCutFileStorageDiagnostics()`. Confirm project, bucket, workspace, initialized Storage, disabled production flags, blocker, and namespace. Do not interpret this read-only output as deployed-rules proof.
+3. Capture read-only application and browser-local cache audit results. Do not edit or clear the 47 local data URLs.
+4. Manually run `await runCfr03StorageRoundTripTest({ confirmation: "CFR03 STORAGE TEST" })` once.
+5. Require `uploadCompleted`, `metadataVerified`, `downloadCompleted`, `contentVerified`, `deleteCompleted`, `absenceVerified`, `protectedStateMatched`, and `localJobFileCacheMatched` to be true; require `firestoreWriteAttempted` and `appStateMutationDetected` to be false.
+6. If `operationIndeterminate` is true or a warning says an object may remain, do not rerun. Preserve the exact result for operator investigation.
+7. In browser network tools, confirm there was no Firestore write and no request to a production cutting-file path.
+
+Implementation tests use mocks only. No authenticated write, emulator rules test, production round trip, import, repair, migration, cleanup, or deletion was run while developing CFR-03.
+
+## CFR-04 boundary
+
+CFR-04 may design authoritative workspace membership and, only after review and provisioning, production cutting-file authorization. CFR-03 does not implement production uploads/downloads, previews, per-job Firestore documents, cutting-job or pump-log imports, migrations, or local-cache cleanup.

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "storage": {
+    "rules": "storage.rules"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -200,6 +200,7 @@
   <!-- Your app code (split into focused modules; order matters) -->
   <script src="js/cuttingFileContentFirewall.js"></script>
   <script src="js/core.js"></script>
+  <script src="js/cfr03StorageRoundTrip.js"></script>
   <script src="js/auth/msalClient.js"></script>
   <script src="js/onedrive/graph.js"></script>
   <script src="js/onedrive/onedriveLibrary.js"></script>

--- a/js/cfr03StorageRoundTrip.js
+++ b/js/cfr03StorageRoundTrip.js
@@ -25,7 +25,7 @@
     "receiptTrackerWeeks", "orderRequests", "weeklyCostReports", "dailyCutHours",
     "totalHistory", "pumpEff", "garnetCleanings", "appConfig", "dashboardLayout",
     "costLayout", "jobLayout", "maintenanceTasksV2", "maintenanceCalendarInstancesV2",
-    "maintenanceOccurrencesV2", "localStateBackup"
+    "maintenanceOccurrencesV2"
   ];
   let lastResult = null;
 
@@ -81,12 +81,14 @@
   function captureSafetyState(env){
     const roots = {};
     PROTECTED_KEYS.forEach(key=>{
-      const value = key === "localStateBackup"
-        ? readLocalStorage(env, "omax_local_state_backup_v1")
-        : (Object.prototype.hasOwnProperty.call(env, key) ? env[key] : { $cfr03Type:"missing-property" });
+      const value = Object.prototype.hasOwnProperty.call(env, key) ? env[key] : { $cfr03Type:"missing-property" };
       roots[key] = canonical(value, `$.${key}`);
     });
-    return { roots, jobFileCache:canonical(readLocalStorage(env, "cutting_job_files_v1"), "$.cutting_job_files_v1") };
+    return {
+      roots,
+      localStateBackup:canonical(readLocalStorage(env, "omax_local_state_backup_v1"), "$.localStateBackup"),
+      jobFileCache:canonical(readLocalStorage(env, "cutting_job_files_v1"), "$.cutting_job_files_v1")
+    };
   }
 
   function compareSafetyState(before, after){
@@ -97,8 +99,9 @@
       protectedStateRootResults[key] = { matched:paths.length === 0, mismatchPaths:paths };
       protectedStateMismatchPaths.push(...paths);
     });
+    const localStateBackupMismatchPaths = mismatchPaths(before.localStateBackup, after.localStateBackup, "$.localStateBackup");
     const localJobFileCacheMismatchPaths = mismatchPaths(before.jobFileCache, after.jobFileCache, "$.cutting_job_files_v1");
-    return { protectedStateRootResults, protectedStateMismatchPaths, localJobFileCacheMismatchPaths };
+    return { protectedStateRootResults, protectedStateMismatchPaths, localStateBackupMismatchPaths, localJobFileCacheMismatchPaths };
   }
 
   function newResult(now){
@@ -110,6 +113,7 @@
       absenceVerified:false, cleanupAttempted:false, cleanupCompleted:false, cleanupAbsenceVerified:false, possibleOrphanPath:"",
       manualCleanupRequired:false, operationIndeterminate:false, failedStage:"", error:null, warnings:[], firestoreWriteAttempted:false,
       appStateMutationDetected:false, protectedStateMatched:false, protectedStateMismatchPaths:[], protectedStateRootResults:{},
+      localStateBackupMatched:false, localStateBackupMismatchPaths:[], localStateBackupDriftObserved:false,
       localJobFileCacheMatched:false, localJobFileCacheMismatchPaths:[]
     };
   }
@@ -160,6 +164,8 @@
         Object.assign(result, comparison);
         result.protectedStateMatched = comparison.protectedStateMismatchPaths.length === 0;
         result.appStateMutationDetected = !result.protectedStateMatched;
+        result.localStateBackupMatched = comparison.localStateBackupMismatchPaths.length === 0;
+        result.localStateBackupDriftObserved = !result.localStateBackupMatched;
         result.localJobFileCacheMatched = comparison.localJobFileCacheMismatchPaths.length === 0;
         lastResult = summarize(result); return result;
       };

--- a/js/cfr03StorageRoundTrip.js
+++ b/js/cfr03StorageRoundTrip.js
@@ -16,6 +16,8 @@
   const NAMESPACE = "workspaces/{workspaceId}/cfr03-tests/{uid}/{testId}/cfr03-test.json";
   const CONTENT_TYPE = "application/json";
   const FILE_NAME = "cfr03-test.json";
+  const DOWNLOAD_TIMEOUT_MS = 10000;
+  const TRANSIENT_KEYS = new Set(["saveMeta", "syncMeta", "diagnostics", "diagnostic", "cfr03Diagnostics", "lastCfr03TestResult"]);
   const PROTECTED_KEYS = [
     "cuttingJobs", "completedCuttingJobs", "cuttingJobDatabase", "deletedItems",
     "tasksInterval", "tasksAsReq", "settingsFolders", "folders", "jobFolders",
@@ -23,50 +25,92 @@
     "receiptTrackerWeeks", "orderRequests", "weeklyCostReports", "dailyCutHours",
     "totalHistory", "pumpEff", "garnetCleanings", "appConfig", "dashboardLayout",
     "costLayout", "jobLayout", "maintenanceTasksV2", "maintenanceCalendarInstancesV2",
-    "maintenanceOccurrencesV2"
+    "maintenanceOccurrencesV2", "localStateBackup"
   ];
   let lastResult = null;
 
-  function stableValue(value, seen){
+  function canonicalize(value, path, ancestors){
+    if (value === undefined) return { $cfr03Type:"undefined" };
+    if (typeof value === "number" && !Number.isFinite(value)) return { $cfr03Type:String(value) };
+    if (typeof value === "bigint") return { $cfr03Type:"bigint", value:String(value) };
+    if (typeof value === "function" || typeof value === "symbol") return { $cfr03Type:typeof value, value:String(value) };
     if (value === null || typeof value !== "object") return value;
-    if (seen.has(value)) return "[Circular]";
-    seen.add(value);
-    if (Array.isArray(value)) return value.map(item=>stableValue(item, seen));
+    if (ancestors.has(value)) return { $cfr03Type:"circular", path:ancestors.get(value) };
+    const next = new Map(ancestors); next.set(value, path);
+    if (Array.isArray(value)) return value.map((item, index)=>canonicalize(item, `${path}[${index}]`, next));
     const result = {};
     Object.keys(value).sort().forEach(key=>{
-      if (/^(generatedAtISO|diagnostics?|saveMeta|syncMeta|lastSavedAt|updatedAtISO)$/i.test(key)) return;
-      result[key] = stableValue(value[key], seen);
+      if (TRANSIENT_KEYS.has(key)) return;
+      result[key] = canonicalize(value[key], `${path}.${key}`, next);
     });
     return result;
   }
 
-  function fingerprint(value){
-    return JSON.stringify(stableValue(value, new WeakSet()));
+  function canonical(value, path){ return canonicalize(value, path, new Map()); }
+  function sameValue(left, right){ return JSON.stringify(left) === JSON.stringify(right); }
+
+  function mismatchPaths(before, after, path){
+    if (sameValue(before, after)) return [];
+    const beforeArray = Array.isArray(before); const afterArray = Array.isArray(after);
+    if (beforeArray || afterArray){
+      if (!beforeArray || !afterArray) return [path];
+      const differences = [];
+      if (before.length !== after.length) differences.push(`${path}.length`);
+      const length = Math.min(before.length, after.length);
+      for (let index=0; index<length; index++) differences.push(...mismatchPaths(before[index], after[index], `${path}[${index}]`));
+      return differences;
+    }
+    const beforeObject = before !== null && typeof before === "object";
+    const afterObject = after !== null && typeof after === "object";
+    if (!beforeObject || !afterObject) return [path];
+    const differences = [];
+    const keys = Array.from(new Set([...Object.keys(before), ...Object.keys(after)])).sort();
+    keys.forEach(key=>{
+      const childPath = `${path}.${key}`;
+      if (!Object.prototype.hasOwnProperty.call(before, key) || !Object.prototype.hasOwnProperty.call(after, key)) differences.push(childPath);
+      else differences.push(...mismatchPaths(before[key], after[key], childPath));
+    });
+    return differences;
+  }
+
+  function readLocalStorage(env, key){
+    try { return { available:true, value:env.localStorage?.getItem(key) ?? null }; }
+    catch (error){ return { available:false, value:{ $cfr03Type:"inaccessible", errorName:String(error?.name || "Error") } }; }
   }
 
   function captureSafetyState(env){
-    const protectedState = {};
-    PROTECTED_KEYS.forEach(key=>{ protectedState[key] = env[key]; });
-    let localBackup = null;
-    let jobFileCache = null;
-    try { localBackup = env.localStorage?.getItem("omax_local_state_backup_v1") ?? null; } catch (_err){ localBackup = "[inaccessible]"; }
-    try { jobFileCache = env.localStorage?.getItem("cutting_job_files_v1") ?? null; } catch (_err){ jobFileCache = "[inaccessible]"; }
-    return {
-      protectedFingerprint:fingerprint({ protectedState, localBackup }),
-      jobFileCacheFingerprint:fingerprint(jobFileCache)
-    };
+    const roots = {};
+    PROTECTED_KEYS.forEach(key=>{
+      const value = key === "localStateBackup"
+        ? readLocalStorage(env, "omax_local_state_backup_v1")
+        : (Object.prototype.hasOwnProperty.call(env, key) ? env[key] : { $cfr03Type:"missing-property" });
+      roots[key] = canonical(value, `$.${key}`);
+    });
+    return { roots, jobFileCache:canonical(readLocalStorage(env, "cutting_job_files_v1"), "$.cutting_job_files_v1") };
+  }
+
+  function compareSafetyState(before, after){
+    const protectedStateRootResults = {};
+    const protectedStateMismatchPaths = [];
+    PROTECTED_KEYS.forEach(key=>{
+      const paths = mismatchPaths(before.roots[key], after.roots[key], `$.${key}`);
+      protectedStateRootResults[key] = { matched:paths.length === 0, mismatchPaths:paths };
+      protectedStateMismatchPaths.push(...paths);
+    });
+    const localJobFileCacheMismatchPaths = mismatchPaths(before.jobFileCache, after.jobFileCache, "$.cutting_job_files_v1");
+    return { protectedStateRootResults, protectedStateMismatchPaths, localJobFileCacheMismatchPaths };
   }
 
   function newResult(now){
     return {
-      generatedAtISO:now().toISOString(), confirmed:false, firebaseProjectId:"", bucket:"",
-      workspaceId:"", uid:"", testId:"", objectPath:"", uploadAttempted:false,
-      uploadCompleted:false, metadataVerified:false, downloadAttempted:false,
-      downloadCompleted:false, contentVerified:false, deleteAttempted:false,
-      deleteCompleted:false, absenceVerified:false, operationIndeterminate:false,
-      failedStage:"", error:null, warnings:[], firestoreWriteAttempted:false,
-      appStateMutationDetected:false, protectedStateMatched:false,
-      localJobFileCacheMatched:false
+      generatedAtISO:now().toISOString(), confirmed:false, firebaseProjectId:"", bucket:"", workspaceId:"", uid:"", testId:"", objectPath:"",
+      uploadAttempted:false, uploadCompleted:false, metadataVerified:false, downloadAttempted:false, downloadUrlCreated:false,
+      downloadMethod:"XMLHttpRequest", downloadCompleted:false, contentVerified:false, downloadErrorType:"", downloadHttpStatus:null,
+      corsFailureSuspected:false, networkFailureSuspected:false, cleanupRequired:false, deleteAttempted:false, deleteCompleted:false,
+      absenceVerified:false, cleanupAttempted:false, cleanupCompleted:false, cleanupAbsenceVerified:false, possibleOrphanPath:"",
+      manualCleanupRequired:false, operationIndeterminate:false, failedStage:"", error:null, warnings:[], firestoreWriteAttempted:false,
+      appStateMutationDetected:false, protectedStateMatched:false, protectedStateMismatchPaths:[], protectedStateRootResults:{},
+      localJobFileCacheMatched:false, localJobFileCacheMismatchPaths:[]
     };
   }
 
@@ -75,147 +119,136 @@
     if (!pattern.test(text)) throw new Error(`${label} is not a safe bounded path segment.`);
     return text;
   }
-
   function randomTestId(cryptoApi){
     if (!cryptoApi || typeof cryptoApi.getRandomValues !== "function") throw new Error("Cryptographically secure browser randomness is unavailable.");
-    const bytes = new Uint8Array(16);
-    cryptoApi.getRandomValues(bytes);
+    const bytes = new Uint8Array(16); cryptoApi.getRandomValues(bytes);
     return Array.from(bytes, byte=>byte.toString(16).padStart(2, "0")).join("");
   }
+  function errorText(error){ return { code:String(error?.code || ""), message:String(error?.message || error || "Unknown error") }; }
 
-  function errorText(error){
-    return { code:String(error?.code || ""), message:String(error?.message || error || "Unknown error") };
+  function xhrDownloadText(url, XMLHttpRequestCtor, timeoutMs){
+    return new Promise((resolve, reject)=>{
+      const xhr = new XMLHttpRequestCtor();
+      xhr.open("GET", url, true); xhr.timeout = timeoutMs; xhr.responseType = "text"; xhr.withCredentials = false;
+      xhr.onload = ()=>{
+        const status = Number(xhr.status) || 0;
+        if (status >= 200 && status < 300) resolve({ text:String(xhr.responseText ?? xhr.response ?? ""), status });
+        else reject(Object.assign(new Error(`Test download failed with HTTP ${status}.`), { downloadErrorType:"http_status", httpStatus:status }));
+      };
+      xhr.onerror = ()=>reject(Object.assign(new Error("Test download failed at the browser network boundary."), { downloadErrorType:"network", corsFailureSuspected:true, networkFailureSuspected:true }));
+      xhr.ontimeout = ()=>reject(Object.assign(new Error("Test download timed out."), { downloadErrorType:"timeout", networkFailureSuspected:true }));
+      xhr.onabort = ()=>reject(Object.assign(new Error("Test download was aborted."), { downloadErrorType:"aborted" }));
+      xhr.send();
+    });
   }
 
   function summarize(result){
     if (!result) return null;
-    const keys = ["generatedAtISO", "confirmed", "firebaseProjectId", "bucket", "workspaceId", "uid", "testId", "objectPath", "uploadAttempted", "uploadCompleted", "metadataVerified", "downloadAttempted", "downloadCompleted", "contentVerified", "deleteAttempted", "deleteCompleted", "absenceVerified", "operationIndeterminate", "failedStage", "error", "warnings", "firestoreWriteAttempted", "appStateMutationDetected", "protectedStateMatched", "localJobFileCacheMatched"];
-    return Object.fromEntries(keys.map(key=>[key, result[key]]));
+    const copy = { ...result }; delete copy.protectedStateRootResults;
+    return copy;
   }
 
   function createApi(env, injected = {}){
     const now = injected.now || (()=>new Date());
     const cryptoApi = injected.crypto || env.crypto;
-    const fetchFn = injected.fetch || (typeof env.fetch === "function" ? env.fetch.bind(env) : null);
+    const XMLHttpRequestCtor = injected.XMLHttpRequest || env.XMLHttpRequest;
 
     async function runCfr03StorageRoundTripTest(options = {}){
-      const result = newResult(now);
-      const before = captureSafetyState(env);
+      const result = newResult(now); const before = captureSafetyState(env);
       const finish = ()=>{
-        const after = captureSafetyState(env);
-        result.protectedStateMatched = before.protectedFingerprint === after.protectedFingerprint;
-        result.localJobFileCacheMatched = before.jobFileCacheFingerprint === after.jobFileCacheFingerprint;
+        const comparison = compareSafetyState(before, captureSafetyState(env));
+        Object.assign(result, comparison);
+        result.protectedStateMatched = comparison.protectedStateMismatchPaths.length === 0;
         result.appStateMutationDetected = !result.protectedStateMatched;
-        lastResult = summarize(result);
-        return result;
+        result.localJobFileCacheMatched = comparison.localJobFileCacheMismatchPaths.length === 0;
+        lastResult = summarize(result); return result;
       };
       if (options.confirmation !== CONFIRMATION){
-        result.failedStage = "confirmation";
-        result.error = { code:"cfr03/confirmation-required", message:`Exact confirmation text required: ${CONFIRMATION}` };
+        result.failedStage = "validation"; result.error = { code:"cfr03/confirmation-required", message:`Exact confirmation text required: ${CONFIRMATION}` };
         return finish();
       }
       result.confirmed = true;
-
-      let objectRef = null;
+      let objectRef = null; let primaryError = null;
       try {
         const firebaseState = injected.firebaseState ? injected.firebaseState() : (function(){
           const app = env.firebase?.apps?.[0];
-          return {
-            user:typeof env.firebase?.auth === "function" ? env.firebase.auth().currentUser : null,
-            projectId:String(app?.options?.projectId || env.FIREBASE_CONFIG?.projectId || ""),
-            bucket:BUCKET,
-            workspaceId:String(env.WORKSPACE_ID || ""),
-            storage:typeof app?.storage === "function" ? app.storage(`gs://${BUCKET}`) : null
-          };
+          return { user:typeof env.firebase?.auth === "function" ? env.firebase.auth().currentUser : null,
+            projectId:String(app?.options?.projectId || env.FIREBASE_CONFIG?.projectId || ""), bucket:BUCKET,
+            workspaceId:String(env.WORKSPACE_ID || ""), storage:typeof app?.storage === "function" ? app.storage(`gs://${BUCKET}`) : null };
         })();
         const user = firebaseState?.user;
-        if (!user?.uid) throw Object.assign(new Error("A signed-in Firebase user is required."), { stage:"authentication" });
+        if (!user?.uid) throw new Error("A signed-in Firebase user is required.");
         result.uid = safeSegment(user.uid, /^[A-Za-z0-9][A-Za-z0-9:_-]{0,127}$/, "UID");
-        result.firebaseProjectId = String(firebaseState.projectId || "");
-        result.bucket = String(firebaseState.bucket || "").replace(/^gs:\/\//, "");
+        result.firebaseProjectId = String(firebaseState.projectId || ""); result.bucket = String(firebaseState.bucket || "").replace(/^gs:\/\//, "");
         result.workspaceId = safeSegment(firebaseState.workspaceId, /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/, "Workspace ID");
-        if (result.firebaseProjectId !== PROJECT_ID) throw Object.assign(new Error("Unexpected Firebase project."), { stage:"configuration" });
-        if (result.bucket !== BUCKET) throw Object.assign(new Error("Unexpected Firebase Storage bucket."), { stage:"configuration" });
-        if (result.workspaceId !== WORKSPACE_ID) throw Object.assign(new Error("Unexpected workspace."), { stage:"configuration" });
-        if (!firebaseState.storage) throw Object.assign(new Error("Firebase Storage is unavailable."), { stage:"configuration" });
-        if (!fetchFn) throw Object.assign(new Error("Browser fetch is unavailable."), { stage:"configuration" });
-
-        result.testId = randomTestId(cryptoApi);
-        result.objectPath = `workspaces/${result.workspaceId}/cfr03-tests/${result.uid}/${result.testId}/${FILE_NAME}`;
+        if (result.firebaseProjectId !== PROJECT_ID) throw new Error("Unexpected Firebase project.");
+        if (result.bucket !== BUCKET) throw new Error("Unexpected Firebase Storage bucket.");
+        if (result.workspaceId !== WORKSPACE_ID) throw new Error("Unexpected workspace.");
+        if (!firebaseState.storage) throw new Error("Firebase Storage is unavailable.");
+        if (typeof XMLHttpRequestCtor !== "function") throw new Error("XMLHttpRequest is unavailable.");
+        result.testId = randomTestId(cryptoApi); result.objectPath = `workspaces/${result.workspaceId}/cfr03-tests/${result.uid}/${result.testId}/${FILE_NAME}`;
         const payload = JSON.stringify({ testId:result.testId, timestamp:result.generatedAtISO });
-        const payloadBytes = new TextEncoder().encode(payload);
-        objectRef = firebaseState.storage.ref(result.objectPath);
+        const payloadBytes = new TextEncoder().encode(payload); objectRef = firebaseState.storage.ref(result.objectPath);
 
         result.uploadAttempted = true;
-        let uploadSnapshot;
-        try {
-          uploadSnapshot = await objectRef.put(new Blob([payload], { type:CONTENT_TYPE }), {
-            contentType:CONTENT_TYPE,
-            customMetadata:{ uid:result.uid, workspaceId:result.workspaceId, testId:result.testId }
-          });
-          result.uploadCompleted = true;
-        } catch (error){
-          result.operationIndeterminate = true;
-          throw Object.assign(error, { stage:"upload" });
+        try { await objectRef.put(new Blob([payload], { type:CONTENT_TYPE }), { contentType:CONTENT_TYPE, customMetadata:{ uid:result.uid, workspaceId:result.workspaceId, testId:result.testId } }); result.uploadCompleted = true; }
+        catch (error){ result.operationIndeterminate = true; result.failedStage = "upload"; throw error; }
+
+        result.failedStage = "metadata";
+        const metadata = await objectRef.getMetadata();
+        if (!(metadata?.fullPath === result.objectPath && Number(metadata?.size) === payloadBytes.byteLength && metadata?.contentType === CONTENT_TYPE
+          && metadata?.customMetadata?.uid === result.uid && metadata?.customMetadata?.workspaceId === result.workspaceId && metadata?.customMetadata?.testId === result.testId)) {
+          throw new Error("Uploaded object metadata did not match the exact CFR-03 object.");
         }
-        if (uploadSnapshot?.ref?.fullPath && uploadSnapshot.ref.fullPath !== result.objectPath) throw Object.assign(new Error("Upload completed at an unexpected path."), { stage:"upload-verification" });
-
-        let metadata;
-        try { metadata = await objectRef.getMetadata(); }
-        catch (error){ throw Object.assign(error, { stage:"metadata" }); }
-        const metadataMatches = metadata?.fullPath === result.objectPath
-          && Number(metadata?.size) === payloadBytes.byteLength
-          && metadata?.contentType === CONTENT_TYPE
-          && metadata?.customMetadata?.uid === result.uid
-          && metadata?.customMetadata?.workspaceId === result.workspaceId
-          && metadata?.customMetadata?.testId === result.testId;
-        if (!metadataMatches) throw Object.assign(new Error("Uploaded object metadata did not match the exact CFR-03 object."), { stage:"metadata" });
-        result.metadataVerified = true;
-
-        result.downloadAttempted = true;
-        const url = await objectRef.getDownloadURL();
-        const response = await fetchFn(url, { cache:"no-store", credentials:"omit" });
-        if (!response?.ok) throw Object.assign(new Error(`Test download failed with HTTP ${response?.status || "unknown"}.`), { stage:"download" });
-        const downloaded = await response.text();
-        result.downloadCompleted = true;
-        if (downloaded !== payload) throw Object.assign(new Error("Downloaded test content did not match exactly."), { stage:"content" });
+        result.metadataVerified = true; result.downloadAttempted = true; result.failedStage = "download_url";
+        const downloadUrl = await objectRef.getDownloadURL(); result.downloadUrlCreated = true; result.failedStage = "download_content";
+        let downloaded;
+        try { downloaded = await xhrDownloadText(downloadUrl, XMLHttpRequestCtor, DOWNLOAD_TIMEOUT_MS); result.downloadHttpStatus = downloaded.status; }
+        catch (error){
+          result.downloadErrorType = String(error.downloadErrorType || "unknown"); result.downloadHttpStatus = error.httpStatus ?? null;
+          result.corsFailureSuspected = error.corsFailureSuspected === true; result.networkFailureSuspected = error.networkFailureSuspected === true; throw error;
+        }
+        result.downloadCompleted = true; result.failedStage = "content_verification";
+        if (downloaded.text !== payload) throw new Error("Downloaded test content did not match exactly.");
         result.contentVerified = true;
+      } catch (error){ primaryError = error; if (!result.failedStage) result.failedStage = "validation"; result.error = errorText(error); }
 
-        result.deleteAttempted = true;
-        try { await objectRef.delete(); result.deleteCompleted = true; }
-        catch (error){ result.operationIndeterminate = true; throw Object.assign(error, { stage:"delete" }); }
+      if (result.uploadCompleted){
+        result.cleanupRequired = true; result.cleanupAttempted = true; result.deleteAttempted = true;
         try {
-          await objectRef.getMetadata();
-          throw Object.assign(new Error("Deleted test object is still present."), { stage:"absence" });
+          await objectRef.delete(); result.cleanupCompleted = true; result.deleteCompleted = true;
+          try {
+            await objectRef.getMetadata();
+            const absenceError = new Error("Deleted test object is still present.");
+            if (!primaryError){ primaryError = absenceError; result.error = errorText(absenceError); result.failedStage = "cleanup_absence_verification"; }
+          }
+          catch (error){
+            if (error?.code === "storage/object-not-found") { result.cleanupAbsenceVerified = true; result.absenceVerified = true; }
+            else {
+              result.operationIndeterminate = true;
+              if (!primaryError){ primaryError = error; result.error = errorText(error); result.failedStage = "cleanup_absence_verification"; }
+            }
+          }
         } catch (error){
-          if (error?.code !== "storage/object-not-found") throw Object.assign(error, { stage:error?.stage || "absence" });
-          result.absenceVerified = true;
+          result.operationIndeterminate = true; result.manualCleanupRequired = true; result.possibleOrphanPath = result.objectPath;
+          if (!primaryError){ primaryError = error; result.error = errorText(error); result.failedStage = "cleanup_delete"; }
         }
-      } catch (error){
-        result.failedStage = error?.stage || (result.confirmed ? "preflight" : "confirmation");
-        result.error = errorText(error);
-        if (result.uploadCompleted && !result.deleteCompleted) result.warnings.push("The exact test object may remain; no automatic retry or cleanup was attempted.");
+        if (!result.cleanupAbsenceVerified){ result.manualCleanupRequired = true; result.possibleOrphanPath = result.objectPath; }
+      } else if (result.uploadAttempted && result.operationIndeterminate){
+        result.manualCleanupRequired = true; result.possibleOrphanPath = result.objectPath;
       }
+      if (!primaryError && result.cleanupAbsenceVerified) result.failedStage = "";
+      if (result.manualCleanupRequired) result.warnings.push("The exact test object may remain; no automatic retry was attempted.");
       return finish();
     }
 
-    function getDiagnostics(){
-      return {
-        storageRulesExpectedVersion:"CFR-03-v1",
-        productionUploadsEnabled:false,
-        productionDownloadsEnabled:false,
-        cfr03TestHelperAvailable:true,
-        cfr03TestNamespace:NAMESPACE,
-        workspaceMembershipMechanism:"none-authoritative-found",
-        productionAuthorizationReady:false,
-        productionAuthorizationBlockers:["No authoritative workspace membership record, role, or custom claim is available to Storage rules."],
-        lastCfr03TestResult:lastResult
-      };
-    }
+    function getDiagnostics(){ return {
+      storageRulesExpectedVersion:"CFR-03A-deny-all-v1", productionUploadsEnabled:false, productionDownloadsEnabled:false,
+      cfr03TestHelperAvailable:true, cfr03TestNamespace:NAMESPACE, workspaceMembershipMechanism:"none-authoritative-found",
+      productionAuthorizationReady:false, productionAuthorizationBlockers:["No authoritative workspace membership record, role, or custom claim is available to Storage rules."],
+      lastCfr03TestResult:lastResult
+    }; }
     return { runCfr03StorageRoundTripTest, getDiagnostics };
   }
-
-  const api = createApi(root);
-  api.createForTests = createApi;
-  return api;
+  const api = createApi(root); api.createForTests = createApi; return api;
 });

--- a/js/cfr03StorageRoundTrip.js
+++ b/js/cfr03StorageRoundTrip.js
@@ -1,0 +1,221 @@
+(function(root, factory){
+  "use strict";
+  if (typeof module === "object" && module.exports) module.exports = factory;
+  else {
+    const api = factory(root);
+    root.runCfr03StorageRoundTripTest = api.runCfr03StorageRoundTripTest;
+    root.getCfr03StorageRoundTripDiagnostics = api.getDiagnostics;
+  }
+})(typeof window !== "undefined" ? window : globalThis, function(root){
+  "use strict";
+
+  const CONFIRMATION = "CFR03 STORAGE TEST";
+  const PROJECT_ID = "omax-maintenance";
+  const BUCKET = "omax-maintenance.firebasestorage.app";
+  const WORKSPACE_ID = "github-prod";
+  const NAMESPACE = "workspaces/{workspaceId}/cfr03-tests/{uid}/{testId}/cfr03-test.json";
+  const CONTENT_TYPE = "application/json";
+  const FILE_NAME = "cfr03-test.json";
+  const PROTECTED_KEYS = [
+    "cuttingJobs", "completedCuttingJobs", "cuttingJobDatabase", "deletedItems",
+    "tasksInterval", "tasksAsReq", "settingsFolders", "folders", "jobFolders",
+    "inventory", "inventoryFolders", "inventoryMaterials", "inventoryTransactions",
+    "receiptTrackerWeeks", "orderRequests", "weeklyCostReports", "dailyCutHours",
+    "totalHistory", "pumpEff", "garnetCleanings", "appConfig", "dashboardLayout",
+    "costLayout", "jobLayout", "maintenanceTasksV2", "maintenanceCalendarInstancesV2",
+    "maintenanceOccurrencesV2"
+  ];
+  let lastResult = null;
+
+  function stableValue(value, seen){
+    if (value === null || typeof value !== "object") return value;
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
+    if (Array.isArray(value)) return value.map(item=>stableValue(item, seen));
+    const result = {};
+    Object.keys(value).sort().forEach(key=>{
+      if (/^(generatedAtISO|diagnostics?|saveMeta|syncMeta|lastSavedAt|updatedAtISO)$/i.test(key)) return;
+      result[key] = stableValue(value[key], seen);
+    });
+    return result;
+  }
+
+  function fingerprint(value){
+    return JSON.stringify(stableValue(value, new WeakSet()));
+  }
+
+  function captureSafetyState(env){
+    const protectedState = {};
+    PROTECTED_KEYS.forEach(key=>{ protectedState[key] = env[key]; });
+    let localBackup = null;
+    let jobFileCache = null;
+    try { localBackup = env.localStorage?.getItem("omax_local_state_backup_v1") ?? null; } catch (_err){ localBackup = "[inaccessible]"; }
+    try { jobFileCache = env.localStorage?.getItem("cutting_job_files_v1") ?? null; } catch (_err){ jobFileCache = "[inaccessible]"; }
+    return {
+      protectedFingerprint:fingerprint({ protectedState, localBackup }),
+      jobFileCacheFingerprint:fingerprint(jobFileCache)
+    };
+  }
+
+  function newResult(now){
+    return {
+      generatedAtISO:now().toISOString(), confirmed:false, firebaseProjectId:"", bucket:"",
+      workspaceId:"", uid:"", testId:"", objectPath:"", uploadAttempted:false,
+      uploadCompleted:false, metadataVerified:false, downloadAttempted:false,
+      downloadCompleted:false, contentVerified:false, deleteAttempted:false,
+      deleteCompleted:false, absenceVerified:false, operationIndeterminate:false,
+      failedStage:"", error:null, warnings:[], firestoreWriteAttempted:false,
+      appStateMutationDetected:false, protectedStateMatched:false,
+      localJobFileCacheMatched:false
+    };
+  }
+
+  function safeSegment(value, pattern, label){
+    const text = String(value || "");
+    if (!pattern.test(text)) throw new Error(`${label} is not a safe bounded path segment.`);
+    return text;
+  }
+
+  function randomTestId(cryptoApi){
+    if (!cryptoApi || typeof cryptoApi.getRandomValues !== "function") throw new Error("Cryptographically secure browser randomness is unavailable.");
+    const bytes = new Uint8Array(16);
+    cryptoApi.getRandomValues(bytes);
+    return Array.from(bytes, byte=>byte.toString(16).padStart(2, "0")).join("");
+  }
+
+  function errorText(error){
+    return { code:String(error?.code || ""), message:String(error?.message || error || "Unknown error") };
+  }
+
+  function summarize(result){
+    if (!result) return null;
+    const keys = ["generatedAtISO", "confirmed", "firebaseProjectId", "bucket", "workspaceId", "uid", "testId", "objectPath", "uploadAttempted", "uploadCompleted", "metadataVerified", "downloadAttempted", "downloadCompleted", "contentVerified", "deleteAttempted", "deleteCompleted", "absenceVerified", "operationIndeterminate", "failedStage", "error", "warnings", "firestoreWriteAttempted", "appStateMutationDetected", "protectedStateMatched", "localJobFileCacheMatched"];
+    return Object.fromEntries(keys.map(key=>[key, result[key]]));
+  }
+
+  function createApi(env, injected = {}){
+    const now = injected.now || (()=>new Date());
+    const cryptoApi = injected.crypto || env.crypto;
+    const fetchFn = injected.fetch || (typeof env.fetch === "function" ? env.fetch.bind(env) : null);
+
+    async function runCfr03StorageRoundTripTest(options = {}){
+      const result = newResult(now);
+      const before = captureSafetyState(env);
+      const finish = ()=>{
+        const after = captureSafetyState(env);
+        result.protectedStateMatched = before.protectedFingerprint === after.protectedFingerprint;
+        result.localJobFileCacheMatched = before.jobFileCacheFingerprint === after.jobFileCacheFingerprint;
+        result.appStateMutationDetected = !result.protectedStateMatched;
+        lastResult = summarize(result);
+        return result;
+      };
+      if (options.confirmation !== CONFIRMATION){
+        result.failedStage = "confirmation";
+        result.error = { code:"cfr03/confirmation-required", message:`Exact confirmation text required: ${CONFIRMATION}` };
+        return finish();
+      }
+      result.confirmed = true;
+
+      let objectRef = null;
+      try {
+        const firebaseState = injected.firebaseState ? injected.firebaseState() : (function(){
+          const app = env.firebase?.apps?.[0];
+          return {
+            user:typeof env.firebase?.auth === "function" ? env.firebase.auth().currentUser : null,
+            projectId:String(app?.options?.projectId || env.FIREBASE_CONFIG?.projectId || ""),
+            bucket:BUCKET,
+            workspaceId:String(env.WORKSPACE_ID || ""),
+            storage:typeof app?.storage === "function" ? app.storage(`gs://${BUCKET}`) : null
+          };
+        })();
+        const user = firebaseState?.user;
+        if (!user?.uid) throw Object.assign(new Error("A signed-in Firebase user is required."), { stage:"authentication" });
+        result.uid = safeSegment(user.uid, /^[A-Za-z0-9][A-Za-z0-9:_-]{0,127}$/, "UID");
+        result.firebaseProjectId = String(firebaseState.projectId || "");
+        result.bucket = String(firebaseState.bucket || "").replace(/^gs:\/\//, "");
+        result.workspaceId = safeSegment(firebaseState.workspaceId, /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/, "Workspace ID");
+        if (result.firebaseProjectId !== PROJECT_ID) throw Object.assign(new Error("Unexpected Firebase project."), { stage:"configuration" });
+        if (result.bucket !== BUCKET) throw Object.assign(new Error("Unexpected Firebase Storage bucket."), { stage:"configuration" });
+        if (result.workspaceId !== WORKSPACE_ID) throw Object.assign(new Error("Unexpected workspace."), { stage:"configuration" });
+        if (!firebaseState.storage) throw Object.assign(new Error("Firebase Storage is unavailable."), { stage:"configuration" });
+        if (!fetchFn) throw Object.assign(new Error("Browser fetch is unavailable."), { stage:"configuration" });
+
+        result.testId = randomTestId(cryptoApi);
+        result.objectPath = `workspaces/${result.workspaceId}/cfr03-tests/${result.uid}/${result.testId}/${FILE_NAME}`;
+        const payload = JSON.stringify({ testId:result.testId, timestamp:result.generatedAtISO });
+        const payloadBytes = new TextEncoder().encode(payload);
+        objectRef = firebaseState.storage.ref(result.objectPath);
+
+        result.uploadAttempted = true;
+        let uploadSnapshot;
+        try {
+          uploadSnapshot = await objectRef.put(new Blob([payload], { type:CONTENT_TYPE }), {
+            contentType:CONTENT_TYPE,
+            customMetadata:{ uid:result.uid, workspaceId:result.workspaceId, testId:result.testId }
+          });
+          result.uploadCompleted = true;
+        } catch (error){
+          result.operationIndeterminate = true;
+          throw Object.assign(error, { stage:"upload" });
+        }
+        if (uploadSnapshot?.ref?.fullPath && uploadSnapshot.ref.fullPath !== result.objectPath) throw Object.assign(new Error("Upload completed at an unexpected path."), { stage:"upload-verification" });
+
+        let metadata;
+        try { metadata = await objectRef.getMetadata(); }
+        catch (error){ throw Object.assign(error, { stage:"metadata" }); }
+        const metadataMatches = metadata?.fullPath === result.objectPath
+          && Number(metadata?.size) === payloadBytes.byteLength
+          && metadata?.contentType === CONTENT_TYPE
+          && metadata?.customMetadata?.uid === result.uid
+          && metadata?.customMetadata?.workspaceId === result.workspaceId
+          && metadata?.customMetadata?.testId === result.testId;
+        if (!metadataMatches) throw Object.assign(new Error("Uploaded object metadata did not match the exact CFR-03 object."), { stage:"metadata" });
+        result.metadataVerified = true;
+
+        result.downloadAttempted = true;
+        const url = await objectRef.getDownloadURL();
+        const response = await fetchFn(url, { cache:"no-store", credentials:"omit" });
+        if (!response?.ok) throw Object.assign(new Error(`Test download failed with HTTP ${response?.status || "unknown"}.`), { stage:"download" });
+        const downloaded = await response.text();
+        result.downloadCompleted = true;
+        if (downloaded !== payload) throw Object.assign(new Error("Downloaded test content did not match exactly."), { stage:"content" });
+        result.contentVerified = true;
+
+        result.deleteAttempted = true;
+        try { await objectRef.delete(); result.deleteCompleted = true; }
+        catch (error){ result.operationIndeterminate = true; throw Object.assign(error, { stage:"delete" }); }
+        try {
+          await objectRef.getMetadata();
+          throw Object.assign(new Error("Deleted test object is still present."), { stage:"absence" });
+        } catch (error){
+          if (error?.code !== "storage/object-not-found") throw Object.assign(error, { stage:error?.stage || "absence" });
+          result.absenceVerified = true;
+        }
+      } catch (error){
+        result.failedStage = error?.stage || (result.confirmed ? "preflight" : "confirmation");
+        result.error = errorText(error);
+        if (result.uploadCompleted && !result.deleteCompleted) result.warnings.push("The exact test object may remain; no automatic retry or cleanup was attempted.");
+      }
+      return finish();
+    }
+
+    function getDiagnostics(){
+      return {
+        storageRulesExpectedVersion:"CFR-03-v1",
+        productionUploadsEnabled:false,
+        productionDownloadsEnabled:false,
+        cfr03TestHelperAvailable:true,
+        cfr03TestNamespace:NAMESPACE,
+        workspaceMembershipMechanism:"none-authoritative-found",
+        productionAuthorizationReady:false,
+        productionAuthorizationBlockers:["No authoritative workspace membership record, role, or custom claim is available to Storage rules."],
+        lastCfr03TestResult:lastResult
+      };
+    }
+    return { runCfr03StorageRoundTripTest, getDiagnostics };
+  }
+
+  const api = createApi(root);
+  api.createForTests = createApi;
+  return api;
+});

--- a/js/core.js
+++ b/js/core.js
@@ -4181,7 +4181,7 @@ function getCloudCutFileStorageDiagnostics(){
   const cfr03 = typeof window.getCfr03StorageRoundTripDiagnostics === "function"
     ? window.getCfr03StorageRoundTripDiagnostics()
     : {
-        storageRulesExpectedVersion:"CFR-03-v1", productionUploadsEnabled:false,
+        storageRulesExpectedVersion:"CFR-03A-deny-all-v1", productionUploadsEnabled:false,
         productionDownloadsEnabled:false, cfr03TestHelperAvailable:false,
         cfr03TestNamespace:"workspaces/{workspaceId}/cfr03-tests/{uid}/{testId}/cfr03-test.json",
         workspaceMembershipMechanism:"none-authoritative-found", productionAuthorizationReady:false,

--- a/js/core.js
+++ b/js/core.js
@@ -4178,6 +4178,16 @@ function getCloudCutFileStorageDiagnostics(){
   const location = typeof window.location === "object" ? window.location : { hostname:"", href:"" };
   const currentFirewall = scanAuthoritativeCutFileContent(snapshotState({ skipLocalFileCacheSync:true }), "$.currentSnapshot");
   const projectId = String(FB.app?.options?.projectId || window.FIREBASE_CONFIG?.projectId || "");
+  const cfr03 = typeof window.getCfr03StorageRoundTripDiagnostics === "function"
+    ? window.getCfr03StorageRoundTripDiagnostics()
+    : {
+        storageRulesExpectedVersion:"CFR-03-v1", productionUploadsEnabled:false,
+        productionDownloadsEnabled:false, cfr03TestHelperAvailable:false,
+        cfr03TestNamespace:"workspaces/{workspaceId}/cfr03-tests/{uid}/{testId}/cfr03-test.json",
+        workspaceMembershipMechanism:"none-authoritative-found", productionAuthorizationReady:false,
+        productionAuthorizationBlockers:["No authoritative workspace membership record, role, or custom claim is available to Storage rules."],
+        lastCfr03TestResult:null
+      };
   return {
     generatedAtISO:new Date().toISOString(), hostname:String(location.hostname || ""), url:String(location.href || ""),
     isVercelPreviewHostname:/\.vercel\.app$/i.test(String(location.hostname || "")),
@@ -4189,7 +4199,8 @@ function getCloudCutFileStorageDiagnostics(){
     authoritativeFirestoreDocumentPath:FB.docRef?.path || `workspaces/${WORKSPACE_ID}/app/state`,
     pointsToProductionFirebase:projectId === "omax-maintenance", uploadsEnabled:false, downloadsEnabled:false,
     storageRulesActuallyTested:false, firewallAvailable:typeof window.CuttingFileContentFirewall?.scanCuttingFileContent === "function",
-    currentSnapshotFirewallSummary:{ contaminated:currentFirewall.contaminated, blockingFindingCount:currentFirewall.blockingFindingCount, wouldPass:!currentFirewall.contaminated }
+    currentSnapshotFirewallSummary:{ contaminated:currentFirewall.contaminated, blockingFindingCount:currentFirewall.blockingFindingCount, wouldPass:!currentFirewall.contaminated },
+    ...cfr03
   };
 }
 

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,34 @@
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+    // CFR-03 permits only a 2 KiB, generated JSON probe. Production file paths
+    // and every path not matched here remain denied by the final catch-all.
+    match /workspaces/{workspaceId}/cfr03-tests/{uid}/{testId}/{fileName} {
+      function ownedSafeTestPath() {
+        return request.auth != null
+          && request.auth.uid == uid
+          && workspaceId.matches('^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$')
+          && uid.matches('^[A-Za-z0-9][A-Za-z0-9:_-]{0,127}$')
+          && testId.matches('^[a-f0-9]{32}$')
+          && fileName == 'cfr03-test.json';
+      }
+
+      allow create: if ownedSafeTestPath()
+        && resource == null
+        && request.resource.size > 0
+        && request.resource.size <= 2048
+        && request.resource.contentType == 'application/json'
+        && request.resource.metadata.keys().hasOnly(['uid', 'workspaceId', 'testId'])
+        && request.resource.metadata.uid == uid
+        && request.resource.metadata.workspaceId == workspaceId
+        && request.resource.metadata.testId == testId;
+      allow get: if ownedSafeTestPath();
+      allow delete: if ownedSafeTestPath();
+    }
+
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/storage.rules
+++ b/storage.rules
@@ -2,31 +2,6 @@ rules_version = '2';
 
 service firebase.storage {
   match /b/{bucket}/o {
-    // CFR-03 permits only a 2 KiB, generated JSON probe. Production file paths
-    // and every path not matched here remain denied by the final catch-all.
-    match /workspaces/{workspaceId}/cfr03-tests/{uid}/{testId}/{fileName} {
-      function ownedSafeTestPath() {
-        return request.auth != null
-          && request.auth.uid == uid
-          && workspaceId.matches('^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$')
-          && uid.matches('^[A-Za-z0-9][A-Za-z0-9:_-]{0,127}$')
-          && testId.matches('^[a-f0-9]{32}$')
-          && fileName == 'cfr03-test.json';
-      }
-
-      allow create: if ownedSafeTestPath()
-        && resource == null
-        && request.resource.size > 0
-        && request.resource.size <= 2048
-        && request.resource.contentType == 'application/json'
-        && request.resource.metadata.keys().hasOnly(['uid', 'workspaceId', 'testId'])
-        && request.resource.metadata.uid == uid
-        && request.resource.metadata.workspaceId == workspaceId
-        && request.resource.metadata.testId == testId;
-      allow get: if ownedSafeTestPath();
-      allow delete: if ownedSafeTestPath();
-    }
-
     match /{allPaths=**} {
       allow read, write: if false;
     }

--- a/tests/cfr03-storage-roundtrip.test.js
+++ b/tests/cfr03-storage-roundtrip.test.js
@@ -1,146 +1,58 @@
 "use strict";
-
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const factory = require("../js/cfr03StorageRoundTrip.js");
+const tests=[]; const test=(name,fn)=>tests.push({name,fn});
+const CONFIRMATION="CFR03 STORAGE TEST"; const now=()=>new Date("2026-08-13T12:00:00.000Z");
+const cryptoMock={getRandomValues(bytes){bytes.fill(10);return bytes;}};
 
-const tests = [];
-const test = (name, fn)=>tests.push({ name, fn });
-const CONFIRMATION = "CFR03 STORAGE TEST";
-const fixedNow = ()=>new Date("2026-08-13T12:00:00.000Z");
-const cryptoMock = { getRandomValues(bytes){ bytes.fill(10); return bytes; } };
-
-function harness(overrides = {}){
-  const calls = [];
-  const path = "workspaces/github-prod/cfr03-tests/user_1/0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a/cfr03-test.json";
-  const payload = JSON.stringify({ testId:"0a".repeat(16), timestamp:fixedNow().toISOString() });
-  let deleted = false;
-  let putResolve;
-  const putGate = overrides.putGate || Promise.resolve();
-  const ref = {
-    fullPath:path,
-    async put(blob, metadata){
-      calls.push(["put", metadata]);
-      if (overrides.putError) throw overrides.putError;
-      await putGate;
-      putResolve = true;
-      return { ref:{ fullPath:path } };
-    },
-    async getMetadata(){
-      calls.push(["getMetadata"]);
-      if (deleted) throw Object.assign(new Error("not found"), { code:"storage/object-not-found" });
-      return overrides.metadata || { fullPath:path, size:new TextEncoder().encode(payload).byteLength, contentType:"application/json", customMetadata:{ uid:"user_1", workspaceId:"github-prod", testId:"0a".repeat(16) } };
-    },
-    async getDownloadURL(){ calls.push(["getDownloadURL"]); return "https://storage.test/object"; },
-    async delete(){ calls.push(["delete"]); if (overrides.deleteError) throw overrides.deleteError; deleted = true; }
+function harness(options={}){
+  const calls=[]; const testId="0a".repeat(16); const path=`workspaces/github-prod/cfr03-tests/user_1/${testId}/cfr03-test.json`;
+  const payload=JSON.stringify({testId,timestamp:now().toISOString()}); let deleted=false;
+  const ref={
+    async put(){calls.push("put");if(options.uploadError)throw options.uploadError;},
+    async getMetadata(){calls.push("metadata");if(deleted && options.absenceError)throw options.absenceError;if(deleted)throw Object.assign(new Error("not found"),{code:"storage/object-not-found"});if(options.metadataError)throw options.metadataError;return {fullPath:path,size:new TextEncoder().encode(payload).byteLength,contentType:"application/json",customMetadata:{uid:"user_1",workspaceId:"github-prod",testId}};},
+    async getDownloadURL(){calls.push("download_url");if(options.urlError)throw options.urlError;return "https://secret-token.invalid/object?token=SECRET";},
+    async delete(){calls.push("delete");if(options.deleteError)throw options.deleteError;deleted=true;}
   };
-  const storage = { ref(requestedPath){ calls.push(["ref", requestedPath]); assert.equal(requestedPath, path); return ref; } };
-  const state = {
-    user:{ uid:"user_1" }, projectId:"omax-maintenance", bucket:"omax-maintenance.firebasestorage.app",
-    workspaceId:"github-prod", storage, ...(overrides.state || {})
-  };
-  const local = new Map([["cutting_job_files_v1", "47-local-data-urls"], ["omax_local_state_backup_v1", "protected-backup"]]);
-  const env = {
-    cuttingJobs:[{ id:"job-1" }], completedCuttingJobs:[], inventory:[{ id:"part-1" }],
-    localStorage:{ getItem:key=>local.get(key) ?? null }
-  };
-  const fetchMock = async()=>{
-    calls.push(["fetch"]);
-    return { ok:true, status:200, text:async()=>overrides.downloadContent ?? payload };
-  };
-  const api = factory(env).createForTests(env, { now:fixedNow, crypto:cryptoMock, fetch:fetchMock, firebaseState:()=>state });
-  return { api, calls, env, local, state, wasPutResolved:()=>putResolve === true };
+  const state={user:{uid:"user_1"},projectId:"omax-maintenance",bucket:"omax-maintenance.firebasestorage.app",workspaceId:"github-prod",storage:{ref(requested){calls.push("ref");assert.equal(requested,path);return ref;}},...(options.state||{})};
+  const cache="47-local-data-urls-byte-equivalent"; const backup="protected-backup";
+  const env={cuttingJobs:[{id:"job",config:{b:2,a:1}}],completedCuttingJobs:[],deletedItems:[],inventory:[{id:"part"}],maintenanceOccurrencesV2:[{id:"occurrence"}],localStorage:{getItem:key=>key==="cutting_job_files_v1"?cache:key==="omax_local_state_backup_v1"?backup:null}};
+  class XHR {
+    open(method,url){calls.push("xhr_open");this.url=url;assert.equal(method,"GET");}
+    send(){
+      calls.push("xhr_send"); if(options.mutateDuringDownload)options.mutateDuringDownload(env);
+      queueMicrotask(()=>{
+        if(options.xhr==="network")return this.onerror(); if(options.xhr==="timeout")return this.ontimeout(); if(options.xhr==="abort")return this.onabort();
+        this.status=options.httpStatus ?? 200; this.responseText=options.content ?? payload; this.onload();
+      });
+    }
+  }
+  const api=factory(env).createForTests(env,{now,crypto:cryptoMock,XMLHttpRequest:XHR,firebaseState:()=>state});
+  return {api,calls,env,path,cache};
 }
+const run=h=>h.api.runCfr03StorageRoundTripTest({confirmation:CONFIRMATION});
 
-test("missing confirmation performs zero Storage operations", async()=>{
-  const h = harness(); const result = await h.api.runCfr03StorageRoundTripTest();
-  assert.equal(result.confirmed, false); assert.deepEqual(h.calls, []);
-});
-test("incorrect confirmation performs zero Storage operations", async()=>{
-  const h = harness(); await h.api.runCfr03StorageRoundTripTest({ confirmation:"yes" }); assert.deepEqual(h.calls, []);
-});
-test("unsigned users are rejected before a Storage reference", async()=>{
-  const h = harness({ state:{ user:null } }); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
-  assert.equal(result.failedStage, "authentication"); assert.deepEqual(h.calls, []);
-});
-for (const [name, state] of [
-  ["project", { projectId:"other" }], ["bucket", { bucket:"other.invalid" }], ["workspace", { workspaceId:"preview" }]
-]) test(`unexpected ${name} is rejected`, async()=>{
-  const h = harness({ state }); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
-  assert.equal(result.failedStage, "configuration"); assert.deepEqual(h.calls, []);
-});
-test("generated path is isolated and owned by the exact UID", async()=>{
-  const h = harness(); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
-  assert.equal(result.objectPath, `workspaces/github-prod/cfr03-tests/${result.uid}/${result.testId}/cfr03-test.json`);
-  assert.equal(result.uid, "user_1"); assert.match(result.testId, /^[a-f0-9]{32}$/);
-});
-test("unsafe UID path ownership is rejected before Storage", async()=>{
-  const h = harness({ state:{ user:{ uid:"../other" } } }); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
-  assert.equal(result.failedStage, "preflight"); assert.deepEqual(h.calls, []);
-});
-test("upload completion is awaited before metadata", async()=>{
-  let release; const gate = new Promise(resolve=>{ release=resolve; }); const h = harness({ putGate:gate });
-  const pending = h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
-  await new Promise(resolve=>setImmediate(resolve));
-  assert.deepEqual(h.calls.map(call=>call[0]), ["ref", "put"]); release(); await pending;
-  assert.equal(h.wasPutResolved(), true); assert.ok(h.calls.findIndex(x=>x[0] === "getMetadata") > h.calls.findIndex(x=>x[0] === "put"));
-});
-test("upload failure prevents download and delete assumptions and is not retried", async()=>{
-  const h = harness({ putError:Object.assign(new Error("network"), { code:"storage/retry-limit-exceeded" }) });
-  const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
-  assert.equal(result.uploadAttempted, true); assert.equal(result.uploadCompleted, false); assert.equal(result.operationIndeterminate, true);
-  assert.deepEqual(h.calls.map(x=>x[0]), ["ref", "put"]);
-});
-test("metadata must match every exact object attribute", async()=>{
-  const h = harness({ metadata:{ fullPath:"wrong", size:1, contentType:"text/html", customMetadata:{} } });
-  const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
-  assert.equal(result.metadataVerified, false); assert.equal(result.failedStage, "metadata"); assert.equal(result.downloadAttempted, false);
-});
-test("downloaded contents must match exactly", async()=>{
-  const h = harness({ downloadContent:"different" }); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
-  assert.equal(result.downloadCompleted, true); assert.equal(result.contentVerified, false); assert.equal(result.deleteAttempted, false);
-});
-test("exact deletion is awaited and absence is verified", async()=>{
-  const h = harness(); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
-  assert.equal(result.deleteCompleted, true); assert.equal(result.absenceVerified, true);
-  assert.deepEqual(h.calls.map(x=>x[0]), ["ref", "put", "getMetadata", "getDownloadURL", "fetch", "delete", "getMetadata"]);
-});
-test("indeterminate deletion is not retried", async()=>{
-  const h = harness({ deleteError:new Error("network") }); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
-  assert.equal(result.operationIndeterminate, true); assert.equal(h.calls.filter(x=>x[0] === "delete").length, 1); assert.equal(result.absenceVerified, false);
-});
-test("helper does not expose or call Firestore saves", async()=>{
-  const h = harness(); h.env.saveCloudNow=()=>{ throw new Error("must not run"); }; h.env.saveCloudDebounced=h.env.saveCloudNow;
-  const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
-  assert.equal(result.firestoreWriteAttempted, false); assert.equal(result.absenceVerified, true);
-  assert.deepEqual(Object.keys(h.api).sort(), ["getDiagnostics", "runCfr03StorageRoundTripTest"]);
-});
-test("protected app state and jobFileCache remain unchanged", async()=>{
-  const h = harness(); const beforeJobs=JSON.stringify(h.env.cuttingJobs); const beforeCache=h.local.get("cutting_job_files_v1");
-  const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
-  assert.equal(result.protectedStateMatched, true); assert.equal(result.appStateMutationDetected, false);
-  assert.equal(result.localJobFileCacheMatched, true); assert.equal(JSON.stringify(h.env.cuttingJobs), beforeJobs); assert.equal(h.local.get("cutting_job_files_v1"), beforeCache);
-});
-test("production transfers stay disabled and diagnostics are read-only", ()=>{
-  const h = harness(); const before=JSON.stringify(h.env); const diagnostics=h.api.getDiagnostics();
-  assert.equal(diagnostics.productionUploadsEnabled, false); assert.equal(diagnostics.productionDownloadsEnabled, false);
-  assert.equal(diagnostics.productionAuthorizationReady, false); assert.equal(JSON.stringify(h.env), before); assert.deepEqual(h.calls, []);
-});
-test("rules are default deny and allow only bounded CFR-03 create/get/delete", ()=>{
-  const rules = fs.readFileSync("storage.rules", "utf8");
-  assert.match(rules, /match \/workspaces\/\{workspaceId\}\/cfr03-tests\/\{uid\}\/\{testId\}\/\{fileName\}/);
-  assert.match(rules, /request\.auth\.uid == uid/); assert.match(rules, /request\.resource\.size <= 2048/);
-  assert.match(rules, /request\.resource\.contentType == 'application\/json'/); assert.match(rules, /allow create:/);
-  assert.match(rules, /metadata\.keys\(\)\.hasOnly/);
-  assert.doesNotMatch(rules, /allow update:/); assert.match(rules, /allow read, write: if false/);
-});
-test("core diagnostics extension contains no write path", ()=>{
-  const core=fs.readFileSync("js/core.js", "utf8");
-  const section=core.slice(core.indexOf("function getCloudCutFileStorageDiagnostics"), core.indexOf("/* ======================== HISTORY"));
-  assert.doesNotMatch(section, /saveCloud|docRef\.set|\.put\(|\.delete\(/);
-});
+test("committed rules are exact deny-all",()=>assert.equal(fs.readFileSync("storage.rules","utf8"),`rules_version = '2';\n\nservice firebase.storage {\n  match /b/{bucket}/o {\n    match /{allPaths=**} {\n      allow read, write: if false;\n    }\n  }\n}\n`));
+test("missing and incorrect confirmation perform zero Storage operations",async()=>{for(const confirmation of [undefined,"wrong"]){const h=harness();await h.api.runCfr03StorageRoundTripTest({confirmation});assert.deepEqual(h.calls,[]);}});
+test("unsigned and unexpected configurations stop at validation",async()=>{for(const state of [{user:null},{projectId:"other"},{bucket:"other"},{workspaceId:"other"}]){const h=harness({state});const r=await run(h);assert.equal(r.failedStage,"validation");assert.deepEqual(h.calls,[]);}});
+test("post-upload network failure has correct stage and exactly one successful cleanup",async()=>{const h=harness({xhr:"network"});const r=await run(h);assert.equal(r.failedStage,"download_content");assert.equal(r.downloadUrlCreated,true);assert.equal(r.downloadErrorType,"network");assert.equal(r.cleanupAttempted,true);assert.equal(r.cleanupCompleted,true);assert.equal(r.cleanupAbsenceVerified,true);assert.equal(h.calls.filter(x=>x==="delete").length,1);});
+test("download URL failure is staged and cleaned",async()=>{const h=harness({urlError:new Error("url failed")});const r=await run(h);assert.equal(r.failedStage,"download_url");assert.equal(r.downloadUrlCreated,false);assert.equal(r.cleanupAbsenceVerified,true);});
+test("failed cleanup is never retried and reports exact possible orphan",async()=>{const h=harness({xhr:"network",deleteError:new Error("unknown delete outcome")});const r=await run(h);assert.equal(h.calls.filter(x=>x==="delete").length,1);assert.equal(r.operationIndeterminate,true);assert.equal(r.manualCleanupRequired,true);assert.equal(r.possibleOrphanPath,h.path);});
+test("indeterminate absence verification is never retried",async()=>{const h=harness({absenceError:new Error("unknown metadata outcome")});const r=await run(h);assert.equal(h.calls.filter(x=>x==="delete").length,1);assert.equal(h.calls.filter(x=>x==="metadata").length,2);assert.equal(r.operationIndeterminate,true);assert.equal(r.manualCleanupRequired,true);assert.equal(r.possibleOrphanPath,h.path);});
+test("indeterminate upload is not automatically deleted",async()=>{const h=harness({uploadError:new Error("unknown upload outcome")});const r=await run(h);assert.equal(r.failedStage,"upload");assert.equal(r.cleanupAttempted,false);assert.equal(h.calls.includes("delete"),false);assert.equal(r.possibleOrphanPath,h.path);});
+test("returned result never contains URL or token",async()=>{const h=harness({xhr:"network"});const r=await run(h);const serialized=JSON.stringify(r);assert.doesNotMatch(serialized,/https:|SECRET|token=/);assert.equal(r.downloadMethod,"XMLHttpRequest");});
+test("HTTP status failure is classified and status retained",async()=>{const r=await run(harness({httpStatus:403}));assert.equal(r.failedStage,"download_content");assert.equal(r.downloadErrorType,"http_status");assert.equal(r.downloadHttpStatus,403);assert.equal(r.corsFailureSuspected,false);});
+test("timeout is classified without claiming CORS",async()=>{const r=await run(harness({xhr:"timeout"}));assert.equal(r.downloadErrorType,"timeout");assert.equal(r.networkFailureSuspected,true);assert.equal(r.corsFailureSuspected,false);});
+test("opaque browser network error honestly suspects CORS and network",async()=>{const r=await run(harness({xhr:"network"}));assert.equal(r.corsFailureSuspected,true);assert.equal(r.networkFailureSuspected,true);});
+test("successful download verifies exact content and cleanup",async()=>{const r=await run(harness());assert.equal(r.downloadCompleted,true);assert.equal(r.contentVerified,true);assert.equal(r.failedStage,"");assert.equal(r.cleanupAbsenceVerified,true);});
+test("content mismatch has exact stage and is cleaned",async()=>{const r=await run(harness({content:"different"}));assert.equal(r.failedStage,"content_verification");assert.equal(r.contentVerified,false);assert.equal(r.cleanupAbsenceVerified,true);});
+test("canonical object-key ordering does not cause mismatch",async()=>{const h=harness({mutateDuringDownload(env){env.cuttingJobs[0].config={a:1,b:2};}});const r=await run(h);assert.equal(r.protectedStateMatched,true);assert.deepEqual(r.protectedStateMismatchPaths,[]);});
+test("value changes report exact paths",async()=>{const r=await run(harness({mutateDuringDownload(env){env.inventory[0].id="changed";}}));assert.equal(r.appStateMutationDetected,true);assert.deepEqual(r.protectedStateMismatchPaths,["$.inventory[0].id"]);assert.equal(r.protectedStateRootResults.inventory.matched,false);});
+test("property presence changes report exact paths",async()=>{const r=await run(harness({mutateDuringDownload(env){env.cuttingJobs[0].optional=undefined;}}));assert.deepEqual(r.protectedStateMismatchPaths,["$.cuttingJobs[0].optional"]);});
+test("array order changes report exact paths",async()=>{const h=harness({mutateDuringDownload(env){env.completedCuttingJobs.push({id:"b"},{id:"a"});env.completedCuttingJobs.reverse();}});const r=await run(h);assert.ok(r.protectedStateMismatchPaths.some(path=>path.startsWith("$.completedCuttingJobs")));});
+test("diagnostic session fields are excluded",async()=>{const h=harness({mutateDuringDownload(env){env.inventory[0].diagnostic={generatedAtISO:"later"};env.lastCfr03TestResult={anything:true};}});const r=await run(h);assert.equal(r.protectedStateMatched,true);});
+test("job file cache remains byte-equivalent and separate",async()=>{const h=harness();const r=await run(h);assert.equal(r.localJobFileCacheMatched,true);assert.deepEqual(r.localJobFileCacheMismatchPaths,[]);assert.equal(h.env.localStorage.getItem("cutting_job_files_v1"),h.cache);});
+test("no Firestore save occurs and production flags remain false",async()=>{const h=harness();h.env.saveCloudNow=()=>{throw new Error("called")};h.env.saveCloudDebounced=h.env.saveCloudNow;const r=await run(h);assert.equal(r.firestoreWriteAttempted,false);const d=h.api.getDiagnostics();assert.equal(d.productionUploadsEnabled,false);assert.equal(d.productionDownloadsEnabled,false);assert.equal(d.storageRulesExpectedVersion,"CFR-03A-deny-all-v1");});
 
-(async()=>{
-  for (const { name, fn } of tests){ await fn(); process.stdout.write(`ok - ${name}\n`); }
-  process.stdout.write(`1..${tests.length}\n`);
-})().catch(error=>{ console.error(error); process.exitCode=1; });
+(async()=>{for(const {name,fn} of tests){await fn();process.stdout.write(`ok - ${name}\n`);}process.stdout.write(`1..${tests.length}\n`);})().catch(error=>{console.error(error);process.exitCode=1;});

--- a/tests/cfr03-storage-roundtrip.test.js
+++ b/tests/cfr03-storage-roundtrip.test.js
@@ -16,12 +16,12 @@ function harness(options={}){
     async delete(){calls.push("delete");if(options.deleteError)throw options.deleteError;deleted=true;}
   };
   const state={user:{uid:"user_1"},projectId:"omax-maintenance",bucket:"omax-maintenance.firebasestorage.app",workspaceId:"github-prod",storage:{ref(requested){calls.push("ref");assert.equal(requested,path);return ref;}},...(options.state||{})};
-  const cache="47-local-data-urls-byte-equivalent"; const backup="protected-backup";
+  const cache="47-local-data-urls-byte-equivalent"; let backup="protected-backup";
   const env={cuttingJobs:[{id:"job",config:{b:2,a:1}}],completedCuttingJobs:[],deletedItems:[],inventory:[{id:"part"}],maintenanceOccurrencesV2:[{id:"occurrence"}],localStorage:{getItem:key=>key==="cutting_job_files_v1"?cache:key==="omax_local_state_backup_v1"?backup:null}};
   class XHR {
     open(method,url){calls.push("xhr_open");this.url=url;assert.equal(method,"GET");}
     send(){
-      calls.push("xhr_send"); if(options.mutateDuringDownload)options.mutateDuringDownload(env);
+      calls.push("xhr_send"); if(options.mutateDuringDownload)options.mutateDuringDownload(env); if(options.localBackupDrift)backup=options.localBackupDrift;
       queueMicrotask(()=>{
         if(options.xhr==="network")return this.onerror(); if(options.xhr==="timeout")return this.ontimeout(); if(options.xhr==="abort")return this.onabort();
         this.status=options.httpStatus ?? 200; this.responseText=options.content ?? payload; this.onload();
@@ -52,6 +52,7 @@ test("value changes report exact paths",async()=>{const r=await run(harness({mut
 test("property presence changes report exact paths",async()=>{const r=await run(harness({mutateDuringDownload(env){env.cuttingJobs[0].optional=undefined;}}));assert.deepEqual(r.protectedStateMismatchPaths,["$.cuttingJobs[0].optional"]);});
 test("array order changes report exact paths",async()=>{const h=harness({mutateDuringDownload(env){env.completedCuttingJobs.push({id:"b"},{id:"a"});env.completedCuttingJobs.reverse();}});const r=await run(h);assert.ok(r.protectedStateMismatchPaths.some(path=>path.startsWith("$.completedCuttingJobs")));});
 test("diagnostic session fields are excluded",async()=>{const h=harness({mutateDuringDownload(env){env.inventory[0].diagnostic={generatedAtISO:"later"};env.lastCfr03TestResult={anything:true};}});const r=await run(h);assert.equal(r.protectedStateMatched,true);});
+test("independent local-backup drift is reported without a false business-state mutation",async()=>{const h=harness({localBackupDrift:"independently-refreshed-backup"});h.env.saveCloudNow=()=>{throw new Error("must not run")};h.env.saveCloudDebounced=h.env.saveCloudNow;h.env.snapshotState=h.env.saveCloudNow;const r=await run(h);assert.equal(r.uploadCompleted,true);assert.equal(r.downloadCompleted,true);assert.equal(r.contentVerified,true);assert.equal(r.cleanupAbsenceVerified,true);assert.equal(r.firestoreWriteAttempted,false);assert.equal(r.protectedStateMatched,true);assert.equal(r.appStateMutationDetected,false);assert.deepEqual(r.protectedStateMismatchPaths,[]);assert.equal(r.localStateBackupMatched,false);assert.equal(r.localStateBackupDriftObserved,true);assert.deepEqual(r.localStateBackupMismatchPaths,["$.localStateBackup.value"]);assert.equal(r.localJobFileCacheMatched,true);assert.deepEqual(r.localJobFileCacheMismatchPaths,[]);});
 test("job file cache remains byte-equivalent and separate",async()=>{const h=harness();const r=await run(h);assert.equal(r.localJobFileCacheMatched,true);assert.deepEqual(r.localJobFileCacheMismatchPaths,[]);assert.equal(h.env.localStorage.getItem("cutting_job_files_v1"),h.cache);});
 test("no Firestore save occurs and production flags remain false",async()=>{const h=harness();h.env.saveCloudNow=()=>{throw new Error("called")};h.env.saveCloudDebounced=h.env.saveCloudNow;const r=await run(h);assert.equal(r.firestoreWriteAttempted,false);const d=h.api.getDiagnostics();assert.equal(d.productionUploadsEnabled,false);assert.equal(d.productionDownloadsEnabled,false);assert.equal(d.storageRulesExpectedVersion,"CFR-03A-deny-all-v1");});
 

--- a/tests/cfr03-storage-roundtrip.test.js
+++ b/tests/cfr03-storage-roundtrip.test.js
@@ -1,0 +1,146 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const factory = require("../js/cfr03StorageRoundTrip.js");
+
+const tests = [];
+const test = (name, fn)=>tests.push({ name, fn });
+const CONFIRMATION = "CFR03 STORAGE TEST";
+const fixedNow = ()=>new Date("2026-08-13T12:00:00.000Z");
+const cryptoMock = { getRandomValues(bytes){ bytes.fill(10); return bytes; } };
+
+function harness(overrides = {}){
+  const calls = [];
+  const path = "workspaces/github-prod/cfr03-tests/user_1/0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a/cfr03-test.json";
+  const payload = JSON.stringify({ testId:"0a".repeat(16), timestamp:fixedNow().toISOString() });
+  let deleted = false;
+  let putResolve;
+  const putGate = overrides.putGate || Promise.resolve();
+  const ref = {
+    fullPath:path,
+    async put(blob, metadata){
+      calls.push(["put", metadata]);
+      if (overrides.putError) throw overrides.putError;
+      await putGate;
+      putResolve = true;
+      return { ref:{ fullPath:path } };
+    },
+    async getMetadata(){
+      calls.push(["getMetadata"]);
+      if (deleted) throw Object.assign(new Error("not found"), { code:"storage/object-not-found" });
+      return overrides.metadata || { fullPath:path, size:new TextEncoder().encode(payload).byteLength, contentType:"application/json", customMetadata:{ uid:"user_1", workspaceId:"github-prod", testId:"0a".repeat(16) } };
+    },
+    async getDownloadURL(){ calls.push(["getDownloadURL"]); return "https://storage.test/object"; },
+    async delete(){ calls.push(["delete"]); if (overrides.deleteError) throw overrides.deleteError; deleted = true; }
+  };
+  const storage = { ref(requestedPath){ calls.push(["ref", requestedPath]); assert.equal(requestedPath, path); return ref; } };
+  const state = {
+    user:{ uid:"user_1" }, projectId:"omax-maintenance", bucket:"omax-maintenance.firebasestorage.app",
+    workspaceId:"github-prod", storage, ...(overrides.state || {})
+  };
+  const local = new Map([["cutting_job_files_v1", "47-local-data-urls"], ["omax_local_state_backup_v1", "protected-backup"]]);
+  const env = {
+    cuttingJobs:[{ id:"job-1" }], completedCuttingJobs:[], inventory:[{ id:"part-1" }],
+    localStorage:{ getItem:key=>local.get(key) ?? null }
+  };
+  const fetchMock = async()=>{
+    calls.push(["fetch"]);
+    return { ok:true, status:200, text:async()=>overrides.downloadContent ?? payload };
+  };
+  const api = factory(env).createForTests(env, { now:fixedNow, crypto:cryptoMock, fetch:fetchMock, firebaseState:()=>state });
+  return { api, calls, env, local, state, wasPutResolved:()=>putResolve === true };
+}
+
+test("missing confirmation performs zero Storage operations", async()=>{
+  const h = harness(); const result = await h.api.runCfr03StorageRoundTripTest();
+  assert.equal(result.confirmed, false); assert.deepEqual(h.calls, []);
+});
+test("incorrect confirmation performs zero Storage operations", async()=>{
+  const h = harness(); await h.api.runCfr03StorageRoundTripTest({ confirmation:"yes" }); assert.deepEqual(h.calls, []);
+});
+test("unsigned users are rejected before a Storage reference", async()=>{
+  const h = harness({ state:{ user:null } }); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
+  assert.equal(result.failedStage, "authentication"); assert.deepEqual(h.calls, []);
+});
+for (const [name, state] of [
+  ["project", { projectId:"other" }], ["bucket", { bucket:"other.invalid" }], ["workspace", { workspaceId:"preview" }]
+]) test(`unexpected ${name} is rejected`, async()=>{
+  const h = harness({ state }); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
+  assert.equal(result.failedStage, "configuration"); assert.deepEqual(h.calls, []);
+});
+test("generated path is isolated and owned by the exact UID", async()=>{
+  const h = harness(); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
+  assert.equal(result.objectPath, `workspaces/github-prod/cfr03-tests/${result.uid}/${result.testId}/cfr03-test.json`);
+  assert.equal(result.uid, "user_1"); assert.match(result.testId, /^[a-f0-9]{32}$/);
+});
+test("unsafe UID path ownership is rejected before Storage", async()=>{
+  const h = harness({ state:{ user:{ uid:"../other" } } }); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
+  assert.equal(result.failedStage, "preflight"); assert.deepEqual(h.calls, []);
+});
+test("upload completion is awaited before metadata", async()=>{
+  let release; const gate = new Promise(resolve=>{ release=resolve; }); const h = harness({ putGate:gate });
+  const pending = h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
+  await new Promise(resolve=>setImmediate(resolve));
+  assert.deepEqual(h.calls.map(call=>call[0]), ["ref", "put"]); release(); await pending;
+  assert.equal(h.wasPutResolved(), true); assert.ok(h.calls.findIndex(x=>x[0] === "getMetadata") > h.calls.findIndex(x=>x[0] === "put"));
+});
+test("upload failure prevents download and delete assumptions and is not retried", async()=>{
+  const h = harness({ putError:Object.assign(new Error("network"), { code:"storage/retry-limit-exceeded" }) });
+  const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
+  assert.equal(result.uploadAttempted, true); assert.equal(result.uploadCompleted, false); assert.equal(result.operationIndeterminate, true);
+  assert.deepEqual(h.calls.map(x=>x[0]), ["ref", "put"]);
+});
+test("metadata must match every exact object attribute", async()=>{
+  const h = harness({ metadata:{ fullPath:"wrong", size:1, contentType:"text/html", customMetadata:{} } });
+  const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
+  assert.equal(result.metadataVerified, false); assert.equal(result.failedStage, "metadata"); assert.equal(result.downloadAttempted, false);
+});
+test("downloaded contents must match exactly", async()=>{
+  const h = harness({ downloadContent:"different" }); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
+  assert.equal(result.downloadCompleted, true); assert.equal(result.contentVerified, false); assert.equal(result.deleteAttempted, false);
+});
+test("exact deletion is awaited and absence is verified", async()=>{
+  const h = harness(); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
+  assert.equal(result.deleteCompleted, true); assert.equal(result.absenceVerified, true);
+  assert.deepEqual(h.calls.map(x=>x[0]), ["ref", "put", "getMetadata", "getDownloadURL", "fetch", "delete", "getMetadata"]);
+});
+test("indeterminate deletion is not retried", async()=>{
+  const h = harness({ deleteError:new Error("network") }); const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
+  assert.equal(result.operationIndeterminate, true); assert.equal(h.calls.filter(x=>x[0] === "delete").length, 1); assert.equal(result.absenceVerified, false);
+});
+test("helper does not expose or call Firestore saves", async()=>{
+  const h = harness(); h.env.saveCloudNow=()=>{ throw new Error("must not run"); }; h.env.saveCloudDebounced=h.env.saveCloudNow;
+  const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
+  assert.equal(result.firestoreWriteAttempted, false); assert.equal(result.absenceVerified, true);
+  assert.deepEqual(Object.keys(h.api).sort(), ["getDiagnostics", "runCfr03StorageRoundTripTest"]);
+});
+test("protected app state and jobFileCache remain unchanged", async()=>{
+  const h = harness(); const beforeJobs=JSON.stringify(h.env.cuttingJobs); const beforeCache=h.local.get("cutting_job_files_v1");
+  const result = await h.api.runCfr03StorageRoundTripTest({ confirmation:CONFIRMATION });
+  assert.equal(result.protectedStateMatched, true); assert.equal(result.appStateMutationDetected, false);
+  assert.equal(result.localJobFileCacheMatched, true); assert.equal(JSON.stringify(h.env.cuttingJobs), beforeJobs); assert.equal(h.local.get("cutting_job_files_v1"), beforeCache);
+});
+test("production transfers stay disabled and diagnostics are read-only", ()=>{
+  const h = harness(); const before=JSON.stringify(h.env); const diagnostics=h.api.getDiagnostics();
+  assert.equal(diagnostics.productionUploadsEnabled, false); assert.equal(diagnostics.productionDownloadsEnabled, false);
+  assert.equal(diagnostics.productionAuthorizationReady, false); assert.equal(JSON.stringify(h.env), before); assert.deepEqual(h.calls, []);
+});
+test("rules are default deny and allow only bounded CFR-03 create/get/delete", ()=>{
+  const rules = fs.readFileSync("storage.rules", "utf8");
+  assert.match(rules, /match \/workspaces\/\{workspaceId\}\/cfr03-tests\/\{uid\}\/\{testId\}\/\{fileName\}/);
+  assert.match(rules, /request\.auth\.uid == uid/); assert.match(rules, /request\.resource\.size <= 2048/);
+  assert.match(rules, /request\.resource\.contentType == 'application\/json'/); assert.match(rules, /allow create:/);
+  assert.match(rules, /metadata\.keys\(\)\.hasOnly/);
+  assert.doesNotMatch(rules, /allow update:/); assert.match(rules, /allow read, write: if false/);
+});
+test("core diagnostics extension contains no write path", ()=>{
+  const core=fs.readFileSync("js/core.js", "utf8");
+  const section=core.slice(core.indexOf("function getCloudCutFileStorageDiagnostics"), core.indexOf("/* ======================== HISTORY"));
+  assert.doesNotMatch(section, /saveCloud|docRef\.set|\.put\(|\.delete\(/);
+});
+
+(async()=>{
+  for (const { name, fn } of tests){ await fn(); process.stdout.write(`ok - ${name}\n`); }
+  process.stdout.write(`1..${tests.length}\n`);
+})().catch(error=>{ console.error(error); process.exitCode=1; });


### PR DESCRIPTION
### Motivation

- Implement a safe, operator-triggered Cloud Storage round-trip test without enabling any production cutting-file uploads, and record blockers for production authorization. 
- Modify diagnostics and Firebase configuration to surface CFR-03 readiness and to point to a repo-controlled `storage.rules` while preserving default-deny behavior.
- Add a test helper that proves create/read/delete behavior only within an isolated, UID-owned namespace and that never mutates Firestore or protected app state.

### Description

- Added repository-controlled Storage rules in `storage.rules` and a minimal `firebase.json` that references it; rules are default-deny and only allow `workspaces/{workspaceId}/cfr03-tests/{uid}/{testId}/cfr03-test.json` create/get/delete under strict checks (auth UID equality, bounded segments, create-only, 2048B max, `application/json`, exact metadata). 
- Added a browser-only, manual helper `runCfr03StorageRoundTripTest(options)` in `js/cfr03StorageRoundTrip.js` that requires the exact confirmation `CFR03 STORAGE TEST`, validates project/bucket/workspace/uid, generates a cryptographically secure testId, uploads a small JSON payload, verifies metadata and exact content, deletes the object, and returns a structured stage-by-stage result while fingerprinting protected state and local job file cache before/after. 
- Extended diagnostics by adding CFR-03 fields to `getCloudCutFileStorageDiagnostics()` in `js/core.js` and loaded the helper in `index.html`; added operator documentation at `docs/cfr-03-secure-storage-round-trip.md`. 
- Added deterministic mocked Node tests in `tests/cfr03-storage-roundtrip.test.js` covering confirmation gates, auth/config validations, namespace ownership, awaited upload/metadata/download/delete sequencing, failure/indeterminate behavior, non-retry semantics, no Firestore writes, and protected-state/cache invariants.

### Testing

- Confirmed `package.json` is absent and therefore did not run npm installs. 
- Ran `node --check` on changed JavaScript and test files and executed deterministic tests: `tests/cfr03-storage-roundtrip.test.js` (19 tests) passed, existing `tests/cfr02-content-firewall.test.js` (21 tests) passed, and both `maintenance-history-import.test.js` and `pump-rebuild-duplication.test.js` passed. 
- Ran repository checks including `git diff --check`, conflict-marker search, direct-operation searches, and verified `vercel.json` remains exactly `{ "cleanUrls": true }`; all checks passed. 

Notes: Firebase CLI / emulator was not available in this environment so rules were not executed against an emulator, and no live Firebase Storage or Firestore writes were performed; PR creation via GitHub CLI was not completed because the environment has no authenticated GitHub credentials.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dedc215308325bf93d6c0efed087f)